### PR TITLE
Remove default maxmempool value

### DIFF
--- a/templates/bitcoin-sample.conf
+++ b/templates/bitcoin-sample.conf
@@ -14,6 +14,5 @@ rpcauth=<rpcauth>
 
 # Optimizations
 dbcache=<size>
-maxmempool=300
 maxconnections=40
 maxuploadtarget=1000


### PR DESCRIPTION
Since the [default value](https://github.com/bitcoin/bitcoin/blob/0d71395848bbc2941862e7a0644f47212ec02e87/doc/reduce-memory.md#memory-pool) of maxmempool is 300mb, we probably don't need to specify it in the config. @lukechilds can you please confirm? 