### PR TITLE
Fix hostname cycling bug on Umbrel OS v0.1.2

### DIFF
--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -29,7 +29,7 @@ if [[ ! -z "${UMBREL_OS:-}" ]]; then
     # eth0,wlan0 interfaces to prevent hostname cycling
     # https://github.com/getumbrel/umbrel-os/issues/76
     # This patch can be safely removed from Umbrel v0.3.x+
-    if [[ $UMBREL_OS == "0.1.2" ]] && [[ ! -f "/etc/avahi/avahi-daemon.conf" ]]; then
+    if [[ $UMBREL_OS == "0.1.2" ]] && [[ -f "/etc/avahi/avahi-daemon.conf" ]]; then
         echo "Binding Avahi to eth0 and wlan0"
         sed -i "s/#allow-interfaces=eth0/allow-interfaces=eth0,wlan0/g;" "/etc/avahi/avahi-daemon.conf"
         systemctl restart avahi-daemon.service


### PR DESCRIPTION
Should fix https://github.com/getumbrel/umbrel-os/issues/76 via the next OTA update on existing Umbrel OS installs.