### PR TITLE
Umbrel v0.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Ensure that your account is [correctly permissioned to use docker](https://docs.
 > Run this in an empty directory where you want to install Umbrel
 
 ```bash
-curl -L https://github.com/getumbrel/umbrel/archive/v0.2.1.tar.gz | tar -xz --strip-components=1
+curl -L https://github.com/getumbrel/umbrel/archive/v0.2.2.tar.gz | tar -xz --strip-components=1
 ```
 
 ### Step 2. Run

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
-    "version": "0.2.1",
-    "name": "Umbrel v0.2.1",
-    "requires": ">=0.2.0",
+    "version": "0.2.2",
+    "name": "Umbrel v0.2.2",
+    "requires": ">=0.2.1",
     "notes": ""
 }


### PR DESCRIPTION
Even though this release is not dependent upon `v0.2.1`, we're doing so only for the purposes of testing an OTA update with a hop. 