### PR TITLE
Neutrino switch container

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ If you are looking to run Umbrel on your hardware, you do not need to use this r
 - [`LND`](https://github.com/getumbrel/docker-lnd)
 - [`Tor`](https://github.com/getumbrel/docker-tor)
 - [`Nginx`](https://github.com/nginx/nginx)
+- [`lnd-neutrino-switch`](https://github.com/lncm/docker-lnd-neutrino-switch) - Utility container for seamlessly transitioning from neutrino mode to bitcoind mode
 
 
 **Architecture**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,6 +129,7 @@ services:
                     net:
                         ipv4_address: 10.11.2.2
         neutrino-switcher:
+                container_name: neutrino-switcher
                 image: lncm/neutrino-switcher:1.0.3
                 logging: *default-logging
                 depends_on: [ bitcoin, lnd ]
@@ -137,8 +138,11 @@ services:
                     - "${PWD}/lnd:/lnd"
                     - "${PWD}/secrets:/secrets"
                     - "${PWD}/statuses:/statuses"
+                    - "/var/run/docker.sock:/var/run/docker.sock"
                 environment:
                     JSONRPCURL: http://10.11.1.1:RPCPORT
+                    LND_CONTAINER_NAME: lnd
+                    SLEEPTIME: 86400
                 networks:
                     net:
                         ipv4_address: 10.11.5.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,7 +130,7 @@ services:
                         ipv4_address: 10.11.2.2
         neutrino-switcher:
                 container_name: neutrino-switcher
-                image: lncm/neutrino-switcher:1.0.3
+                image: lncm/neutrino-switcher:1.0.2
                 logging: *default-logging
                 depends_on: [ bitcoin, lnd ]
                 restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,6 +125,20 @@ services:
                 networks:
                     net:
                         ipv4_address: 10.11.2.2
+        neutrino-switcher:
+                image: lncm/neutrino-switcher:1.0.0
+                logging: *default-logging
+                depends_on: [ bitcoin, lnd ]
+                restart: always
+                volumes:
+                    - "${PWD}/lnd:/lnd"
+                    - "${PWD}/secrets:/secrets"
+                    - "${PWD}/statuses:/statuses"
+                environment:
+                    JSONRPCURL: http://10.11.1.1:RPCPORT
+                networks:
+                    net:
+                        ipv4_address: 10.11.5.2
 networks:
     net:
         ipam:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,7 +133,7 @@ services:
                 image: lncm/neutrino-switcher:1.0.2
                 logging: *default-logging
                 depends_on: [ bitcoin, lnd ]
-                restart: always
+                restart: unless-stopped
                 volumes:
                     - "${PWD}/lnd:/lnd"
                     - "${PWD}/secrets:/secrets"
@@ -142,7 +142,7 @@ services:
                 environment:
                     JSONRPCURL: http://10.11.1.1:RPCPORT
                     LND_CONTAINER_NAME: lnd
-                    SLEEPTIME: 86400
+                    SLEEPTIME: 3600
                 networks:
                     net:
                         ipv4_address: 10.11.5.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,7 +129,7 @@ services:
                     net:
                         ipv4_address: 10.11.2.2
         neutrino-switcher:
-                image: lncm/neutrino-switcher:1.0.0
+                image: lncm/neutrino-switcher:1.0.3
                 logging: *default-logging
                 depends_on: [ bitcoin, lnd ]
                 restart: always

--- a/lnd/lnd.conf
+++ b/lnd/lnd.conf
@@ -38,7 +38,6 @@ bitcoind.estimatemode=ECONOMICAL
 ; If the Bitcoin chain should be active. Atm, only a single chain can be
 ; active.
 bitcoin.active=1
-; Change 'bitcoin.mainnet=1' to 'bitcoin.testnet=1' if TESTNET or bitcoin.regtest=1 if REGTEST
 bitcoin.mainnet=1
 ; Use neutrino for now, but maybe it could be permanent and then switch
 ; to a full node if theres enough space

--- a/lnd/lnd.conf
+++ b/lnd/lnd.conf
@@ -18,10 +18,10 @@ routing.assumechanvalid=1
 
 ; Commented TLS options as they do not seem to work as of v0.10.1-experimental
 ; Extra TLS
-; tlsextradomain=lnd
-; tlsextraip=10.11.1.2
-; Unsure if this is a 0.10.0 command (make mental note to test this)
-; tlsautorefresh=1
+tlsextradomain=lnd
+tlsextraip=10.11.1.2
+; LND 0.10.X feature so we can add in new hosts and not worry about fiddling with tls files
+tlsautorefresh=1
 ; Add external address for TLS
 ;externalip=externaladdress
 

--- a/lnd/lnd.conf
+++ b/lnd/lnd.conf
@@ -12,10 +12,6 @@ color=#5351FB
 ; 0.9.X keysend functionality
 accept-keysend=true
 
-; Makes routing faster but have to use images built with experimental tag
-[Routing]
-routing.assumechanvalid=1
-
 ; Commented TLS options as they do not seem to work as of v0.10.1-experimental
 ; Extra TLS
 tlsextradomain=lnd
@@ -24,6 +20,10 @@ tlsextraip=10.11.1.2
 tlsautorefresh=1
 ; Add external address for TLS
 ;externalip=externaladdress
+
+; Makes routing faster but have to use images built with experimental tag
+[Routing]
+routing.assumechanvalid=1
 
 ; Default setting currently is neutrino
 [Bitcoind]


### PR DESCRIPTION
Closes #2 when resolved

Currently this will notify that it has switched configurations (in form of a file) but it will not restart the node for the sake of not doing stuff without telling the user. From a users point of view they need not care if it is neutrino or not.  I've designed it in a way to be non-intrusive.

Eventually we can have the dashboard notify of important updates and details of said update

Also if the node is pruned it will continue to use neutrino as there may be issues with pruned nodes and LND when the channel creation date is no longer in the node history. So this can ONLY be tested properly on full nodes. It will continue to work seamlessly on any nodes but won't do anything.
