### PR TITLE
Check /sd-root has been bind mounted

### DIFF
--- a/scripts/umbrel-os/external-storage/mount
+++ b/scripts/umbrel-os/external-storage/mount
@@ -146,6 +146,9 @@ main () {
   sleep 1
   df -h "${UMBREL_ROOT}" | grep --quiet '/dev/sd'
 
+  echo "Checking SD Card root is bind mounted at /sd-root..."
+  df -h "/sd-root${UMBREL_ROOT}" | grep --quiet "/dev/root"
+
   echo "Mount script completed successfully!"
 }
 


### PR DESCRIPTION
Make sure `/` is bind-mounted at `/sd-root` or else fail.