### PR TITLE
Persist LND backend between OTA updates

### DIFF
--- a/scripts/configure
+++ b/scripts/configure
@@ -25,7 +25,7 @@ fi
 check_dependencies docker docker-compose dirname readlink
 
 # Switch to Umbrel's root directory
-UMBREL_ROOT="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")"/..)"
+UMBREL_ROOT="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")"/../..)"
 if [[ ! -d "$UMBREL_ROOT" ]]; then
   echo "Root dir does not exist '$UMBREL_ROOT'"
   exit 1

--- a/scripts/configure
+++ b/scripts/configure
@@ -156,6 +156,10 @@ sed -i "s/tor.password=<password>/tor.password=$TOR_PASS/g;" "$LND_CONF_FILE"
 sed -i "s/TOR_PASSWORD=<password>/TOR_PASSWORD=$TOR_PASS/g;" "$ENV_FILE"
 sed -i "s/TOR_HASHED_PASSWORD=<password>/TOR_HASHED_PASSWORD=$TOR_HASHED_PASS/g;" "$ENV_FILE"
 
+# If node is already synced, do not reset to neutrino
+if [[ -f "${UMBREL_ROOT}/statuses/node-status-bitcoind-ready" ]]; then
+  sed -i "s/bitcoin.node=.*/bitcoin.node=bitcoind/g;" "$LND_CONF_FILE"
+fi
 
 ##########################################################
 ############### Performance optimizations ################

--- a/scripts/configure
+++ b/scripts/configure
@@ -25,7 +25,7 @@ fi
 check_dependencies docker docker-compose dirname readlink
 
 # Switch to Umbrel's root directory
-UMBREL_ROOT="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")"/../..)"
+UMBREL_ROOT="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")"/..)"
 if [[ ! -d "$UMBREL_ROOT" ]]; then
   echo "Root dir does not exist '$UMBREL_ROOT'"
   exit 1

--- a/scripts/configure
+++ b/scripts/configure
@@ -158,7 +158,7 @@ sed -i "s/TOR_HASHED_PASSWORD=<password>/TOR_HASHED_PASSWORD=$TOR_HASHED_PASS/g;
 
 # If node is already synced, do not reset to neutrino
 if [[ -f "${UMBREL_ROOT}/statuses/node-status-bitcoind-ready" ]]; then
-  sed -i "s/bitcoin.node=neutrino/bitcoin.node=bitcoind/g;" "$LND_CONF_FILE"
+  sed -i "s/bitcoin.node=.*/bitcoin.node=bitcoind/g;" "$LND_CONF_FILE"
 fi
 
 ##########################################################

--- a/scripts/configure
+++ b/scripts/configure
@@ -164,8 +164,6 @@ sed -i "s/TOR_PASSWORD=<password>/TOR_PASSWORD=$TOR_PASS/g;" "$ENV_FILE"
 sed -i "s/TOR_HASHED_PASSWORD=<password>/TOR_HASHED_PASSWORD=$TOR_HASHED_PASS/g;" "$ENV_FILE"
 
 # If node is already synced, do not reset to neutrino
-echo "UMBREL_ROOT: ${UMBREL_ROOT}"
-echo "LND_CONF_FILE: ${LND_CONF_FILE}"
 if [[ -f "${STATUS_DIR}/node-status-bitcoind-ready" ]]; then
   sed -i "s/bitcoin.node=.*/bitcoin.node=bitcoind/g;" "$LND_CONF_FILE"
 fi

--- a/scripts/configure
+++ b/scripts/configure
@@ -157,6 +157,8 @@ sed -i "s/TOR_PASSWORD=<password>/TOR_PASSWORD=$TOR_PASS/g;" "$ENV_FILE"
 sed -i "s/TOR_HASHED_PASSWORD=<password>/TOR_HASHED_PASSWORD=$TOR_HASHED_PASS/g;" "$ENV_FILE"
 
 # If node is already synced, do not reset to neutrino
+echo "UMBREL_ROOT: ${UMBREL_ROOT}"
+echo "LND_CONF_FILE: ${LND_CONF_FILE}"
 if [[ -f "${UMBREL_ROOT}/statuses/node-status-bitcoind-ready" ]]; then
   sed -i "s/bitcoin.node=.*/bitcoin.node=bitcoind/g;" "$LND_CONF_FILE"
 fi

--- a/scripts/configure
+++ b/scripts/configure
@@ -158,7 +158,7 @@ sed -i "s/TOR_HASHED_PASSWORD=<password>/TOR_HASHED_PASSWORD=$TOR_HASHED_PASS/g;
 
 # If node is already synced, do not reset to neutrino
 if [[ -f "${UMBREL_ROOT}/statuses/node-status-bitcoind-ready" ]]; then
-  sed -i "s/bitcoin.node=.*/bitcoin.node=bitcoind/g;" "$LND_CONF_FILE"
+  sed -i "s/bitcoin.node=neutrino/bitcoin.node=bitcoind/g;" "$LND_CONF_FILE"
 fi
 
 ##########################################################

--- a/scripts/configure
+++ b/scripts/configure
@@ -32,6 +32,13 @@ if [[ ! -d "$UMBREL_ROOT" ]]; then
 fi
 cd "$UMBREL_ROOT"
 
+# Make sure we use the status dir from the real Umbrel installation if this is
+# an OTA update.
+STATUS_DIR="${UMBREL_ROOT}/statuses"
+if [[ -f "${UMBREL_ROOT}/../.umbrel" ]]; then
+  STATUS_DIR="${UMBREL_ROOT}/../statuses"
+fi
+
 # Configure for mainnet or testnet or regtest depending
 # upon the user-supplied value of $NETWORK
 BITCOIN_NETWORK="${NETWORK:-mainnet}"
@@ -43,7 +50,7 @@ fi
 
 echo
 echo "======================================"
-if [[ -f "${UMBREL_ROOT}/statuses/configured" ]]; then
+if [[ -f "${STATUS_DIR}/configured" ]]; then
   echo "=========== RECONFIGURING ============"
 else
   echo "============ CONFIGURING ============="
@@ -159,7 +166,7 @@ sed -i "s/TOR_HASHED_PASSWORD=<password>/TOR_HASHED_PASSWORD=$TOR_HASHED_PASS/g;
 # If node is already synced, do not reset to neutrino
 echo "UMBREL_ROOT: ${UMBREL_ROOT}"
 echo "LND_CONF_FILE: ${LND_CONF_FILE}"
-if [[ -f "${UMBREL_ROOT}/statuses/node-status-bitcoind-ready" ]]; then
+if [[ -f "${STATUS_DIR}/node-status-bitcoind-ready" ]]; then
   sed -i "s/bitcoin.node=.*/bitcoin.node=bitcoind/g;" "$LND_CONF_FILE"
 fi
 
@@ -201,7 +208,7 @@ echo
 chown -R 1000:1000 "$UMBREL_ROOT"
 
 # Create configured status
-touch "$UMBREL_ROOT"/statuses/configured
+touch "${STATUS_DIR}/configured"
 
 echo "Configuration successful"
 echo "You can now start Umbrel by running:"


### PR DESCRIPTION
Replaces #208 

This removes the possibility of pre-existing install being re-configured back to Neutrino and then never switching back to Bitcoin Core.