### PR TITLE
Auto-configure Umbrel on start

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,23 +80,17 @@ Ensure that your account is [correctly permissioned to use docker](https://docs.
 curl -L https://github.com/getumbrel/umbrel/archive/v0.1.6-beta.3.tar.gz | tar -xz --strip-components=1
 ```
 
-### Step 2. Configure
+### Step 2. Run
 
 ```bash
 # To use Umbrel on mainnet, run:
-./scripts/configure
+sudo ./scripts/start
 
 # For testnet, run:
-NETWORK=testnet ./scripts/configure
+NETWORK=testnet ./scripts/start
 
 # For regtest, run:
-NETWORK=regtest ./scripts/configure
-```
-
-### Step 3. Run
-
-```bash
-sudo ./scripts/start
+NETWORK=regtest ./scripts/start
 ```
 
 To stop Umbrel, run:

--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ curl -L https://github.com/getumbrel/umbrel/archive/v0.1.6-beta.3.tar.gz | tar -
 sudo ./scripts/start
 
 # For testnet, run:
-NETWORK=testnet ./scripts/start
+sudo NETWORK=testnet ./scripts/start
 
 # For regtest, run:
-NETWORK=regtest ./scripts/start
+sudo NETWORK=regtest ./scripts/start
 ```
 
 To stop Umbrel, run:

--- a/scripts/configure
+++ b/scripts/configure
@@ -42,12 +42,15 @@ if [ "$BITCOIN_NETWORK" != "mainnet" ] && [ "$BITCOIN_NETWORK" != "testnet" ] &&
 fi
 
 echo
+echo "======================================"
 if [[ -f "${UMBREL_ROOT}/statuses/configured" ]]; then
-  echo "Reconfiguring Umbrel for $BITCOIN_NETWORK"
+  echo "=========== RECONFIGURING ============"
 else
-  echo "Configuring Umbrel for $BITCOIN_NETWORK"
+  echo "============ CONFIGURING ============="
 fi
-echo 
+echo "============== UMBREL ================"
+echo "======================================"
+echo
 
 
 ##########################################################

--- a/scripts/configure
+++ b/scripts/configure
@@ -48,7 +48,7 @@ if [[ -f "${UMBREL_ROOT}/statuses/configured" ]]; then
 else
   echo "============ CONFIGURING ============="
 fi
-echo "============== UMBREL ================"
+echo "========= UMBREL (${NETWORK}) ==========="
 echo "======================================"
 echo
 

--- a/scripts/start
+++ b/scripts/start
@@ -28,9 +28,6 @@ check_dependencies fswatch
 # Check OTA update scripts' dependencies
 check_dependencies rsync jq wget
 
-echo "Starting Umbrel..."
-echo
-
 UMBREL_ROOT="$(dirname $(readlink -f "${BASH_SOURCE[0]}"))/.."
 
 if [[ ! -d "$UMBREL_ROOT" ]]; then
@@ -38,22 +35,33 @@ if [[ ! -d "$UMBREL_ROOT" ]]; then
   exit 1
 fi
 
+# Configure Umbrel if it isn't already configured
+if [[ ! -f "${UMBREL_ROOT}/statuses/configured" ]]; then
+  NETWORK="${NETWORK:-mainnet}" "${UMBREL_ROOT}/scripts/configure"
+fi
+
+echo
+echo "======================================"
+echo "============= STARTING ==============="
+echo "============== UMBREL ================"
+echo "======================================"
+echo
+
 echo "Setting environment variables..."
 echo
 DEVICE_IP="$(hostname -I | cut -d ' ' -f 1)"
 DEVICE_HOSTNAME="$(hostname)"
 export DEVICE_HOST="http://"${DEVICE_IP:-"$DEVICE_HOSTNAME".local}""
+# Increase default Docker and Compose timeouts to 240s
+# as bitcoin can take a long while to respond
+export DOCKER_CLIENT_TIMEOUT=240
+export COMPOSE_HTTP_TIMEOUT=240
 
 cd "$UMBREL_ROOT"
 
 echo "Starting karen..."
 echo
 ./karen &
-
-# Increase default Docker and Compose timeouts to 240s
-# As bitcoin can take a long while to respond
-export DOCKER_CLIENT_TIMEOUT=240
-export COMPOSE_HTTP_TIMEOUT=240
 
 echo
 echo "Starting Docker services..."

--- a/scripts/umbrel-os/boot
+++ b/scripts/umbrel-os/boot
@@ -23,27 +23,7 @@ enable_service() {
   fi
 }
 
-# Configure Umbrel on first boot
-# We assume that it's the first boot if Umbrel hasn't been configured
-if [ ! -f "${UMBREL_ROOT}/statuses/configured" ]; then
-  echo
-  echo "======================================"
-  echo "============ FIRST BOOT =============="
-  echo "=========== hello world! ============="
-  echo "======================================"
-  echo 
-  echo "Configuring Umbrel..."
-  echo
-  if [ -f "${UMBREL_ROOT}/scripts/configure" ]; then
-    cd "$UMBREL_ROOT"
-    NETWORK=mainnet ./scripts/configure || exit 1
-  else 
-    echo "Error: No configuration script found at ${UMBREL_ROOT}/scripts/configure"
-    exit 1
-  fi
-fi
-
-# Enable all services
+# Enable all Umbrel services
 enable_service "umbrel-external-storage.service"
 enable_service "umbrel-startup.service"
 enable_service "umbrel-connection-details.service"


### PR DESCRIPTION
Benefits:

- Configuration on the first boot will only happen on the external storage (since it will be triggered by `umbrel-startup.service` and not `rc.local`), so the SD card will always have a brand new, unconfigured copy of Umbrel.
- Reduces the number of steps taken to run Umbrel from a very high number, i.e. 3, to a tiny 2.
- The only purpose of the `boot` script is to now enable all the `systemd` services and that's it. 