### PR TITLE
Allow boot when external storage isn't present

### DIFF
--- a/contrib/partitioner/partitioner.py
+++ b/contrib/partitioner/partitioner.py
@@ -217,7 +217,7 @@ def main():
         os.system('/bin/umount /mnt/data')
 
         print('Update /etc/fstab')
-        os.system('echo "UUID=' + first_partition_uuid + ' /mnt/data ext4 defaults,noatime 0 0" >> /etc/fstab')
+        os.system('echo "UUID=' + first_partition_uuid + ' /mnt/data ext4 defaults,noatime,nofail 0 0" >> /etc/fstab')
 
         print('Remounting through /bin/mount')
         os.system('/bin/mount -a');


### PR DESCRIPTION
This solves the issue of removing the initial setup drive making the device unbootable.

However it's just a temporary work around. This means the device will boot, but it will try to read/write from `/mnt/data` which is now just an empty folder on the SD card. 

The symlinks are also all broken since they point to directories that no longer exist, so docker-compose will fail to mount volumes and exit. But it at least gets the system bootable.

I think we need to rethink the partitioning/mounting logic quite a bit.

The partitioner shouldn't be a run once job. It should run on every boot and check each time if everything is already set up or if we have a new drive that needs to be formatted and mounted, symlinks added/removed, etc.