### PR TITLE
Sync filesystem changes before checking partition exists

### DIFF
--- a/scripts/umbrel-os/external-storage/mount
+++ b/scripts/umbrel-os/external-storage/mount
@@ -58,7 +58,18 @@ get_block_device_model () {
 
 is_partition_ext4 () {
   partition_path="${1}"
-  blkid -o value -s TYPE "${partition_path}" | grep --quiet '^ext4$'
+  # We check the partition type with multiple different methods since some can
+  # be unreliable
+  if
+    blkid -o value -s TYPE "${partition_path}" | grep --quiet '^ext4$' ||
+    df -T "${partition_path}" | tail -n 1 | awk '{print $2}' | grep --quiet '^ext4$' ||
+    lsblk -f "${partition_path}" | tail -n 1 | awk '{print $2}' | grep --quiet '^ext4$' ||
+    mount | grep "^${partition_path} " | tail -n 1 | awk '{print $5}' | grep --quiet '^ext4$'
+  then
+    true
+  else
+    false
+  fi
 }
 
 # Wipes a block device and reformats it with a single EXT4 partition

--- a/scripts/umbrel-os/external-storage/mount
+++ b/scripts/umbrel-os/external-storage/mount
@@ -63,8 +63,7 @@ is_partition_ext4 () {
   if
     blkid -o value -s TYPE "${partition_path}" | grep --quiet '^ext4$' ||
     df -T "${partition_path}" | tail -n 1 | awk '{print $2}' | grep --quiet '^ext4$' ||
-    lsblk -f "${partition_path}" | tail -n 1 | awk '{print $2}' | grep --quiet '^ext4$' ||
-    mount | grep "^${partition_path} " | tail -n 1 | awk '{print $5}' | grep --quiet '^ext4$'
+    lsblk -f "${partition_path}" | tail -n 1 | awk '{print $2}' | grep --quiet '^ext4$'
   then
     true
   else

--- a/scripts/umbrel-os/external-storage/mount
+++ b/scripts/umbrel-os/external-storage/mount
@@ -37,6 +37,9 @@ check_dependencies () {
 
 # Returns a list of block device paths
 list_block_devices () {
+  # We need to run sync here to make sure the filesystem is reflecting the
+  # the latest changes in /sys/block/sd*
+  sync
   # We use "2>/dev/null || true" to swallow errors if there are
   # no block devices. In that case the function just returns nothing
   # instead of an error which is what we want.
@@ -58,17 +61,10 @@ get_block_device_model () {
 
 is_partition_ext4 () {
   partition_path="${1}"
-  # We check the partition type with multiple different methods since some can
-  # be unreliable
-  if
-    blkid -o value -s TYPE "${partition_path}" | grep --quiet '^ext4$' ||
-    df -T "${partition_path}" | tail -n 1 | awk '{print $2}' | grep --quiet '^ext4$' ||
-    lsblk -f "${partition_path}" | tail -n 1 | awk '{print $2}' | grep --quiet '^ext4$'
-  then
-    true
-  else
-    false
-  fi
+  # We need to run sync here to make sure the filesystem is reflecting the
+  # the latest changes in /dev/*
+  sync
+  blkid -o value -s TYPE "${partition_path}" | grep --quiet '^ext4$'
 }
 
 # Wipes a block device and reformats it with a single EXT4 partition


### PR DESCRIPTION
It seems in some strange edge cases the device file can exist (`/dev/sda`) but not the partition file (`/dev/sda1`).

If we don't run `sync` before checking for the existence of the Umbrel partition, it can appear to be non-existent and we will erroneously wipe the external storage and reformat it, despite it containing a valid Umbrel install.

Running `sync` before the check ensures the latest filesystem changes are showing properly. 