### PR TITLE
Prevent start script from failing on no hidden service file

### DIFF
--- a/scripts/start
+++ b/scripts/start
@@ -88,4 +88,6 @@ echo
 echo "Umbrel is now accessible at"
 echo "  http://${DEVICE_HOSTNAME}.local"
 echo "  http://${DEVICE_IP}"
-[[ ! -z "${hidden_service_url:-}" ]] && echo "  http://${hidden_service_url}"
+if [[ ! -z "${hidden_service_url:-}" ]]; then
+    echo "  http://${hidden_service_url}"
+fi


### PR DESCRIPTION
The previous check failed when there was no hidden service URL.