### PR TITLE
Remove non-standard minrelaytxfee

### DIFF
--- a/templates/bitcoin-sample.conf
+++ b/templates/bitcoin-sample.conf
@@ -17,4 +17,3 @@ dbcache=<size>
 maxmempool=300
 maxconnections=40
 maxuploadtarget=1000
-minrelaytxfee=0.00000001


### PR DESCRIPTION
Following on from https://github.com/getumbrel/umbrel/pull/152, this setting was left in because we thought it may be resolving a bug (https://github.com/getumbrel/umbrel/issues/96).

However after further investigation, this error is caused by a full mempool meaning that low fee transactions are not accepted, the non-standard `minrelaytxfee` setting we added did nothing to mitigate it.

You can prove this inluding the setting and also artificially limiting the mempool to trigger the bug with:

```
maxmempool=5
minrelaytxfee=0.00000001
```

Once the mempool fills up the bug will trigger. Simply just restarting Bitcoin Core clears the mempool and prevents the error, which was probably what lead to the belief that this setting resolved the issue, since Bitcoin Core would've been restarted after it was added.

The setting could potentially be quite problematic, since it allows users to create non-standard low-fee transactions that will likely never propagate on the network and confirm but will just remain in their own mempool and make the funds unspendable by LND.