### PR TITLE
Refactor external storage logic

### DIFF
--- a/scripts/umbrel-os/boot
+++ b/scripts/umbrel-os/boot
@@ -12,9 +12,9 @@ fi
 
 # Check for disk partition status
 if [ ! -f "$UMBREL_ROOT"/statuses/disk-partitioned ]; then
-    if [ -f "$UMBREL_ROOT"/contrib/partitioner/partitioner.py ]; then
+    if [ -f "$UMBREL_ROOT"/scripts/umbrel-os/partitioner ]; then
       echo "Run partition tool or quit out if unavailable"
-      "$UMBREL_ROOT"/contrib/partitioner/partitioner.py || exit 1
+      "$UMBREL_ROOT"/scripts/umbrel-os/partitioner || exit 1
 
       touch "$UMBREL_ROOT"/statuses/disk-partitioned
       chown -R umbrel.umbrel "$UMBREL_ROOT"/statuses/disk-partitioned

--- a/scripts/umbrel-os/boot
+++ b/scripts/umbrel-os/boot
@@ -13,6 +13,11 @@ fi
 # Check for disk partition status
 if [ ! -f "$UMBREL_ROOT"/statuses/disk-partitioned ]; then
     if [ -f "$UMBREL_ROOT"/scripts/umbrel-os/partitioner ]; then
+      # TODO: Delete this
+      # Temporarily always write this file to ensure we don't brick ourselves.
+      # Nuke the status file and reboot to test the script
+      touch "$UMBREL_ROOT"/statuses/disk-partitioned
+
       echo "Run partition tool or quit out if unavailable"
       "$UMBREL_ROOT"/scripts/umbrel-os/partitioner || exit 1
 

--- a/scripts/umbrel-os/boot
+++ b/scripts/umbrel-os/boot
@@ -26,26 +26,22 @@ if [ ! -f "$UMBREL_ROOT"/statuses/service-configured ]; then
 
     # Next stage, check if service-configured
     echo "Service configured.. Checking for partitioned state"
-    if [ -f "$UMBREL_ROOT"/statuses/disk-partitioned ]; then
-      if [ ! -f /etc/rc2.d/S01umbrel ]; then
-        echo "Set  up symlinks"
-        ln -s /etc/init.d/umbrel /etc/rc2.d/S01umbrel
-        ln -s /etc/init.d/umbrel /etc/rc3.d/S01umbrel
-        ln -s /etc/init.d/umbrel /etc/rc4.d/S01umbrel
-        ln -s /etc/init.d/umbrel /etc/rc5.d/S01umbrel
-        ln -s /etc/init.d/umbrel /etc/rc0.d/K01umbrel
-        ln -s /etc/init.d/umbrel /etc/rc1.d/K01umbrel
-        ln -s /etc/init.d/umbrel /etc/rc6.d/K01umbrel
-        # Do partitioning at first boot
-        echo "Enabling defaults for umbrel"
-        update-rc.d umbrel defaults || exit 1
-        echo "Enabling startup for umbrel box"
-        update-rc.d umbrel enable || exit 1
-        echo "starting up umbrel get it started now)"
-        /etc/init.d/umbrel start
-      fi
-    else
-        echo "Disk not partitioned, will not start umbrel framework (Please do it manually)"
+    if [ ! -f /etc/rc2.d/S01umbrel ]; then
+      echo "Set  up symlinks"
+      ln -s /etc/init.d/umbrel /etc/rc2.d/S01umbrel
+      ln -s /etc/init.d/umbrel /etc/rc3.d/S01umbrel
+      ln -s /etc/init.d/umbrel /etc/rc4.d/S01umbrel
+      ln -s /etc/init.d/umbrel /etc/rc5.d/S01umbrel
+      ln -s /etc/init.d/umbrel /etc/rc0.d/K01umbrel
+      ln -s /etc/init.d/umbrel /etc/rc1.d/K01umbrel
+      ln -s /etc/init.d/umbrel /etc/rc6.d/K01umbrel
+      # Do partitioning at first boot
+      echo "Enabling defaults for umbrel"
+      update-rc.d umbrel defaults || exit 1
+      echo "Enabling startup for umbrel box"
+      update-rc.d umbrel enable || exit 1
+      echo "starting up umbrel get it started now)"
+      /etc/init.d/umbrel start
     fi
 fi
 

--- a/scripts/umbrel-os/boot
+++ b/scripts/umbrel-os/boot
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 UMBREL_ROOT="$(dirname $(readlink -f "${BASH_SOURCE[0]}"))/../.."
+UMBREL_OS_SCRIPTS="${UMBREL_ROOT}/scripts/umbrel-os"
 
 # Check for statuses directory
 if [ ! -d "$UMBREL_ROOT"/statuses ]; then
