### PR TITLE
Make backups thread safe

### DIFF
--- a/scripts/backup/backup
+++ b/scripts/backup/backup
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/../..)"
-BACKUP_FOLDER=".backup/$RANDOM"
-BACKUP_ROOT="${UMBREL_ROOT}/${BACKUP_FOLDER}"
-BACKUP_FILE="${BACKUP_FOLDER}/backup.tar.gz.pgp"
+BACKUP_FOLDER_NAME="backup"
+BACKUP_ROOT="${UMBREL_ROOT}/.backup/$RANDOM/${BACKUP_FOLDER_NAME}"
+BACKUP_FILE="${BACKUP_ROOT}/backup.tar.gz.pgp"
 
 check_dependencies () {
   for cmd in "$@"; do
@@ -35,9 +35,6 @@ derive_entropy () {
 
 [[ -f "${UMBREL_ROOT}/.env" ]] && source "${UMBREL_ROOT}/.env"
 BITCOIN_NETWORK=${BITCOIN_NETWORK:-mainnet}
-
-[[ -d "${BACKUP_ROOT}" ]] && rm -rf "${BACKUP_ROOT}"
-[[ -f "${BACKUP_FILE}" ]] && rm -f "${BACKUP_FILE}"
 
 echo "Deriving keys..."
 
@@ -78,8 +75,8 @@ tar \
   --create \
   --gzip \
   --verbose \
-  --directory "${UMBREL_ROOT}" \
-  "${BACKUP_FOLDER}" \
+  --directory "${BACKUP_ROOT}/.." \
+  "${BACKUP_FOLDER_NAME}" \
   | gpg \
   --batch \
   --symmetric \

--- a/scripts/backup/backup
+++ b/scripts/backup/backup
@@ -26,7 +26,6 @@ derive_entropy () {
 
   if [[ -z "$umbrel_seed" ]] || [[ -z "$identifier" ]]; then
     >&2 echo "Missing derivation parameter, this is unsafe, exiting."
-    rm -f "${UMBREL_ROOT}/statuses/backup-in-progress"
     exit 1
   fi
 
@@ -46,7 +45,6 @@ echo "Creating backup..."
 
 if [[ ! -f "${UMBREL_ROOT}/lnd/data/chain/bitcoin/${BITCOIN_NETWORK}/channel.backup" ]]; then
     echo "No channel.backup file found, skipping backup..."
-    rm -f "${UMBREL_ROOT}/statuses/backup-in-progress"
     exit 1
 fi
 

--- a/scripts/backup/backup
+++ b/scripts/backup/backup
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/../..)"
-BACKUP_FOLDER="backup"
+BACKUP_FOLDER=".backup/$RANDOM"
 BACKUP_ROOT="${UMBREL_ROOT}/${BACKUP_FOLDER}"
-BACKUP_FILE="${UMBREL_ROOT}/backup.tar.gz.pgp"
+BACKUP_FILE="${BACKUP_FOLDER}/backup.tar.gz.pgp"
 
 check_dependencies () {
   for cmd in "$@"; do
@@ -32,15 +32,6 @@ derive_entropy () {
   # We need `sed 's/^.* //'` to trim the "(stdin)= " prefix from some versions of openssl
   printf "%s" "${identifier}" | openssl dgst -sha256 -hmac "${umbrel_seed}" | sed 's/^.* //'
 }
-
-# Make sure an update is not in progres
-if [[ -f "${UMBREL_ROOT}/statuses/backup-in-progress" ]]; then
-    echo "A backup is already in progress. Exiting now."
-    exit 1
-fi
-
-echo "Creating lock..."
-touch "${UMBREL_ROOT}/statuses/backup-in-progress"
 
 [[ -f "${UMBREL_ROOT}/.env" ]] && source "${UMBREL_ROOT}/.env"
 BITCOIN_NETWORK=${BITCOIN_NETWORK:-mainnet}
@@ -121,9 +112,6 @@ echo
 
 rm -rf "${BACKUP_ROOT}"
 rm -f "${BACKUP_FILE}"
-
-echo "Removing lock..."
-rm -f "${UMBREL_ROOT}/statuses/backup-in-progress"
 
 echo "============================="
 echo "===== Backup successful ====="

--- a/scripts/backup/backup
+++ b/scripts/backup/backup
@@ -3,8 +3,9 @@
 set -euo pipefail
 
 UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/../..)"
+BACKUP_ROOT="${UMBREL_ROOT}/.backup/$RANDOM"
 BACKUP_FOLDER_NAME="backup"
-BACKUP_ROOT="${UMBREL_ROOT}/.backup/$RANDOM/${BACKUP_FOLDER_NAME}"
+BACKUP_FOLDER_PATH="${BACKUP_ROOT}/${BACKUP_FOLDER_NAME}"
 BACKUP_FILE="${BACKUP_ROOT}/backup.tar.gz.pgp"
 
 check_dependencies () {
@@ -49,15 +50,15 @@ if [[ ! -f "${UMBREL_ROOT}/lnd/data/chain/bitcoin/${BITCOIN_NETWORK}/channel.bac
     exit 1
 fi
 
-mkdir -p "${BACKUP_ROOT}"
+mkdir -p "${BACKUP_FOLDER_PATH}"
 
-cp --archive "${UMBREL_ROOT}/lnd/data/chain/bitcoin/${BITCOIN_NETWORK}/channel.backup" "${BACKUP_ROOT}/channel.backup"
+cp --archive "${UMBREL_ROOT}/lnd/data/chain/bitcoin/${BITCOIN_NETWORK}/channel.backup" "${BACKUP_FOLDER_PATH}/channel.backup"
 
 # We want to back up user settings too, however we currently store the encrypted
 # mnemonic in this file which is not safe to backup remotely.
 # Uncomment this in the future once we've ensured there's no critical data in
 # this file.
-# cp --archive "${UMBREL_ROOT}/db/user.json" "${BACKUP_ROOT}/user.json"
+# cp --archive "${UMBREL_ROOT}/db/user.json" "${BACKUP_FOLDER_PATH}/user.json"
 
 echo "Adding random padding..."
 
@@ -67,7 +68,7 @@ echo "Adding random padding..."
 # this makes a (already very difficult) timing analysis attack to correlate backup
 # activity with channel state changes practically impossible.
 padding="$(shuf -i 0-10240 -n 1)"
-dd if=/dev/urandom bs="${padding}" count=1 > "${BACKUP_ROOT}/.padding"
+dd if=/dev/urandom bs="${padding}" count=1 > "${BACKUP_FOLDER_PATH}/.padding"
 
 echo "Creating encrypted tarball..."
 
@@ -75,7 +76,7 @@ tar \
   --create \
   --gzip \
   --verbose \
-  --directory "${BACKUP_ROOT}/.." \
+  --directory "${BACKUP_FOLDER_PATH}/.." \
   "${BACKUP_FOLDER_NAME}" \
   | gpg \
   --batch \
@@ -108,7 +109,6 @@ curl --socks5 localhost:9150 -F "file=@/${BACKUP_FILE}" "${BACKUP_API_URL}/${bac
 echo
 
 rm -rf "${BACKUP_ROOT}"
-rm -f "${BACKUP_FILE}"
 
 echo "============================="
 echo "===== Backup successful ====="

--- a/scripts/start
+++ b/scripts/start
@@ -59,10 +59,6 @@ export COMPOSE_HTTP_TIMEOUT=240
 
 cd "$UMBREL_ROOT"
 
-echo "Removing stale statuses and lock files..."
-echo
-[[ -f "${UMBREL_ROOT}/statuses/backup-in-progress" ]] && rm -f "${UMBREL_ROOT}/statuses/backup-in-progress"
-
 echo "Starting karen..."
 echo
 ./karen &

--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -102,6 +102,11 @@ EOF
 cd "$UMBREL_ROOT"
 ./scripts/start
 
+# Delete obselete backup lock file
+# https://github.com/getumbrel/umbrel/pull/213
+# Remove this in the next breaking update
+[[ -f "${UMBREL_ROOT}/statuses/backup-in-progress" ]] && rm -f "${UMBREL_ROOT}/statuses/backup-in-progress"
+
 # Make Umbrel OS specific post-update changes
 if [[ ! -z "${UMBREL_OS:-}" ]]; then
 


### PR DESCRIPTION
This change removes the need for a lock file to prevent concurrent backups. Multiple backup threads can now run concurrently without issue.

This improves reliability, since int he edge case that a lock file doesn't get cleaned up correctly, no future backups would ever run.