### PR TITLE
Remove stale statuses/lock files

### DIFF
--- a/scripts/start
+++ b/scripts/start
@@ -59,6 +59,10 @@ export COMPOSE_HTTP_TIMEOUT=240
 
 cd "$UMBREL_ROOT"
 
+echo "Removing stale statuses and lock files..."
+echo
+[[ -f "${UMBREL_ROOT}/statuses/backup-in-progress" ]] && rm -f "${UMBREL_ROOT}/statuses/backup-in-progress"
+
 echo "Starting karen..."
 echo
 ./karen &


### PR DESCRIPTION
This helps us avoid a situation where a stale lock/status file prevents the execution of a trigger forever. For now, we're removing `backup-in-progress`.