@@ -12,7 +13,7 @@ fi
 
 # Check for disk partition status
 echo "Run partition tool or quit out if unavailable"
-"$UMBREL_ROOT"/scripts/umbrel-os/partitioner || exit 1
+"${UMBREL_OS_SCRIPTS}/partitioner" || exit 1
 
 if [ ! -f "$UMBREL_ROOT"/statuses/service-configured ]; then
     if [ -f "$UMBREL_ROOT"/configure-box.sh ]; then

--- a/scripts/umbrel-os/boot
+++ b/scripts/umbrel-os/boot
@@ -11,7 +11,7 @@ if [ ! -d "$UMBREL_ROOT"/statuses ]; then
 fi
 
 # Check for disk partition status
-if [ ! -f "$UMBREL_ROOT"/statuses/disk-partitioned ]; then
+# if [ ! -f "$UMBREL_ROOT"/statuses/disk-partitioned ]; then
     if [ -f "$UMBREL_ROOT"/scripts/umbrel-os/partitioner ]; then
       # TODO: Delete this
       # Temporarily always write this file to ensure we don't brick ourselves.
@@ -26,7 +26,7 @@ if [ ! -f "$UMBREL_ROOT"/statuses/disk-partitioned ]; then
     else
       echo "Could not find partition tool - some steps might be skipped"
     fi
-fi
+# fi
 
 if [ ! -f "$UMBREL_ROOT"/statuses/service-configured ]; then
     if [ -f "$UMBREL_ROOT"/configure-box.sh ]; then

--- a/scripts/umbrel-os/boot
+++ b/scripts/umbrel-os/boot
@@ -11,9 +11,8 @@ if [ ! -d "$UMBREL_ROOT"/statuses ]; then
     chmod 777 "$UMBREL_ROOT"/statuses
 fi
 
-# Check for disk partition status
-echo "Run partition tool or quit out if unavailable"
-"${UMBREL_OS_SCRIPTS}/partitioner" || exit 1
+# Mount and/or format external storage
+"${UMBREL_OS_SCRIPTS}/external-storage-mounter" || exit 1
 
 if [ ! -f "$UMBREL_ROOT"/statuses/service-configured ]; then
     if [ -f "$UMBREL_ROOT"/configure-box.sh ]; then

--- a/scripts/umbrel-os/boot
+++ b/scripts/umbrel-os/boot
@@ -11,22 +11,8 @@ if [ ! -d "$UMBREL_ROOT"/statuses ]; then
 fi
 
 # Check for disk partition status
-# if [ ! -f "$UMBREL_ROOT"/statuses/disk-partitioned ]; then
-    if [ -f "$UMBREL_ROOT"/scripts/umbrel-os/partitioner ]; then
-      # TODO: Delete this
-      # Temporarily always write this file to ensure we don't brick ourselves.
-      # Nuke the status file and reboot to test the script
-      touch "$UMBREL_ROOT"/statuses/disk-partitioned
-
-      echo "Run partition tool or quit out if unavailable"
-      "$UMBREL_ROOT"/scripts/umbrel-os/partitioner || exit 1
-
-      touch "$UMBREL_ROOT"/statuses/disk-partitioned
-      chown -R umbrel.umbrel "$UMBREL_ROOT"/statuses/disk-partitioned
-    else
-      echo "Could not find partition tool - some steps might be skipped"
-    fi
-# fi
+echo "Run partition tool or quit out if unavailable"
+"$UMBREL_ROOT"/scripts/umbrel-os/partitioner || exit 1
 
 if [ ! -f "$UMBREL_ROOT"/statuses/service-configured ]; then
     if [ -f "$UMBREL_ROOT"/configure-box.sh ]; then

