### PR TITLE
Clean up Bitcoin Core config

### DIFF
--- a/scripts/configure
+++ b/scripts/configure
@@ -107,10 +107,8 @@ if [ "$BITCOIN_NETWORK" == "testnet" ]; then
   # Set testnet ports
   BITCOIN_RPC_PORT=18332
   BITCOIN_P2P_PORT=18333
-  # Uncomment "test" block
-  sed -i "s/\#\[test\]/\[test\]/g;" "$BITCOIN_CONF_FILE"
-  # Enable testnet
-  sed -i "s/\#testnet=1/testnet=1/g" "$BITCOIN_CONF_FILE"
+  # Switch Bitcoin Core to testnet
+  sed -i '1s/^/testnet=1\n[test]\n\n/' "$BITCOIN_CONF_FILE"
   # Switch LND to testnet
   sed -i "s/bitcoin.mainnet=1/bitcoin.testnet=1/g;" "$LND_CONF_FILE"
   # Uncomment testnet neutrino block and peers
@@ -124,10 +122,8 @@ if [ "$BITCOIN_NETWORK" == "regtest" ]; then
   # Set regtest ports
   BITCOIN_RPC_PORT=18443
   BITCOIN_P2P_PORT=18444
-  # Uncomment "regtest" block
-  sed -i "s/\#\[regtest\]/\[regtest\]/g;" "$BITCOIN_CONF_FILE"
-  # Enable regtest
-  sed -i "s/\#regtest=1/regtest=1/g" "$BITCOIN_CONF_FILE"
+  # Switch Bitcoin Core to regtest
+  sed -i '1s/^/regtest=1\n[regtest]\n\n/' "$BITCOIN_CONF_FILE"
   # Switch LND to regtest
   sed -i "s/bitcoin.mainnet=1/bitcoin.regtest=1/g;" "$LND_CONF_FILE"
   # Use bitcoind as the node

--- a/scripts/configure
+++ b/scripts/configure
@@ -133,6 +133,7 @@ fi
 # Update RPC and P2P Ports
 sed -i "s/rpcport=<port>/rpcport=$BITCOIN_RPC_PORT/g;" "$BITCOIN_CONF_FILE"
 sed -i "s/port=<port>/port=$BITCOIN_P2P_PORT/g;" "$BITCOIN_CONF_FILE"
+sed -i "s/<bitcoin-p2p-port>/$BITCOIN_P2P_PORT/g;" "$TOR_CONF_FILE"
 sed -i "s/BITCOIN_RPC_PORT=<port>/BITCOIN_RPC_PORT=$BITCOIN_RPC_PORT/g;" "$ENV_FILE"
 sed -i "s/BITCOIN_P2P_PORT=<port>/BITCOIN_P2P_PORT=$BITCOIN_P2P_PORT/g;" "$ENV_FILE"
 

--- a/templates/bitcoin-sample.conf
+++ b/templates/bitcoin-sample.conf
@@ -1,8 +1,3 @@
-
-# Bitcoin daemon
-server=1
-rest=1
-
 # Automatically uncommented if Umbrel
 # is configured for testnet
 #testnet=1
@@ -29,9 +24,6 @@ rpcauth=<rpcauth>
 
 # Optimizations
 dbcache=<size>
-maxconnections=40
 maxmempool=300
-maxorphantx=10
+maxconnections=40
 maxuploadtarget=1000
-minrelaytxfee=0.00000001
-prune=0

--- a/templates/bitcoin-sample.conf
+++ b/templates/bitcoin-sample.conf
@@ -1,13 +1,3 @@
-# Automatically uncommented if Umbrel
-# is configured for testnet
-#testnet=1
-#[test]
-
-# Automatically uncommented if Umbrel
-# is configured for regtest
-#regtest=1
-#[regtest]
-
 # Tor
 onion=10.11.5.1:29050
 torcontrol=10.11.5.1:29051

--- a/templates/bitcoin-sample.conf
+++ b/templates/bitcoin-sample.conf
@@ -1,7 +1,7 @@
 # Tor
-onion=10.11.5.1:29050
-torcontrol=10.11.5.1:29051
-torpassword=<password>
+proxy=10.11.5.1:29050
+listen=1
+bind=10.11.1.1
 
 # Connections
 port=<port>

--- a/templates/bitcoin-sample.conf
+++ b/templates/bitcoin-sample.conf
@@ -17,3 +17,4 @@ dbcache=<size>
 maxmempool=300
 maxconnections=40
 maxuploadtarget=1000
+minrelaytxfee=0.00000001

--- a/templates/torrc-sample
+++ b/templates/torrc-sample
@@ -6,4 +6,8 @@ ControlPort 10.11.5.1:29051
 HiddenServiceDir /var/lib/tor/web
 HiddenServicePort 80 10.11.0.2:80
 
+# Bitcoin Core P2P Hidden Service
+HiddenServiceDir /var/lib/tor/bitcoin-p2p
+HiddenServicePort <bitcoin-p2p-port> 10.11.1.1:<bitcoin-p2p-port>
+
 HashedControlPassword <password>


### PR DESCRIPTION
I've removed the following:

```
server=1
```
Redundant, it's on by default

```
rest=1
```
As far as I can see we're not using REST for anything.

```
maxorphantx=10
```
Not sure why we've set this, the default is 100 which is not much different. I don't think there's a valid reason to set this to something non-standard.

```
minrelaytxfee=0.00000001
```
There's no benefit to this, it's actually a hindrance since it means our mempool will get filled up with low fee transactions that will probably never confirm. Our mempool will be further out of sync with most other nodes. We should use the default relay fee to maintain a closer mempool state to the rest of the network.

```
prune=0
```
Redundant, this is the default value. If we need to add pruning based on available storage in the future we can just add it dynamically.

```
# Automatically uncommented if Umbrel
# is configured for testnet
#testnet=1
#[test]

# Automatically uncommented if Umbrel
# is configured for regtest
#regtest=1
#[regtest]
```
I've removed the commented out testnet/regtest sections. These are now just dynamically added to the config by the configure script when the appropriate network has been selected.


I've changed the Tor config from:

```
onion=10.11.5.1:29050
torcontrol=10.11.5.1:29051
torpassword=<password>
```

to:

```
proxy=10.11.5.1:29050
listen=1
bind=10.11.1.1
```

This was previously creating and reporting a hidden service that was unreachable. It was also only using the Tor proxy to access Tor nodes, but clearnet nodes were accessed over clearnet.

Now all outgoing network communication happens over Tor. Regardless of whether the node we are connecting to is running on clearnet or Tor, we always route the connection through Tor so our IP is not exposed.

No hidden service is created or reported by Bitcoin core. However we are now manually creating a hidden service in the Tor config and proxying it to the Bitcoin Core P2P port. You can view the address at `tor/data/bitcoin-p2p/hostname`. Bitcoin Core is unaware of this hidden service, so doesn't broadcast it, however it will still respond to connections to the hidden service. This means you can still manually set up Umbrel as a trusted node in wallets such as Wasabi, Samourai or any SPV wallet.

Please let me know if you think any of the configuration options I've changed/removed were needed for a specific reason.