### PR TITLE
Don't accidentally trigger karen when updating

### DIFF
--- a/bin/update/.updateignore
+++ b/bin/update/.updateignore
@@ -5,3 +5,4 @@ lnd
 secrets
 statuses
 tor
+events/signals


### PR DESCRIPTION
Copying `events/signals` accidently triggers karen in the middle of the OTA, and oh boy it's not pretty.