### PR TITLE
Remove Umbrel fingerprint from LND config

### DIFF
--- a/lnd/lnd.conf
+++ b/lnd/lnd.conf
@@ -5,10 +5,6 @@ rpclisten=0.0.0.0:10009
 restlisten=0.0.0.0:8080
 maxpendingchannels=3
 minchansize=10000
-; This should be re-written via script
-alias=My Umbrel Node
-; This should also be re-written by script
-color=#5351FB
 ; 0.9.X keysend functionality
 accept-keysend=true
 


### PR DESCRIPTION
Having the LND node alias as `My Umbrel Node` and color as `#5351FB` creates an obvious fingerprint for Umbrel nodes.

This could potentially lead to reduced privacy for Umbrel users.

If people publicly declare they have setup an Umbrel node, an adversary could perform a timing analysis attack to deanonymise the user.

**Example:**

- User posts on Twitter that they just setup an Umbrel node.
- Adversary is tracking Lightning Network state.
- Adversary looks for a node with an Umbrel fingerprint that was first seen at around the same time of the tweet.
- Adversary can say with some degree of certainty that said LN node belongs to the user.
- Adversary can monitor node pubkey to learn future information on the user's channels and even on-chain UTXOs by monitoring channel open/close transactions.

It's possible for an attacker to perform the same timing analysis attack on any LN node, not just Umbrel. However the Umbrel fingerprint makes the attack significantly more accurate.