### PR TITLE
Remove git dependency check from scripts

### DIFF
--- a/scripts/start
+++ b/scripts/start
@@ -20,10 +20,10 @@ check_dependencies () {
 }
 
 # Check system's dependencies
-check_dependencies readlink dirname docker docker-compose git
+check_dependencies readlink dirname docker docker-compose
 
 # Check karen's dependencies
-check_dependencies fswatch 
+check_dependencies fswatch
 
 # Check OTA update scripts' dependencies
 check_dependencies rsync jq curl

--- a/scripts/update/update
+++ b/scripts/update/update
@@ -14,7 +14,7 @@ check_dependencies () {
   done
 }
 
-check_dependencies jq curl git rsync
+check_dependencies jq curl rsync
 
 UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/../..)"
 


### PR DESCRIPTION
Correct me if I'm wrong but I don't think the git dependency is needed anymore since updates are now performed via `curl`.

`grep`ing the entire code base shows these dependency checks are the only occurrences of `git`.