### PR TITLE
Use github action built (and GPG verified) tor service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ x-utility: &default-utility
 services:
         tor:
                 container_name: tor
-                image: getumbrel/tor:v0.4.1.9
+                image: lncm/tor:0.4.3.6
                 user: toruser
                 restart: unless-stopped
                 logging: *default-logging

--- a/scripts/configure
+++ b/scripts/configure
@@ -101,7 +101,7 @@ echo "Pulling Docker images"
 docker-compose pull
 
 echo "Adding tor password"
-SAVE_PASSWORD=$(docker run --rm getumbrel/tor:v0.4.1.9 --quiet --hash-password "${RPCPASS}")
+SAVE_PASSWORD=$(docker run --rm lncm/tor:0.4.3.6 --quiet --hash-password "${RPCPASS}")
 # Add a new line first
 echo >> tor/torrc
 echo "HashedControlPassword ${SAVE_PASSWORD}" >> tor/torrc


### PR DESCRIPTION
Have a tor container based on debian-slim which is GPG verified and built for cross platform (from the official sources)