### PR TITLE
Clear sync status on startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -152,7 +152,7 @@ services:
                     RPCUSER: $BITCOIN_RPC_USER
                     RPCPASS: $BITCOIN_RPC_PASS
                     LND_CONTAINER_NAME: lnd
-                    SLEEPTIME: 3600
+                    SLEEPTIME: 60
                 networks:
                     net:
                         ipv4_address: 10.11.5.2

--- a/scripts/start
+++ b/scripts/start
@@ -62,6 +62,7 @@ cd "$UMBREL_ROOT"
 echo "Removing stale statuses and lock files..."
 echo
 [[ -f "${UMBREL_ROOT}/statuses/backup-in-progress" ]] && rm -f "${UMBREL_ROOT}/statuses/backup-in-progress"
+[[ -f "${UMBREL_ROOT}/statuses/node-status-bitcoind-ready" ]] && rm -f "${UMBREL_ROOT}/statuses/node-status-bitcoind-ready"
 
 echo "Starting karen..."
 echo


### PR DESCRIPTION
Clear Bitcoin sync status file on startup.

This removes the possibility of pre-existing install being re-configured back to Neutrino and then never switching back to Bitcoin Core.

We also reduce the check interval from one hour to one minute.