### PR TITLE
Check for curl instead of wget

### DIFF
--- a/scripts/start
+++ b/scripts/start
@@ -26,7 +26,7 @@ check_dependencies readlink dirname docker docker-compose git
 check_dependencies fswatch 
 
 # Check OTA update scripts' dependencies
-check_dependencies rsync jq wget
+check_dependencies rsync jq curl
 
 UMBREL_ROOT="$(dirname $(readlink -f "${BASH_SOURCE[0]}"))/.."
 

--- a/scripts/update/update
+++ b/scripts/update/update
@@ -14,7 +14,7 @@ check_dependencies () {
   done
 }
 
-check_dependencies jq wget git rsync
+check_dependencies jq curl git rsync
 
 UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/../..)"
 


### PR DESCRIPTION
We replaced `wget` with `curl` some time ago but forgot to replace it in the dependency check.