### PR TITLE
Don't start Nginx before Dashboard

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
                 container_name: nginx
                 image: nginx:1.17.8
                 logging: *default-logging
+                depends_on: [ dashboard ]
                 volumes:
                         - ${PWD}/nginx:/etc/nginx
                 restart: on-failure


### PR DESCRIPTION
Else it throws 502 bad gateway. No point in having Nginx running before dashboard.