--- a/scripts/umbrel-os/external-storage-mounter
+++ b/scripts/umbrel-os/external-storage-mounter
@@ -108,7 +108,7 @@ main () {
 
   echo "Checking if device contains an Umbrel install..."
   mount_partition "${partition_path}"
-  if [[ -f "${EXTERNAL_UMBREL_ROOT}"/umbrel/docker-compose.yml ]]; then
+  if [[ -f "${EXTERNAL_UMBREL_ROOT}"/docker-compose.yml ]]; then
     echo "Yes, it does"
   else
     echo "No, it doesn't"

--- a/scripts/umbrel-os/external-storage-mounter
+++ b/scripts/umbrel-os/external-storage-mounter
@@ -70,7 +70,7 @@ unmount_partition () {
 }
 
 main () {
-  echo "Running partition script..."
+  echo "Running external storage mount script..."
   check_root
   check_dependencies sed wipefs parted mount sync
 
@@ -79,13 +79,13 @@ main () {
 
   if [[ $no_of_block_devices -lt 1 ]]; then
     echo "No block devices found"
-    echo "Exiting partition script without doing anything"
+    echo "Exiting mount script without doing anything"
     exit
   fi
 
   if [[ $no_of_block_devices -gt 1 ]]; then
     echo "Multiple block devices found, only one drive is supported"
-    echo "Exiting partition script without doing anything"
+    echo "Exiting mount script without doing anything"
     exit 1
   fi
 
@@ -127,7 +127,7 @@ main () {
   sleep 1
   "${UMBREL_ROOT}/scripts/umbrel-os/is-on-external-storage"
 
-  echo "Partition script completed successfully!"
+  echo "Mount script completed successfully!"
 }
 
 main

--- a/scripts/umbrel-os/external-storage-mounter
+++ b/scripts/umbrel-os/external-storage-mounter
@@ -2,6 +2,17 @@
 
 set -euo pipefail
 
+# This script will:
+# - Look for external storage devices
+# - Check if they contain an Umbrel install
+# - If yes
+# - - Mount it
+# - If no
+# - - Format it
+# - - Mount it
+# - - Install Umbrel on it
+# - Bind mount the external installation on top of the local installation
+
 UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/../..)"
 MOUNT_POINT="/mnt/data"
 EXTERNAL_UMBREL_ROOT="${MOUNT_POINT}/umbrel"

--- a/scripts/umbrel-os/external-storage-mounter
+++ b/scripts/umbrel-os/external-storage-mounter
@@ -108,7 +108,7 @@ main () {
 
   echo "Checking if device contains an Umbrel install..."
   mount_partition "${partition_path}"
-  if [[ -f "${EXTERNAL_UMBREL_ROOT}"/docker-compose.yml ]]; then
+  if [[ -f "${EXTERNAL_UMBREL_ROOT}"/.umbrel ]]; then
     echo "Yes, it does"
   else
     echo "No, it doesn't"

--- a/scripts/umbrel-os/is-on-external-storage
+++ b/scripts/umbrel-os/is-on-external-storage
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# This script returns a non-zero exit code if $UMBREL_ROOT is NOT
+# mounted on external storage.
+
+UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/../..)"
+
+df -h "${UMBREL_ROOT}" | grep --quiet '/dev/sd'

--- a/scripts/umbrel-os/partitioner
+++ b/scripts/umbrel-os/partitioner
@@ -44,11 +44,14 @@ format_block_device () {
   device="${1}"
   device_path="/dev/${1}"
   partition_path="${device_path}1"
-  wipefs -a "${device_path}"
-  parted "${device_path}" mklabel gpt
-  parted "${device_path}" mkpart primary ext4 0% 100%
-  sync
-  mkfs.ext4 -F -L umbrel "${partition_path}"
+  {
+    wipefs -a "${device_path}"
+    parted "${device_path}" mklabel gpt
+    parted "${device_path}" mkpart primary ext4 0% 100%
+    sync
+    mkfs.ext4 -F -L umbrel "${partition_path}"
+  } > /dev/null 2>&1
+  blkid -o value -s UUID "${partition_path}"
 }
 
 main () {

--- a/scripts/umbrel-os/partitioner
+++ b/scripts/umbrel-os/partitioner
@@ -71,8 +71,20 @@ main () {
   # At this point we know there is only one block device attached
   block_device=$block_devices
   block_device_model=$(get_block_device_model $block_device)
-  echo "Formatting device \"${block_device_model}\"..."
+  echo "Found device \"${block_device_model}\"!"
+
+  # TODO: Check if the device contains an existing Umbrel install
+
+  echo "Formatting device..."
   format_block_device $block_device
+
+  # TODO: Mount drive
+
+  # TODO: Setup symlinks
+
+  # TODO: Check it's mounted and symlinks are working correctly
+
+  # TODO: Add /etc/fstab entry
 }
 
 main

--- a/scripts/umbrel-os/partitioner
+++ b/scripts/umbrel-os/partitioner
@@ -104,7 +104,14 @@ main () {
     exit 1
   fi
 
-  # TODO: Mount drive
+  echo "Mounting partition..."
+  partition_type=$(blkid -o value -s TYPE "${partition_path}")
+  if [[ "${partition_type}" != "ext4" ]]; then
+    echo "Expecting EXT4 partition got \"${partition_type}\"."
+    exit 1
+  fi
+  mkdir -p /mnt/data
+  mount "${partition_path}" /mnt/data
 
   # TODO: Setup symlinks
 

--- a/scripts/umbrel-os/partitioner
+++ b/scripts/umbrel-os/partitioner
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+check_root () {
+  if [[ $UID != 0 ]]; then
+    echo "This script must be run as root"
+    exit 1
+  fi
+}
+
+check_dependencies () {
+  for cmd in "$@"; do
+    if ! command -v $cmd >/dev/null 2>&1; then
+      echo "This script requires \"${cmd}\" to be installed"
+      exit 1
+    fi
+  done
+}
+
+# Returns a list of block device paths
+list_block_devices () {
+  # We use "2>/dev/null || true" to swallow errors if there are
+  # no block devices. In that case the function just returns nothing
+  # instead of an error which is what we want.
+  #
+  # sed 's!.*/!!' is to return the device path so we get sda
+  # instead of /sys/block/sda
+  (ls -d /sys/block/sd* 2>/dev/null || true) | sed 's!.*/!!'
+}
+
+# Returns the vendor and model name of a block device
+get_block_device_model () {
+  device="${1}"
+  vendor=$(cat "/sys/block/${device}/device/vendor")
+  model=$(cat "/sys/block/${device}/device/model")
+
+  # We echo in a subshell without quotes to strip surrounding newlines
+  echo "$(echo $vendor) $(echo $model)"
+}
+
+# Wipes a block device and reformats it with a single EXT4 partition
+format_block_device () {
+  device="${1}"
+  device_path="/dev/${1}"
+  wipefs -a "${device_path}"
+  parted "${device_path}" mklabel gpt
+  parted "${device_path}" mkpart primary ext4 0% 100%
+}
+
+main () {
+  echo "Running partition script..."
+  check_root
+  check_dependencies sed wipefs parted
+
+  block_devices=$(list_block_devices)
+  no_of_block_devices=$(list_block_devices | wc -l)
+
+  if [[ $no_of_block_devices -lt 1 ]]; then
+    echo "No block devices found"
+    echo "Exiting partition script without doing anything"
+    exit
+  fi
+
+  if [[ $no_of_block_devices -gt 1 ]]; then
+    echo "Multiple block devices found, only one drive is supported"
+    echo "Exiting partition script without doing anything"
+    exit 1
+  fi
+
+  # At this point we know there is only one block device attached
+  block_device=$block_devices
+  block_device_model=$(get_block_device_model $block_device)
+  echo "Formatting device \"${block_device_model}\"..."
+  format_block_device $block_device
+}
+
+main

--- a/scripts/umbrel-os/partitioner
+++ b/scripts/umbrel-os/partitioner
@@ -108,7 +108,11 @@ main () {
   mkdir -p /mnt/data
   mount "${partition_path}" /mnt/data
 
-  # TODO: Setup symlinks
+  echo "Copying Umbrel install to external storage..."
+  cp  --recursive \
+      --archive \
+      --no-target-directory \
+      "${UMBREL_ROOT}" /mnt/data
 
   # TODO: Check it's mounted and symlinks are working correctly
 

--- a/scripts/umbrel-os/partitioner
+++ b/scripts/umbrel-os/partitioner
@@ -57,6 +57,16 @@ format_block_device () {
   mkfs.ext4 -F -L umbrel "${partition_path}"
 }
 
+mount_partition () {
+  partition_path="${1}"
+  mkdir -p "${MOUNT_POINT}"
+  mount "${partition_path}" "${MOUNT_POINT}"
+}
+
+unmount_partition () {
+  umount "${MOUNT_POINT}"
+}
+
 main () {
   echo "Running partition script..."
   check_root
@@ -79,32 +89,41 @@ main () {
 
   # At this point we know there is only one block device attached
   block_device=$block_devices
+  partition_path="/dev/${block_device}1"
   block_device_model=$(get_block_device_model $block_device)
   echo "Found device \"${block_device_model}\""
 
-  # TODO: Check if the device contains an existing Umbrel install
+  echo "Checking if device contains an Umbrel install..."
+  mount_partition "${partition_path}"
+  if [[ -f "${EXTERNAL_UMBREL_ROOT}"/umbrel/docker-compose.yml ]]; then
+    echo "Yes, it does"
+  else
+    echo "No, it doesn't"
 
-  echo "Formatting device..."
-  format_block_device $block_device
-  partition_uuid=$(blkid -o value -s UUID "${partition_path}")
-  # We need to manually check this succeeded because bash doesn't
-  # respect `set -euo pipefail` inside $() and could silently fail 🙄
-  if [ $? -ne 0 ]; then
-    echo "Couldn't get partition UUID"
-    echo "Exiting partition script"
-    exit 1
+    echo "Unmounting partition..."
+    unmount_partition
+
+    echo "Formatting device..."
+    format_block_device $block_device
+    partition_uuid=$(blkid -o value -s UUID "${partition_path}")
+    # We need to manually check this succeeded because bash doesn't
+    # respect `set -euo pipefail` inside $() and could silently fail 🙄
+    if [ $? -ne 0 ]; then
+      echo "Couldn't get partition UUID"
+      echo "Exiting partition script"
+      exit 1
+    fi
+
+    echo "Mounting partition..."
+    mount_partition "${partition_path}"
+
+    echo "Copying Umbrel install to external storage..."
+    mkdir -p "${EXTERNAL_UMBREL_ROOT}"
+    cp  --recursive \
+        --archive \
+        --no-target-directory \
+        "${UMBREL_ROOT}" "${EXTERNAL_UMBREL_ROOT}"
   fi
-
-  echo "Mounting partition..."
-  mkdir -p "${MOUNT_POINT}"
-  mount "${partition_path}" "${MOUNT_POINT}"
-
-  echo "Copying Umbrel install to external storage..."
-  mkdir -p "${EXTERNAL_UMBREL_ROOT}"
-  cp  --recursive \
-      --archive \
-      --no-target-directory \
-      "${UMBREL_ROOT}" "${EXTERNAL_UMBREL_ROOT}"
 
   echo "Bind mounting external storage over local Umbrel installation..."
   mount --bind "${EXTERNAL_UMBREL_ROOT}" "${UMBREL_ROOT}"

--- a/scripts/umbrel-os/partitioner
+++ b/scripts/umbrel-os/partitioner
@@ -51,6 +51,8 @@ format_block_device () {
   wipefs -a "${device_path}"
   parted --script "${device_path}" mklabel gpt
   parted --script "${device_path}" mkpart primary ext4 0% 100%
+  # We need to run sync here to make sure the filesystem is reflecting the
+  # the latest changes in /dev/*
   sync
   mkfs.ext4 -F -L umbrel "${partition_path}"
 }

--- a/scripts/umbrel-os/partitioner
+++ b/scripts/umbrel-os/partitioner
@@ -110,8 +110,8 @@ main () {
 
   # TODO: Check it's mounted and symlinks are working correctly
 
-  echo "Updating filesystem table..."
-  update_filesystem_table "${partition_uuid}"
+  # echo "Updating filesystem table..."
+  # update_filesystem_table "${partition_uuid}"
 
 }
 

--- a/scripts/umbrel-os/partitioner
+++ b/scripts/umbrel-os/partitioner
@@ -57,12 +57,14 @@ format_block_device () {
   mkfs.ext4 -F -L umbrel "${partition_path}"
 }
 
+# Mounts the device given in the first argument at $MOUNT_POINT
 mount_partition () {
   partition_path="${1}"
   mkdir -p "${MOUNT_POINT}"
   mount "${partition_path}" "${MOUNT_POINT}"
 }
 
+# Unmounts $MOUNT_POINT
 unmount_partition () {
   umount "${MOUNT_POINT}"
 }

--- a/scripts/umbrel-os/partitioner
+++ b/scripts/umbrel-os/partitioner
@@ -35,7 +35,7 @@ get_block_device_model () {
   vendor=$(cat "/sys/block/${device}/device/vendor")
   model=$(cat "/sys/block/${device}/device/model")
 
-  # We echo in a subshell without quotes to strip surrounding newlines
+  # We echo in a subshell without quotes to strip surrounding whitespace
   echo "$(echo $vendor) $(echo $model)"
 }
 

--- a/scripts/umbrel-os/partitioner
+++ b/scripts/umbrel-os/partitioner
@@ -44,7 +44,7 @@ get_block_device_model () {
 # Wipes a block device and reformats it with a single EXT4 partition
 format_block_device () {
   device="${1}"
-  device_path="/dev/${1}"
+  device_path="/dev/${device}"
   partition_path="${device_path}1"
   wipefs -a "${device_path}"
   parted --script "${device_path}" mklabel gpt

--- a/scripts/umbrel-os/partitioner
+++ b/scripts/umbrel-os/partitioner
@@ -120,7 +120,12 @@ main () {
   echo "Bind mounting external storage over local Umbrel installation..."
   mount --bind "${EXTERNAL_UMBREL_ROOT}" "${UMBREL_ROOT}"
 
-  # TODO: Check it's mounted and symlinks are working correctly
+  echo "Checking Umbrel root is now on external storage..."
+  sync
+  sleep 1
+  "${UMBREL_ROOT}/scripts/umbrel-os/is-on-external-storage"
+
+  echo "Partition script completed successfully!"
 
   # echo "Updating filesystem table..."
   # update_filesystem_table "${partition_uuid}"

--- a/scripts/umbrel-os/partitioner
+++ b/scripts/umbrel-os/partitioner
@@ -51,7 +51,6 @@ format_block_device () {
     sync
     mkfs.ext4 -F -L umbrel "${partition_path}"
   } > /dev/null 2>&1
-  blkid -o value -s UUID "${partition_path}"
 }
 
 main () {
@@ -83,6 +82,7 @@ main () {
 
   echo "Formatting device..."
   format_block_device $block_device
+  partition_uuid=$(blkid -o value -s UUID "${partition_path}")
 
   # TODO: Mount drive
 

--- a/scripts/umbrel-os/partitioner
+++ b/scripts/umbrel-os/partitioner
@@ -77,7 +77,7 @@ main () {
   # At this point we know there is only one block device attached
   block_device=$block_devices
   block_device_model=$(get_block_device_model $block_device)
-  echo "Found device \"${block_device_model}\"!"
+  echo "Found device \"${block_device_model}\""
 
   # TODO: Check if the device contains an existing Umbrel install
 

--- a/scripts/umbrel-os/partitioner
+++ b/scripts/umbrel-os/partitioner
@@ -105,14 +105,6 @@ main () {
 
     echo "Formatting device..."
     format_block_device $block_device
-    partition_uuid=$(blkid -o value -s UUID "${partition_path}")
-    # We need to manually check this succeeded because bash doesn't
-    # respect `set -euo pipefail` inside $() and could silently fail 🙄
-    if [ $? -ne 0 ]; then
-      echo "Couldn't get partition UUID"
-      echo "Exiting partition script"
-      exit 1
-    fi
 
     echo "Mounting partition..."
     mount_partition "${partition_path}"

--- a/scripts/umbrel-os/partitioner
+++ b/scripts/umbrel-os/partitioner
@@ -105,11 +105,6 @@ main () {
   fi
 
   echo "Mounting partition..."
-  partition_type=$(blkid -o value -s TYPE "${partition_path}")
-  if [[ "${partition_type}" != "ext4" ]]; then
-    echo "Expecting EXT4 partition got \"${partition_type}\"."
-    exit 1
-  fi
   mkdir -p /mnt/data
   mount "${partition_path}" /mnt/data
 

--- a/scripts/umbrel-os/partitioner
+++ b/scripts/umbrel-os/partitioner
@@ -46,8 +46,8 @@ format_block_device () {
   partition_path="${device_path}1"
   {
     wipefs -a "${device_path}"
-    parted "${device_path}" mklabel gpt
-    parted "${device_path}" mkpart primary ext4 0% 100%
+    parted --script "${device_path}" mklabel gpt
+    parted --script "${device_path}" mkpart primary ext4 0% 100%
     sync
     mkfs.ext4 -F -L umbrel "${partition_path}"
   } > /dev/null 2>&1

--- a/scripts/umbrel-os/partitioner
+++ b/scripts/umbrel-os/partitioner
@@ -70,7 +70,7 @@ unmount_partition () {
 main () {
   echo "Running partition script..."
   check_root
-  check_dependencies sed wipefs parted
+  check_dependencies sed wipefs parted mount sync
 
   block_devices=$(list_block_devices)
   no_of_block_devices=$(list_block_devices | wc -l)

--- a/scripts/umbrel-os/partitioner
+++ b/scripts/umbrel-os/partitioner
@@ -43,9 +43,12 @@ get_block_device_model () {
 format_block_device () {
   device="${1}"
   device_path="/dev/${1}"
+  partition_path="${device_path}1"
   wipefs -a "${device_path}"
   parted "${device_path}" mklabel gpt
   parted "${device_path}" mkpart primary ext4 0% 100%
+  sync
+  mkfs.ext4 -F -L umbrel "${partition_path}"
 }
 
 main () {

--- a/scripts/umbrel-os/partitioner
+++ b/scripts/umbrel-os/partitioner
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/../..)"
+
 check_root () {
   if [[ $UID != 0 ]]; then
     echo "This script must be run as root"
@@ -51,6 +53,19 @@ format_block_device () {
   mkfs.ext4 -F -L umbrel "${partition_path}"
 }
 
+update_filesystem_table () {
+  partition_uuid="${1}"
+  # Make sure we escape spaces since we can't quote in fstab
+  bind_mount=$(echo $UMBREL_ROOT | sed 's/ /\\ /g')
+  sed -ie '/^# umbrel start$/,/^# umbrel end$/d' /etc/fstab
+  {
+    echo "# umbrel start"
+    echo "UUID=${partition_uuid} /mnt/data ext4 defaults,noatime,nofail 0 0"
+    echo "/mnt/data ${bind_mount} none bind,nofail 0 0"
+    echo "# umbrel end"
+  } >> /etc/fstab
+}
+
 main () {
   echo "Running partition script..."
   check_root
@@ -95,7 +110,9 @@ main () {
 
   # TODO: Check it's mounted and symlinks are working correctly
 
-  # TODO: Add /etc/fstab entry
+  echo "Updating filesystem table..."
+  update_filesystem_table "${partition_uuid}"
+
 }
 
 main

--- a/scripts/umbrel-os/partitioner
+++ b/scripts/umbrel-os/partitioner
@@ -4,6 +4,7 @@ set -euo pipefail
 
 UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/../..)"
 MOUNT_POINT="/mnt/data"
+EXTERNAL_UMBREL_ROOT="${MOUNT_POINT}/umbrel"
 
 check_root () {
   if [[ $UID != 0 ]]; then
@@ -110,13 +111,14 @@ main () {
   mount "${partition_path}" "${MOUNT_POINT}"
 
   echo "Copying Umbrel install to external storage..."
+  mkdir -p "${EXTERNAL_UMBREL_ROOT}"
   cp  --recursive \
       --archive \
       --no-target-directory \
-      "${UMBREL_ROOT}" "${MOUNT_POINT}"
+      "${UMBREL_ROOT}" "${EXTERNAL_UMBREL_ROOT}"
 
   echo "Bind mounting external storage over local Umbrel installation..."
-  mount --bind "${MOUNT_POINT}" "${UMBREL_ROOT}"
+  mount --bind "${EXTERNAL_UMBREL_ROOT}" "${UMBREL_ROOT}"
 
   # TODO: Check it's mounted and symlinks are working correctly
 

--- a/scripts/umbrel-os/partitioner
+++ b/scripts/umbrel-os/partitioner
@@ -55,19 +55,6 @@ format_block_device () {
   mkfs.ext4 -F -L umbrel "${partition_path}"
 }
 
-update_filesystem_table () {
-  partition_uuid="${1}"
-  # Make sure we escape spaces since we can't quote in fstab
-  bind_mount=$(echo $UMBREL_ROOT | sed 's/ /\\ /g')
-  sed -ie '/^# umbrel start$/,/^# umbrel end$/d' /etc/fstab
-  {
-    echo "# umbrel start"
-    echo "UUID=${partition_uuid} ${MOUNT_POINT} ext4 defaults,noatime,nofail 0 0"
-    echo "${MOUNT_POINT} ${bind_mount} none bind,nofail 0 0"
-    echo "# umbrel end"
-  } >> /etc/fstab
-}
-
 main () {
   echo "Running partition script..."
   check_root
@@ -126,10 +113,6 @@ main () {
   "${UMBREL_ROOT}/scripts/umbrel-os/is-on-external-storage"
 
   echo "Partition script completed successfully!"
-
-  # echo "Updating filesystem table..."
-  # update_filesystem_table "${partition_uuid}"
-
 }
 
 main

--- a/scripts/umbrel-os/partitioner
+++ b/scripts/umbrel-os/partitioner
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/../..)"
+MOUNT_POINT="/mnt/data"
 
 check_root () {
   if [[ $UID != 0 ]]; then
@@ -60,8 +61,8 @@ update_filesystem_table () {
   sed -ie '/^# umbrel start$/,/^# umbrel end$/d' /etc/fstab
   {
     echo "# umbrel start"
-    echo "UUID=${partition_uuid} /mnt/data ext4 defaults,noatime,nofail 0 0"
-    echo "/mnt/data ${bind_mount} none bind,nofail 0 0"
+    echo "UUID=${partition_uuid} ${MOUNT_POINT} ext4 defaults,noatime,nofail 0 0"
+    echo "${MOUNT_POINT} ${bind_mount} none bind,nofail 0 0"
     echo "# umbrel end"
   } >> /etc/fstab
 }
@@ -105,17 +106,17 @@ main () {
   fi
 
   echo "Mounting partition..."
-  mkdir -p /mnt/data
-  mount "${partition_path}" /mnt/data
+  mkdir -p "${MOUNT_POINT}"
+  mount "${partition_path}" "${MOUNT_POINT}"
 
   echo "Copying Umbrel install to external storage..."
   cp  --recursive \
       --archive \
       --no-target-directory \
-      "${UMBREL_ROOT}" /mnt/data
+      "${UMBREL_ROOT}" "${MOUNT_POINT}"
 
   echo "Bind mounting external storage over local Umbrel installation..."
-  mount --bind /mnt/data "${UMBREL_ROOT}"
+  mount --bind "${MOUNT_POINT}" "${UMBREL_ROOT}"
 
   # TODO: Check it's mounted and symlinks are working correctly
 

--- a/scripts/umbrel-os/partitioner
+++ b/scripts/umbrel-os/partitioner
@@ -114,6 +114,9 @@ main () {
       --no-target-directory \
       "${UMBREL_ROOT}" /mnt/data
 
+  echo "Bind mounting external storage over local Umbrel installation..."
+  mount --bind /mnt/data "${UMBREL_ROOT}"
+
   # TODO: Check it's mounted and symlinks are working correctly
 
   # echo "Updating filesystem table..."

--- a/scripts/umbrel-os/partitioner
+++ b/scripts/umbrel-os/partitioner
@@ -44,13 +44,11 @@ format_block_device () {
   device="${1}"
   device_path="/dev/${1}"
   partition_path="${device_path}1"
-  {
-    wipefs -a "${device_path}"
-    parted --script "${device_path}" mklabel gpt
-    parted --script "${device_path}" mkpart primary ext4 0% 100%
-    sync
-    mkfs.ext4 -F -L umbrel "${partition_path}"
-  } > /dev/null 2>&1
+  wipefs -a "${device_path}"
+  parted --script "${device_path}" mklabel gpt
+  parted --script "${device_path}" mkpart primary ext4 0% 100%
+  sync
+  mkfs.ext4 -F -L umbrel "${partition_path}"
 }
 
 main () {

--- a/scripts/umbrel-os/partitioner
+++ b/scripts/umbrel-os/partitioner
@@ -83,6 +83,13 @@ main () {
   echo "Formatting device..."
   format_block_device $block_device
   partition_uuid=$(blkid -o value -s UUID "${partition_path}")
+  # We need to manually check this succeeded because bash doesn't
+  # respect `set -euo pipefail` inside $() and could silently fail 🙄
+  if [ $? -ne 0 ]; then
+    echo "Couldn't get partition UUID"
+    echo "Exiting partition script"
+    exit 1
+  fi
 
   # TODO: Mount drive
 


### PR DESCRIPTION
This PR greatly simplifies and improves the reliability of the external storage logic.

Overview of the logic:

- Look for external storage devices
- Check if they contain an Umbrel install
- If yes
- - Mount it
- If no
- - Format it
- - Mount it
- - Install Umbrel on it
- Bind mount the external installation on top of the local installation

The end result is we have the local installation of Umbrel at `$UMBREL_ROOT`, however when external storage is attached that contains an Umbrel install, it is mounted at `/mnt/data` which contains a folder called `umbrel` (`$UMBREL_EXTERNAL_ROOT`) which is then bind mounted over `$UMBREL_ROOT`.

So `$UMBREL_ROOT` is always the same path regardless of if stored on the SDcard or external storage.

There is no need to save status files or add entries to the filesystem table, the check is completely stateless and runs on every boot.

It also means everything works the same regardless of if Umbrel is installed on external storage or on the SD card. Due to the bind mount all the paths appear the same and there are no symlinks.

The benefits of this are that now the entire Umbrel installation lives on the external storage. If a user sets up Umbrel on a 500GB drive but decides they want to upgrade to a 1TB drive, they can restart with the new drive attached and it will be correctly configured on first boot.

Currently the drive will have to do a fresh sync of the blockchain data but we can add some migration features to automatically transition this data over to the new drive at some point in the future. 

This also paves the way (when combined with https://github.com/getumbrel/umbrel/pull/87) for allowing users to flash SD card updates while maintaining their external storage installation data.

I've also added a new script: `scripts/umbrel-os/is-on-external-storage` which will return a non-zero exit code if `$UMBREL_ROOT` is not mounted on external storage.

This allows other scripts (i.e configure/start) to easily check where Umbrel is running and decide what they want to do.

For now we may just just want to disable Umbrel but in the future we decide to enable/disable certain features depending on what storage media we're running on.

We're also now installing Umbrel inside it's own containing folder in the external storage. The means we can create new top level folders on the external storage for other things we don't want on the SD card such as logs/docker images/swap without polluting `$UMBREL_ROOT`.

### Things I still need to do.

**Move over old logic**
This replaces the old partitioner script, but that script was doing quite a few things outside the repsonsibiltiy of partitioning such as creating a swapfile, configuring prune options etc. These commands are no longer being executed so I need to check through the previous partition script and move any required functionality out to the appropriate places.

**Fix Umbrel service bug**
There is an issue (most likely also happens in master currently as-well) where if the script takes too long to setup the external storage the Umbrel service gets started before the the device has been formatted and mounted.

This means Umbrel gets started running on the SD card while partitioning/installation is still happening and causes it to fail.

I need to make sure the Umbrel service doesn't start until `scripts/umbrel-os/boot` has completed.

**Come up with a better Umbrel installation check (Done https://github.com/getumbrel/umbrel/pull/93/commits/37eec0b88deb2e179540cdb555fc730417d827eb)**
Currently the only thing that stops us nuking an attached drive is checking if it's mountable and contains `umbrel/docker-compose.yml`.

This is a bit worrying, if the mount command fails or the user had for some reason moved/renamed the compose file we will nuke the drive on reboot.

### Caveat

Due to the fact that the directory structure on the external storage has been changed existing Umbrel drives will not be detected and will be formatted.

We could add some migration logic to detect this and update old drives to the new structure so they can be correctly detected.