### PR TITLE
Add update --repo user/repo[#branch] functionality

### DIFF
--- a/scripts/update/update
+++ b/scripts/update/update
@@ -24,9 +24,28 @@ if [[ "${1}" == "--ota" ]]; then
 elif [[ "${1}" == "--path" ]]; then
   update_type="path"
   update_path="${2}"
+elif [[ "${1}" == "--repo" ]]; then
+  update_type="repo"
+  descriptor="${2}"
+  if [[ "${descriptor}" != *"#"* ]]; then
+    descriptor="${descriptor}#master"
+  fi
+  repo="${descriptor%%#*}"
+  branch="${descriptor#*#}"
 else
-  echo "Update requires \"--ota\" or \"--path <path>\" option."
+  echo "Update requires \"--ota\", \"--path <path>\", or \"--repo user/repo[#branch]\" option."
   exit 1
+fi
+
+if [[ "${update_type}" == "repo" ]]; then
+  repo_path="/tmp/umbrel-update/"
+  rm -rf "${repo_path}" 2> /dev/null || true
+  mkdir -p "${repo_path}"
+  git clone --single-branch --branch "${branch}" "https://github.com/${repo}.git" "${repo_path}"
+
+  # Now hand over to the path updater
+  update_type="path"
+  update_path="${repo_path}"
 fi
 
 if [[ "${update_type}" == "path" ]] && [[ ! -f "${update_path}/.umbrel" ]]; then


### PR DESCRIPTION
Super useful for testing out development branches or testing the OTA update process on master.

```
# Pulls down getumbrel/umbrel master branch and runs the OTA update process over the local install
update --repo getumbrel/umbrel

# OTA updates local install to official v2 branch
update --repo getumbrel/umbrel#v2

# OTA updates local install to lukechilds master branch
update --repo lukechilds/umbrel

# OTA updates local install to lukechilds swap feature branch
update --repo lukechilds/umbrel#swap
```

Example of updating from this branch to current getumbrel master:

```
umbrel@umbrel:~/umbrel $ sudo scripts/update/update --repo getumbrel/umbrel
Cloning into '/tmp/umbrel-update'...
remote: Enumerating objects: 1392, done.
remote: Total 1392 (delta 0), reused 0 (delta 0), pack-reused 1392
Receiving objects: 100% (1392/1392), 391.30 KiB | 99.00 KiB/s, done.
Resolving deltas: 100% (769/769), done.

=======================================
=============== UPDATE ================
=======================================
========== Stage: Download ============
=======================================

Creating lock
Cleaning up any previous mess
Copying Umbrel 0.2.3 from /tmp/umbrel-update/
Running update install scripts of the new release

== Begin Update Script 00-run.sh ==

...

Removing backup
Successfully installed Umbrel 0.2.3
== End Update Script 03-run.sh ==

Deleting cloned repository
Removing lock
```