### PR TITLE
Fix incorrect time calculation

### DIFF
--- a/scripts/backup/decoy-trigger
+++ b/scripts/backup/decoy-trigger
@@ -28,7 +28,7 @@ check_dependencies shuf
 main () {
   while true; do
     minutes_in_seconds="60"
-    hours_in_seconds="$((${minutes_in_seconds} * 10))"
+    hours_in_seconds="$((60 * ${minutes_in_seconds}))"
     max_interval="$((8 * ${hours_in_seconds}))"
     delay="$(shuf -i 0-${max_interval} -n 1)"
     echo "Sleeping for ${delay} seconds..."


### PR DESCRIPTION
Sooooo it turns out there's actually 60 minutes in an hour, not 10.