### PR TITLE
Remove unused x-utility block from Docker Compose config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,6 @@ x-logging: &default-logging
     options:
         tag: "{{.Name}}"
 
-x-utility: &default-utility
-    image: alpine:3.11
-    logging: *default-logging
-    network_mode: host
-
 services:
         tor:
                 container_name: tor


### PR DESCRIPTION
This doesn't appear to be used by anything.

I would also like to remove the custom network and use the default compose networking which refers to containers via hostnames and only allows access to ports between containers that we explicitly allow. However that's quite a large change to the networking setup and needs to be thoroughly tested. I don't think we should make that change this close to launch.