### PR TITLE
Export a list of device hosts for CORS whitelist

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,7 @@ services:
                     JWT_PRIVATE_KEY_FILE: "/jwt-private-key/jwt.key"
                     JWT_EXPIRATION: "3600"
                     DOCKER_COMPOSE_DIRECTORY: $PWD
-                    DEVICE_HOST: ${DEVICE_HOST:-http://umbrel.local}
+                    DEVICE_HOSTS: ${DEVICE_HOSTS:-["http://umbrel.local"]}
                     MIDDLEWARE_API_URL: "http://10.11.2.2"
                     UMBREL_SEED_FILE: "/db/umbrel-seed/seed"
                     UMBREL_DASHBOARD_HIDDEN_SERVICE_FILE: "/var/lib/tor/web/hostname"
@@ -134,7 +134,7 @@ services:
                     LND_NETWORK: $BITCOIN_NETWORK
                     LND_HOST: "10.11.1.2"
                     JWT_PUBLIC_KEY_FILE: "/jwt-public-key/jwt.pem"
-                    DEVICE_HOST: ${DEVICE_HOST:-http://umbrel.local}
+                    DEVICE_HOSTS: ${DEVICE_HOSTS:-["http://umbrel.local"]}
                 networks:
                     net:
                         ipv4_address: 10.11.2.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,7 @@ services:
                     JWT_PRIVATE_KEY_FILE: "/jwt-private-key/jwt.key"
                     JWT_EXPIRATION: "3600"
                     DOCKER_COMPOSE_DIRECTORY: $PWD
-                    DEVICE_HOSTS: ${DEVICE_HOSTS:-["http://umbrel.local"]}
+                    DEVICE_HOSTS: ${DEVICE_HOSTS:-"http://umbrel.local"}
                     MIDDLEWARE_API_URL: "http://10.11.2.2"
                     UMBREL_SEED_FILE: "/db/umbrel-seed/seed"
                     UMBREL_DASHBOARD_HIDDEN_SERVICE_FILE: "/var/lib/tor/web/hostname"
@@ -119,7 +119,7 @@ services:
                 image: mayankchhabra/middleware:cors
                 logging: *default-logging
                 depends_on: [ manager, bitcoin, lnd ]
-                # command: ["./wait-for-node-manager.sh", "10.11.2.1", "npm", "start"]
+                command: ["./wait-for-node-manager.sh", "10.11.2.1", "npm", "start"]
                 restart: unless-stopped
                 depends_on: [ manager ]
                 volumes:
@@ -134,7 +134,7 @@ services:
                     LND_NETWORK: $BITCOIN_NETWORK
                     LND_HOST: "10.11.1.2"
                     JWT_PUBLIC_KEY_FILE: "/jwt-public-key/jwt.pem"
-                    DEVICE_HOSTS: ${DEVICE_HOSTS:-["http://umbrel.local"]}
+                    DEVICE_HOSTS: ${DEVICE_HOSTS:-"http://umbrel.local"}
                 networks:
                     net:
                         ipv4_address: 10.11.2.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
                         ipv4_address: 10.11.0.3
         manager:
                 container_name: manager
-                image: getumbrel/manager:v0.2.3
+                image: mayankchhabra/manager:cors
                 logging: *default-logging
                 depends_on: [ tor ]
                 restart: unless-stopped
@@ -116,7 +116,7 @@ services:
                         ipv4_address: 10.11.2.1
         middleware:
                 container_name: middleware
-                image: getumbrel/middleware:v0.1.4
+                image: mayankchhabra/middleware:cors
                 logging: *default-logging
                 depends_on: [ manager, bitcoin, lnd ]
                 command: ["./wait-for-node-manager.sh", "10.11.2.1", "npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,7 +119,7 @@ services:
                 image: mayankchhabra/middleware:cors
                 logging: *default-logging
                 depends_on: [ manager, bitcoin, lnd ]
-                command: ["./wait-for-node-manager.sh", "10.11.2.1", "npm", "start"]
+                # command: ["./wait-for-node-manager.sh", "10.11.2.1", "npm", "start"]
                 restart: unless-stopped
                 depends_on: [ manager ]
                 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
                         ipv4_address: 10.11.0.3
         manager:
                 container_name: manager
-                image: mayankchhabra/manager:cors
+                image: getumbrel/manager:v0.2.3
                 logging: *default-logging
                 depends_on: [ tor ]
                 restart: unless-stopped
@@ -116,7 +116,7 @@ services:
                         ipv4_address: 10.11.2.1
         middleware:
                 container_name: middleware
-                image: mayankchhabra/middleware:cors
+                image: getumbrel/middleware:v0.1.4
                 logging: *default-logging
                 depends_on: [ manager, bitcoin, lnd ]
                 command: ["./wait-for-node-manager.sh", "10.11.2.1", "npm", "start"]

--- a/scripts/start
+++ b/scripts/start
@@ -53,7 +53,7 @@ echo
 # Whitelist device IP, hostname and hidden service for CORS
 DEVICE_IP="$(hostname -I | cut -d ' ' -f 1)"
 DEVICE_HOSTNAME="$(hostname)"
-DEVICE_HOSTS="http://${DEVICE_IP},http://${DEVICE_HOSTNAME}.local,https://${DEVICE_HOSTNAME}.local"
+DEVICE_HOSTS="http://${DEVICE_IP},http://${DEVICE_HOSTNAME}.local,http://${DEVICE_HOSTNAME},https://${DEVICE_HOSTNAME}"
 if [[ -f "${UMBREL_ROOT}/tor/data/web/hostname" ]]; then
     hidden_service_url=$(cat "${UMBREL_ROOT}/tor/data/web/hostname")
     DEVICE_HOSTS="${DEVICE_HOSTS},http://${hidden_service_url}"

--- a/scripts/start
+++ b/scripts/start
@@ -60,8 +60,6 @@ if [[ -f "${UMBREL_ROOT}/tor/data/web/hostname" ]]; then
 fi
 export DEVICE_HOSTS=$DEVICE_HOSTS
 
-echo
-
 # Increase default Docker and Compose timeouts to 240s
 # as bitcoin can take a long while to respond
 export DOCKER_CLIENT_TIMEOUT=240

--- a/scripts/start
+++ b/scripts/start
@@ -57,9 +57,9 @@ DEVICE_HOSTNAME="$(hostname)"
 
 if [[ -f "${UMBREL_ROOT}/tor/data/bitcoin-p2p/hostname" ]]; then
     hidden_service_url=$(cat "${UMBREL_ROOT}/tor/data/bitcoin-p2p/hostname")
-    export DEVICE_HOSTS="['${DEVICE_IP}', 'http://${DEVICE_HOSTNAME}.local', 'https://${DEVICE_HOSTNAME}.local', 'http://${hidden_service_url}']"
+    export DEVICE_HOSTS="\"${DEVICE_IP}\",\"http://${DEVICE_HOSTNAME}.local\",\"https://${DEVICE_HOSTNAME}.local\",\"http://${hidden_service_url}\""
 else
-    export DEVICE_HOSTS="['${DEVICE_IP}', 'http://${DEVICE_HOSTNAME}.local', 'https://${DEVICE_HOSTNAME}.local']"
+    export DEVICE_HOSTS="\"${DEVICE_IP}\",\"http://${DEVICE_HOSTNAME}.local\",\"https://${DEVICE_HOSTNAME}.local\""
 fi
 
 # Increase default Docker and Compose timeouts to 240s
@@ -88,4 +88,4 @@ docker-compose up --detach --build --remove-orphans
 echo
 
 echo "Umbrel is now accessible at"
-echo "  $DEVICE_HOST"
+echo "  $DEVICE_HOSTS"

--- a/scripts/start
+++ b/scripts/start
@@ -53,7 +53,7 @@ echo
 # Whitelist device IP, hostname and hidden service for CORS
 DEVICE_IP="$(hostname -I | cut -d ' ' -f 1)"
 DEVICE_HOSTNAME="$(hostname)"
-DEVICE_HOSTS="http://${DEVICE_IP},http://${DEVICE_HOSTNAME}.local,http://${DEVICE_HOSTNAME},https://${DEVICE_HOSTNAME}"
+DEVICE_HOSTS="http://${DEVICE_IP},http://${DEVICE_HOSTNAME}.local,https://${DEVICE_HOSTNAME}.local,http://${DEVICE_HOSTNAME},https://${DEVICE_HOSTNAME}"
 if [[ -f "${UMBREL_ROOT}/tor/data/web/hostname" ]]; then
     hidden_service_url=$(cat "${UMBREL_ROOT}/tor/data/web/hostname")
     DEVICE_HOSTS="${DEVICE_HOSTS},http://${hidden_service_url}"

--- a/scripts/start
+++ b/scripts/start
@@ -86,4 +86,6 @@ docker-compose up --detach --build --remove-orphans
 echo
 
 echo "Umbrel is now accessible at"
-echo "$DEVICE_HOSTS"
+echo "  http://${DEVICE_HOSTNAME}.local"
+echo "  http://${DEVICE_IP}"
+[[ ! -z "${hidden_service_url:-}" ]] && echo "  http://${hidden_service_url}"

--- a/scripts/start
+++ b/scripts/start
@@ -54,14 +54,17 @@ echo
 
 DEVICE_IP="$(hostname -I | cut -d ' ' -f 1)"
 DEVICE_HOSTNAME="$(hostname)"
-DEVICE_HOSTS="\"${DEVICE_IP}\",\"http://${DEVICE_HOSTNAME}.local\",\"https://${DEVICE_HOSTNAME}.local\""
-
+DEVICE_HOSTS="[\"${DEVICE_IP}\",\"http://${DEVICE_HOSTNAME}.local\",\"https://${DEVICE_HOSTNAME}.local\""
 if [[ -f "${UMBREL_ROOT}/tor/data/web/hostname" ]]; then
     hidden_service_url=$(cat "${UMBREL_ROOT}/tor/data/web/hostname")
     DEVICE_HOSTS="${DEVICE_HOSTS},\"http://${hidden_service_url}\""
 fi
-export DEVICE_HOSTS
+DEVICE_HOSTS="${DEVICE_HOSTS}]"
+export DEVICE_HOSTS=$DEVICE_HOSTS
 
+echo $DEVICE_HOSTS
+
+echo 
 # Increase default Docker and Compose timeouts to 240s
 # as bitcoin can take a long while to respond
 export DOCKER_CLIENT_TIMEOUT=240

--- a/scripts/start
+++ b/scripts/start
@@ -49,9 +49,19 @@ echo
 
 echo "Setting environment variables..."
 echo
+
+# Whitelist device IP, hostname and hidden service for CORS
+
 DEVICE_IP="$(hostname -I | cut -d ' ' -f 1)"
 DEVICE_HOSTNAME="$(hostname)"
-export DEVICE_HOST="http://"${DEVICE_IP:-"$DEVICE_HOSTNAME".local}""
+
+if [[ -f "${UMBREL_ROOT}/tor/data/bitcoin-p2p/hostname" ]]; then
+    hidden_service_url=$(cat "${UMBREL_ROOT}/tor/data/bitcoin-p2p/hostname")
+    export DEVICE_HOSTS="['${DEVICE_IP}', 'http://${DEVICE_HOSTNAME}.local', 'https://${DEVICE_HOSTNAME}.local', 'http://${hidden_service_url}']"
+else
+    export DEVICE_HOSTS="['${DEVICE_IP}', 'http://${DEVICE_HOSTNAME}.local', 'https://${DEVICE_HOSTNAME}.local']"
+fi
+
 # Increase default Docker and Compose timeouts to 240s
 # as bitcoin can take a long while to respond
 export DOCKER_CLIENT_TIMEOUT=240

--- a/scripts/start
+++ b/scripts/start
@@ -54,12 +54,11 @@ echo
 
 DEVICE_IP="$(hostname -I | cut -d ' ' -f 1)"
 DEVICE_HOSTNAME="$(hostname)"
-DEVICE_HOSTS="[\"${DEVICE_IP}\",\"http://${DEVICE_HOSTNAME}.local\",\"https://${DEVICE_HOSTNAME}.local\""
+DEVICE_HOSTS="'${DEVICE_IP}','http://${DEVICE_HOSTNAME}.local','https://${DEVICE_HOSTNAME}.local'"
 if [[ -f "${UMBREL_ROOT}/tor/data/web/hostname" ]]; then
     hidden_service_url=$(cat "${UMBREL_ROOT}/tor/data/web/hostname")
-    DEVICE_HOSTS="${DEVICE_HOSTS},\"http://${hidden_service_url}\""
+    DEVICE_HOSTS="${DEVICE_HOSTS},'http://${hidden_service_url}'"
 fi
-DEVICE_HOSTS="${DEVICE_HOSTS}]"
 export DEVICE_HOSTS=$DEVICE_HOSTS
 
 echo $DEVICE_HOSTS

--- a/scripts/start
+++ b/scripts/start
@@ -51,7 +51,6 @@ echo "Setting environment variables..."
 echo
 
 # Whitelist device IP, hostname and hidden service for CORS
-
 DEVICE_IP="$(hostname -I | cut -d ' ' -f 1)"
 DEVICE_HOSTNAME="$(hostname)"
 DEVICE_HOSTS="http://${DEVICE_IP},http://${DEVICE_HOSTNAME}.local,https://${DEVICE_HOSTNAME}.local"
@@ -61,9 +60,8 @@ if [[ -f "${UMBREL_ROOT}/tor/data/web/hostname" ]]; then
 fi
 export DEVICE_HOSTS=$DEVICE_HOSTS
 
-echo $DEVICE_HOSTS
+echo
 
-echo 
 # Increase default Docker and Compose timeouts to 240s
 # as bitcoin can take a long while to respond
 export DOCKER_CLIENT_TIMEOUT=240
@@ -90,4 +88,4 @@ docker-compose up --detach --build --remove-orphans
 echo
 
 echo "Umbrel is now accessible at"
-echo "  $DEVICE_HOSTS"
+echo "$DEVICE_HOSTS"

--- a/scripts/start
+++ b/scripts/start
@@ -54,13 +54,13 @@ echo
 
 DEVICE_IP="$(hostname -I | cut -d ' ' -f 1)"
 DEVICE_HOSTNAME="$(hostname)"
+DEVICE_HOSTS="\"${DEVICE_IP}\",\"http://${DEVICE_HOSTNAME}.local\",\"https://${DEVICE_HOSTNAME}.local\""
 
-if [[ -f "${UMBREL_ROOT}/tor/data/bitcoin-p2p/hostname" ]]; then
-    hidden_service_url=$(cat "${UMBREL_ROOT}/tor/data/bitcoin-p2p/hostname")
-    export DEVICE_HOSTS="\"${DEVICE_IP}\",\"http://${DEVICE_HOSTNAME}.local\",\"https://${DEVICE_HOSTNAME}.local\",\"http://${hidden_service_url}\""
-else
-    export DEVICE_HOSTS="\"${DEVICE_IP}\",\"http://${DEVICE_HOSTNAME}.local\",\"https://${DEVICE_HOSTNAME}.local\""
+if [[ -f "${UMBREL_ROOT}/tor/data/web/hostname" ]]; then
+    hidden_service_url=$(cat "${UMBREL_ROOT}/tor/data/web/hostname")
+    DEVICE_HOSTS="${DEVICE_HOSTS},\"http://${hidden_service_url}\""
 fi
+export DEVICE_HOSTS
 
 # Increase default Docker and Compose timeouts to 240s
 # as bitcoin can take a long while to respond

--- a/scripts/start
+++ b/scripts/start
@@ -54,10 +54,10 @@ echo
 
 DEVICE_IP="$(hostname -I | cut -d ' ' -f 1)"
 DEVICE_HOSTNAME="$(hostname)"
-DEVICE_HOSTS="'${DEVICE_IP}','http://${DEVICE_HOSTNAME}.local','https://${DEVICE_HOSTNAME}.local'"
+DEVICE_HOSTS="http://${DEVICE_IP},http://${DEVICE_HOSTNAME}.local,https://${DEVICE_HOSTNAME}.local"
 if [[ -f "${UMBREL_ROOT}/tor/data/web/hostname" ]]; then
     hidden_service_url=$(cat "${UMBREL_ROOT}/tor/data/web/hostname")
-    DEVICE_HOSTS="${DEVICE_HOSTS},'http://${hidden_service_url}'"
+    DEVICE_HOSTS="${DEVICE_HOSTS},http://${hidden_service_url}"
 fi
 export DEVICE_HOSTS=$DEVICE_HOSTS
 


### PR DESCRIPTION
Allows us to whitelist multiple device hosts at runtime:

- IP address
- Device's hostname (should also fix https://github.com/getumbrel/umbrel-dev/issues/11)
- Hidden service URL (fixes CORS issue on iOS Tor browsers)