### PR TITLE
Limit stop timeout of umbrel-startup.service

### DIFF
--- a/scripts/umbrel-os/services/umbrel-startup.service
+++ b/scripts/umbrel-os/services/umbrel-startup.service
@@ -12,7 +12,8 @@ After=docker.service
 
 [Service]
 Type=forking
-TimeoutSec=infinity
+TimeoutStartSec=infinity
+TimeoutStopSec=16min
 ExecStart=/home/umbrel/umbrel/scripts/start
 ExecStop=/home/umbrel/umbrel/scripts/stop
 User=root


### PR DESCRIPTION
Start timeout of inifity is ok as it can take as long as it wants to start the Umbrel services, but if the stop timeout takes forever, that means the system can never shut down if one of the processes of `umbrel-startup.service` is stuck.

I think a timeout of 16 minutes is enough as it's 30 seconds more than the maximum timeout of our docker service, i.e. the bitcoin container.

https://github.com/getumbrel/umbrel/blob/3563831a6654d5234eb4263f7f9855331f67e358/docker-compose.yml#L49

PS: There's no code in the OTA update scripts (yet) that'd update this system service on existing installs, but we don't have to worry it about it right now... 