### PR TITLE
Remove access control headers

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -4,17 +4,14 @@ server {
     server_name _;
 
     location /api/ {
-        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, PUT, DELETE';
         proxy_pass http://10.11.2.2:3005/;
     }
 
     location /manager-api/ {
-        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, PUT, DELETE';
         proxy_pass http://10.11.2.1:3006/;
     }
 
     location /logs {
-        add_header Access-Control-Allow-Origin *;
         proxy_pass http://10.11.3.0:9001/logs;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
@@ -22,7 +19,6 @@ server {
     }
     
     location / {
-        add_header Access-Control-Allow-Origin *;
         proxy_pass http://10.11.0.3:3004/;
     }
  


### PR DESCRIPTION
I'm not sure why these access control headers are added but they don't seem to be required and everything appears to still work when they're removed.

They seem potentially dangerous, especially `Access-Control-Allow-Origin *` which would allow a malicious website to make requests directly to Umbrel services on the user's local network and read the responses.

The browser defaults to a very strict CORS policy and these headers loosen it significantly. I don't think we need to loosen the rules because all the Umbrel services are always accessed from the same origin.

@mayankchhabra @nolim1t let me know if there was a reason these rules were added and if they are required for something.