### PR TITLE
Handle upload fail

### DIFF
--- a/scripts/backup/backup
+++ b/scripts/backup/backup
@@ -116,7 +116,11 @@ if [[ $BITCOIN_NETWORK == "regtest" ]]; then
 fi
 
 echo "Uploading backup..."
-curl --socks5 localhost:9150 -F "file=@/${BACKUP_FILE}" "${BACKUP_API_URL}/${backup_id}" || true
+if curl --socks5 localhost:9150 -F "file=@/${BACKUP_FILE}" "${BACKUP_API_URL}/${backup_id}"; then
+  status="===== Backup successful ====="
+else
+  status="======= Backup failed ======="
+fi
 echo
 
 rm -rf "${BACKUP_ROOT}"
@@ -126,7 +130,7 @@ echo "Removing lock..."
 rm -f "${UMBREL_ROOT}/statuses/backup-in-progress"
 
 echo "============================="
-echo "===== Backup successful ====="
+echo "${status}"
 echo "============================="
 
 exit 0

--- a/scripts/backup/backup
+++ b/scripts/backup/backup
@@ -116,7 +116,7 @@ if [[ $BITCOIN_NETWORK == "regtest" ]]; then
 fi
 
 echo "Uploading backup..."
-curl --socks5 localhost:9150 -F "file=@/${BACKUP_FILE}" "${BACKUP_API_URL}/${backup_id}"
+curl --socks5 localhost:9150 -F "file=@/${BACKUP_FILE}" "${BACKUP_API_URL}/${backup_id}" || true
 echo
 
 rm -rf "${BACKUP_ROOT}"


### PR DESCRIPTION
Currently if the upload fails the backup script exits uncleanly.

This PR correctly handles a failed upload by allowing the script to clean up and prints the error in the logs.