### PR TITLE
Build OS image on push/PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
         PR: ${{ steps.findPr.outputs.pr }}
       run: |
         echo "Building PR #${PR}"
-        UMBREL_REPO="$(curl https://api.github.com/repos/getumbrel/umbrel/pulls/${PR} | jq .head.repo.clone_url)"
+        UMBREL_REPO="$(curl https://api.github.com/repos/getumbrel/umbrel/pulls/${PR} | jq .head.repo.clone_url | sed 's/"//g')"
         UMBREL_BRANCH="$(curl https://api.github.com/repos/getumbrel/umbrel/pulls/${PR} | jq .head.ref | sed 's/"//g')"
         echo "::set-env name=UMBREL_REPO::$UMBREL_REPO"
         echo "::set-env name=UMBREL_BRANCH::$UMBREL_BRANCH"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
       run: |
         echo "Building PR #${PR}"
         UMBREL_REPO="$(curl https://api.github.com/repos/AaronDewes/umbrel/pulls/${PR} | jq .head.repo.clone_url)"
-        UMBREL_BRANCH="$(curl https://api.github.com/repos/AaronDewes/umbrel/pulls/${PR} | jq .head.ref)"
+        UMBREL_BRANCH="$(curl https://api.github.com/repos/AaronDewes/umbrel/pulls/${PR} | jq .head.ref | sed 's/"//g')"
         echo "::set-env name=UMBREL_REPO::$UMBREL_REPO"
         echo "::set-env name=UMBREL_BRANCH::$UMBREL_BRANCH"
               

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
         sudo systemctl restart docker
     - name: Download Umbrel OS build scripts
       run: |
-        git clone git://github.com/AaronDewes/umbrel-os.git -b test
+        git clone git://github.com/getumbrel/umbrel-os.git
     - name: Setting env vars
       run: |
         UMBREL_OS_VERSION="dev"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,75 @@
+name: Build OS image on push/PR
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: jwalton/gh-find-current-pr@v1
+      id: findPr
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Run apt update
+      run: sudo apt update
+
+    - name: Install dependencies
+      run: sudo apt -y install quilt qemu-user-static debootstrap libarchive-tools jq
+
+    - name: Nuke current Docker installation
+      run: |
+        sudo systemctl stop docker
+        sudo apt-get purge docker-ce docker-ce-cli containerd.io moby-engine moby-cli
+        sudo rm -rf /var/lib/docker
+    - name: Re-install Docker
+      run: |
+        curl -fsSL https://get.docker.com -o get-docker.sh
+        sudo sh get-docker.sh
+        docker --version
+    - name: Enable experimental features in Docker
+      run: |
+        sudo rm -rf /etc/docker/daemon.json
+        echo '{"experimental": true}' | sudo tee -a /etc/docker/daemon.json
+        sudo systemctl restart docker
+    - name: Download Umbrel OS build scripts
+      run: |
+        git clone git://github.com/AaronDewes/umbrel-os.git -b test
+    - name: Setting env vars
+      run: |
+        UMBREL_OS_VERSION="dev"
+        IMAGE_NAME="umbrel-os-dev"
+        UMBREL_REPO="https://github.com/getumbrel/umbrel.git"
+        UMBREL_BRANCH="master"
+        echo "::set-env name=UMBREL_OS_VERSION::$UMBREL_OS_VERSION"
+        echo "::set-env name=IMAGE_NAME::$IMAGE_NAME"
+        echo "::set-env name=UMBREL_REPO::$UMBREL_REPO"
+        echo "::set-env name=UMBREL_BRANCH::$UMBREL_BRANCH"
+    - name: Setting env vars for PR
+      if: success() && steps.findPr.outputs.pr
+      env:
+        PR: ${{ steps.findPr.outputs.pr }}
+      run: |
+        echo "Building PR #${PR}"
+        UMBREL_REPO="$(curl https://api.github.com/repos/AaronDewes/umbrel/pulls/${PR} | jq .head.repo.clone_url)"
+        UMBREL_BRANCH="$(curl https://api.github.com/repos/AaronDewes/umbrel/pulls/${PR} | jq .head.ref)"
+        echo "::set-env name=UMBREL_REPO::$UMBREL_REPO"
+        echo "::set-env name=UMBREL_BRANCH::$UMBREL_BRANCH"
+              
+    - name: Build Umbrel OS
+      run: |
+        cd umbrel-os
+        echo "Building $IMAGE_NAME"
+        sudo IMG_FILENAME=$IMAGE_NAME ZIP_FILENAME=$IMAGE_NAME UMBREL_OS_VERSION=$UMBREL_OS_VERSION UMBREL_REPO=$UMBREL_REPO UMBREL_BRANCH=$UMBREL_BRANCH ./build.sh
+        cd ..
+        
+    - name: Copy ZIP to current working dir
+      run: cp umbrel-os/deploy/*.zip ./
+
+    - name: Uploading artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        path: ${{ env.IMAGE_NAME }}.zip
+        name: ${{ env.IMAGE_NAME }}.zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,8 +53,8 @@ jobs:
         PR: ${{ steps.findPr.outputs.pr }}
       run: |
         echo "Building PR #${PR}"
-        UMBREL_REPO="$(curl https://api.github.com/repos/AaronDewes/umbrel/pulls/${PR} | jq .head.repo.clone_url)"
-        UMBREL_BRANCH="$(curl https://api.github.com/repos/AaronDewes/umbrel/pulls/${PR} | jq .head.ref | sed 's/"//g')"
+        UMBREL_REPO="$(curl https://api.github.com/repos/getumbrel/umbrel/pulls/${PR} | jq .head.repo.clone_url)"
+        UMBREL_BRANCH="$(curl https://api.github.com/repos/getumbrel/umbrel/pulls/${PR} | jq .head.ref | sed 's/"//g')"
         echo "::set-env name=UMBREL_REPO::$UMBREL_REPO"
         echo "::set-env name=UMBREL_BRANCH::$UMBREL_BRANCH"
               


### PR DESCRIPTION
This creates a test image on every push and PR with the latest Umbrel/the Umbrel from the PR. 

This runs `on: [push]`, not on pull_request, because the pr detection doesn't work with that for some reasons, but PRs are still built.

The clone command will be changed to `git clone git://github.com/getumbrel/umbrel-os.git` when https://github.com/getumbrel/umbrel-os/pull/88 is merged.

An example can be found at https://github.com/AaronDewes/umbrel/pull/11.