### PR TITLE
Expose LND RPC/REST for lndconnect

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,8 +86,7 @@ services:
                         - ${PWD}/info.json:/info.json
                         - ${PWD}/db:/db
                         - ${PWD}/events/signals:/signals
-                        - ${PWD}/lnd/data/chain/bitcoin/${BITCOIN_NETWORK}/admin.macaroon:/lnd/admin.macaroon
-                        - ${PWD}/lnd/tls.cert:/lnd/tls.cert
+                        - ${PWD}/lnd:/lnd:ro
                         - ${PWD}/statuses:/statuses
                         - ${PWD}/tor/data:/var/lib/tor/
                         - /var/run/docker.sock:/var/run/docker.sock
@@ -110,7 +109,7 @@ services:
                     LND_REST_HIDDEN_SERVICE_FILE: "/var/lib/tor/lnd-rest/hostname"
                     LND_RPC_HIDDEN_SERVICE_FILE: "/var/lib/tor/lnd-rpc/hostname"
                     LND_CERT_FILE: "/lnd/tls.cert"
-                    LND_ADMIN_MACAROON_FILE: "/lnd/admin.macaroon"
+                    LND_ADMIN_MACAROON_FILE: "/lnd/data/chain/bitcoin/${BITCOIN_NETWORK}/admin.macaroon"
                     SHUTDOWN_SIGNAL_FILE: "/signals/shutdown"
                     REBOOT_SIGNAL_FILE: "/signals/reboot"
                     GITHUB_REPO: "getumbrel/umbrel"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
                         ipv4_address: 10.11.1.2
         dashboard:
                 container_name: dashboard
-                image: getumbrel/dashboard:v0.3.7
+                image: mayankchhabra/dashboard:lndconnect
                 logging: *default-logging
                 restart: unless-stopped
                 stop_grace_period: 1m30s
@@ -76,7 +76,7 @@ services:
                         ipv4_address: 10.11.0.3
         manager:
                 container_name: manager
-                image: getumbrel/manager:v0.2.4
+                image: mayankchhabra/manager:lndconnect
                 logging: *default-logging
                 depends_on: [ tor ]
                 restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
                         ipv4_address: 10.11.1.2
         dashboard:
                 container_name: dashboard
-                image: mayankchhabra/dashboard:lndconnect
+                image: getumbrel/dashboard:v0.3.7
                 logging: *default-logging
                 restart: unless-stopped
                 stop_grace_period: 1m30s
@@ -76,7 +76,7 @@ services:
                         ipv4_address: 10.11.0.3
         manager:
                 container_name: manager
-                image: mayankchhabra/manager:lndconnect
+                image: getumbrel/manager:v0.2.4
                 logging: *default-logging
                 depends_on: [ tor ]
                 restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,7 @@ services:
                     JWT_EXPIRATION: "3600"
                     DOCKER_COMPOSE_DIRECTORY: $PWD
                     DEVICE_HOSTS: ${DEVICE_HOSTS:-"http://umbrel.local"}
-                    DEVICE_IP: ${DEVICE_IP:-""}
+                    DEVICE_HOSTNAME: ${DEVICE_HOSTNAME:-""}
                     MIDDLEWARE_API_URL: "http://10.11.2.2"
                     UMBREL_SEED_FILE: "/db/umbrel-seed/seed"
                     UMBREL_DASHBOARD_HIDDEN_SERVICE_FILE: "/var/lib/tor/web/hostname"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,7 @@ services:
                     JWT_EXPIRATION: "3600"
                     DOCKER_COMPOSE_DIRECTORY: $PWD
                     DEVICE_HOSTS: ${DEVICE_HOSTS:-"http://umbrel.local"}
+                    DEVICE_IP: ${DEVICE_IP:-""}
                     MIDDLEWARE_API_URL: "http://10.11.2.2"
                     UMBREL_SEED_FILE: "/db/umbrel-seed/seed"
                     UMBREL_DASHBOARD_HIDDEN_SERVICE_FILE: "/var/lib/tor/web/hostname"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
                         ipv4_address: 10.11.1.2
         dashboard:
                 container_name: dashboard
-                image: getumbrel/dashboard:v0.3.7
+                image: mayankchhabra/dashboard:lndconnect
                 logging: *default-logging
                 restart: unless-stopped
                 stop_grace_period: 1m30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,8 @@ services:
                 stop_grace_period: 5m30s
                 ports:
                     - "9735:9735"
+                    - "8080:8080"
+                    - "10009:10009"
                 networks:
                     net:
                         ipv4_address: 10.11.1.2
@@ -74,7 +76,7 @@ services:
                         ipv4_address: 10.11.0.3
         manager:
                 container_name: manager
-                image: getumbrel/manager:v0.2.4
+                image: mayankchhabra/manager:lndconnect
                 logging: *default-logging
                 depends_on: [ tor ]
                 restart: unless-stopped
@@ -84,6 +86,8 @@ services:
                         - ${PWD}/info.json:/info.json
                         - ${PWD}/db:/db
                         - ${PWD}/events/signals:/signals
+                        - ${PWD}/lnd/data/chain/bitcoin/${BITCOIN_NETWORK}/admin.macaroon:/lnd/admin.macaroon
+                        - ${PWD}/lnd/tls.cert:/lnd/tls.cert
                         - ${PWD}/statuses:/statuses
                         - ${PWD}/tor/data:/var/lib/tor/
                         - /var/run/docker.sock:/var/run/docker.sock
@@ -103,6 +107,10 @@ services:
                     UMBREL_DASHBOARD_HIDDEN_SERVICE_FILE: "/var/lib/tor/web/hostname"
                     BITCOIN_P2P_HIDDEN_SERVICE_FILE: "/var/lib/tor/bitcoin-p2p/hostname"
                     BITCOIN_P2P_PORT: $BITCOIN_P2P_PORT
+                    LND_REST_HIDDEN_SERVICE_FILE: "/var/lib/tor/lnd-rest/hostname"
+                    LND_RPC_HIDDEN_SERVICE_FILE: "/var/lib/tor/lnd-rpc/hostname"
+                    LND_CERT_FILE: "/lnd/tls.cert"
+                    LND_ADMIN_MACAROON_FILE: "/lnd/admin.macaroon"
                     SHUTDOWN_SIGNAL_FILE: "/signals/shutdown"
                     REBOOT_SIGNAL_FILE: "/signals/reboot"
                     GITHUB_REPO: "getumbrel/umbrel"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,7 +107,7 @@ services:
                     BITCOIN_P2P_HIDDEN_SERVICE_FILE: "/var/lib/tor/bitcoin-p2p/hostname"
                     BITCOIN_P2P_PORT: $BITCOIN_P2P_PORT
                     LND_REST_HIDDEN_SERVICE_FILE: "/var/lib/tor/lnd-rest/hostname"
-                    LND_RPC_HIDDEN_SERVICE_FILE: "/var/lib/tor/lnd-rpc/hostname"
+                    LND_GRPC_HIDDEN_SERVICE_FILE: "/var/lib/tor/lnd-grpc/hostname"
                     LND_CERT_FILE: "/lnd/tls.cert"
                     LND_ADMIN_MACAROON_FILE: "/lnd/data/chain/bitcoin/${BITCOIN_NETWORK}/admin.macaroon"
                     SHUTDOWN_SIGNAL_FILE: "/signals/shutdown"

--- a/scripts/configure
+++ b/scripts/configure
@@ -163,6 +163,10 @@ sed -i "s/tor.password=<password>/tor.password=$TOR_PASS/g;" "$LND_CONF_FILE"
 sed -i "s/TOR_PASSWORD=<password>/TOR_PASSWORD=$TOR_PASS/g;" "$ENV_FILE"
 sed -i "s/TOR_HASHED_PASSWORD=<password>/TOR_HASHED_PASSWORD=$TOR_HASHED_PASS/g;" "$ENV_FILE"
 
+# Add hostname to lnd.conf for TLS certificate
+DEVICE_HOSTNAME="$(hostname)"
+sed -i "s/tlsextradomain=<hostname>/tlsextradomain=$DEVICE_HOSTNAME.local/g;" "$LND_CONF_FILE"
+
 # If node is already synced, do not reset to neutrino
 if [[ -f "${STATUS_DIR}/node-status-bitcoind-ready" ]]; then
   sed -i "s/bitcoin.node=.*/bitcoin.node=bitcoind/g;" "$LND_CONF_FILE"

--- a/scripts/start
+++ b/scripts/start
@@ -59,7 +59,7 @@ if [[ -f "${UMBREL_ROOT}/tor/data/web/hostname" ]]; then
     DEVICE_HOSTS="${DEVICE_HOSTS},http://${hidden_service_url}"
 fi
 export DEVICE_HOSTS=$DEVICE_HOSTS
-export DEVICE_IP=$DEVICE_IP
+export DEVICE_HOSTNAME=$DEVICE_HOSTNAME
 
 # Increase default Docker and Compose timeouts to 240s
 # as bitcoin can take a long while to respond

--- a/scripts/start
+++ b/scripts/start
@@ -59,7 +59,7 @@ if [[ -f "${UMBREL_ROOT}/tor/data/web/hostname" ]]; then
     DEVICE_HOSTS="${DEVICE_HOSTS},http://${hidden_service_url}"
 fi
 export DEVICE_HOSTS=$DEVICE_HOSTS
-export DEVICE_HOSTNAME=$DEVICE_HOSTNAME
+export DEVICE_HOSTNAME="${DEVICE_HOSTNAME}.local"
 
 # Increase default Docker and Compose timeouts to 240s
 # as bitcoin can take a long while to respond

--- a/scripts/start
+++ b/scripts/start
@@ -59,6 +59,7 @@ if [[ -f "${UMBREL_ROOT}/tor/data/web/hostname" ]]; then
     DEVICE_HOSTS="${DEVICE_HOSTS},http://${hidden_service_url}"
 fi
 export DEVICE_HOSTS=$DEVICE_HOSTS
+export DEVICE_IP=$DEVICE_IP
 
 # Increase default Docker and Compose timeouts to 240s
 # as bitcoin can take a long while to respond

--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -79,8 +79,6 @@ EOF
 cd "$UMBREL_ROOT"
 ./scripts/stop
 
-OLD_UMBREL_VERSION=$(cat "${UMBREL_ROOT}/info.json" | jq -r .version | cut -d "-" -f "1")
-
 # Overlay home dir structure with new dir tree
 echo "Overlaying $UMBREL_ROOT/ with new directory tree"
 rsync --archive \

--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -7,12 +7,6 @@ UMBREL_ROOT=$2
 # Only used on Umbrel OS
 SD_CARD_UMBREL_ROOT="/sd-root${UMBREL_ROOT}"
 
-check_semver_range () {
-  local range="${1}"
-  local version="${2}"
-  "${UMBREL_ROOT}/scripts/umbrel-os/semver" -r "${range}" "${version}" | grep --quiet "^${version}$"
-}
-
 echo
 echo "======================================="
 echo "=============== UPDATE ================"
@@ -101,18 +95,6 @@ rsync --archive \
 echo "Fixing permissions"
 chown -R 1000:1000 "$UMBREL_ROOT"/
 chmod -R 700 "$UMBREL_ROOT"/tor/data/*
-
-# In Umbrel v0.2.11 we whitelisted a tls domain in lnd.conf
-# which requires manually deleting old tls.cert and tls.key files
-# so lnd can re-generate new ones on the next run. We don't delete
-# them in all OTA updates as they'll break existing lndconnect urls
-# https://github.com/getumbrel/umbrel/pull/237
-# This logic can be safely removed from Umbrel v0.3.0+
-if check_semver_range "<0.2.11" "$OLD_UMBREL_VERSION"; then
-  echo "Deleting lnd/tls.cert and lnd/tls.key so they're regenerated..."
-  [[ -f "${UMBREL_ROOT}/lnd/tls.cert" ]] && rm -f "${UMBREL_ROOT}/lnd/tls.cert"
-  [[ -f "${UMBREL_ROOT}/lnd/tls.key" ]] && rm -f "${UMBREL_ROOT}/lnd/tls.key"
-fi
 
 # Start updated containers
 echo "Starting new containers"

--- a/templates/lnd-sample.conf
+++ b/templates/lnd-sample.conf
@@ -6,6 +6,7 @@ maxpendingchannels=3
 minchansize=10000
 accept-keysend=true
 tlsextraip=10.11.1.2
+tlsextradomain=umbrel.local
 tlsautorefresh=1
 
 [Bitcoind]

--- a/templates/lnd-sample.conf
+++ b/templates/lnd-sample.conf
@@ -8,6 +8,7 @@ accept-keysend=true
 tlsextraip=10.11.1.2
 tlsextraip=192.168.0.0/16
 tlsextradomain=umbrel.local
+tlsextradomain=umbrel-testnet.local
 tlsautorefresh=1
 
 [Bitcoind]

--- a/templates/lnd-sample.conf
+++ b/templates/lnd-sample.conf
@@ -6,6 +6,7 @@ maxpendingchannels=3
 minchansize=10000
 accept-keysend=true
 tlsextraip=10.11.1.2
+tlsextraip=192.168.0.0/16
 tlsextradomain=umbrel.local
 tlsautorefresh=1
 

--- a/templates/lnd-sample.conf
+++ b/templates/lnd-sample.conf
@@ -6,7 +6,6 @@ maxpendingchannels=3
 minchansize=10000
 accept-keysend=true
 tlsextraip=10.11.1.2
-tlsextraip=192.168.0.0/16
 tlsextradomain=<hostname>
 tlsautorefresh=1
 

--- a/templates/lnd-sample.conf
+++ b/templates/lnd-sample.conf
@@ -7,8 +7,7 @@ minchansize=10000
 accept-keysend=true
 tlsextraip=10.11.1.2
 tlsextraip=192.168.0.0/16
-tlsextradomain=umbrel.local
-tlsextradomain=umbrel-testnet.local
+tlsextradomain=<hostname>
 tlsautorefresh=1
 
 [Bitcoind]

--- a/templates/torrc-sample
+++ b/templates/torrc-sample
@@ -14,8 +14,8 @@ HiddenServicePort <bitcoin-p2p-port> 10.11.1.1:<bitcoin-p2p-port>
 HiddenServiceDir /var/lib/tor/lnd-rest
 HiddenServicePort 8080 10.11.1.2:8080
 
-# LND RPC Hidden Service
-HiddenServiceDir /var/lib/tor/lnd-rpc
+# LND gRPC Hidden Service
+HiddenServiceDir /var/lib/tor/lnd-grpc
 HiddenServicePort 10009 10.11.1.2:10009
 
 HashedControlPassword <password>

--- a/templates/torrc-sample
+++ b/templates/torrc-sample
@@ -10,4 +10,12 @@ HiddenServicePort 80 10.11.0.2:80
 HiddenServiceDir /var/lib/tor/bitcoin-p2p
 HiddenServicePort <bitcoin-p2p-port> 10.11.1.1:<bitcoin-p2p-port>
 
+# LND REST Hidden Service
+HiddenServiceDir /var/lib/tor/lnd-rest
+HiddenServicePort 8080 10.11.1.2:8080
+
+# LND RPC Hidden Service
+HiddenServiceDir /var/lib/tor/lnd-rpc
+HiddenServicePort 10009 10.11.1.2:10009
+
 HashedControlPassword <password>


### PR DESCRIPTION
Resolves #236.

This PR exposes LND's gRPC and REST over Tor so `umbrel-manager` could use it to encode `lndconnect` URL schemes.

Testing:

**Zap desktop**
[I couldn't get Zap on desktop to work](https://github.com/LN-Zap/zap-desktop/issues/3620#issuecomment-693972786) with gRPC over Tor. It does work on the local network though (by selecting `lndconnect gRPC` from the dropdown).

**Zap iOS**
Doesn't scan the QR for some reason but worked without an issue when copy-pasting the generated URL. 

**Zeus Wallet**
It was able to scan the QR code and connect locally. [It doesn't support Tor yet](https://github.com/ZeusLN/zeus/blob/master/docs/Bounties.md#tor-on-ios).

---
Before merge:
- [x] Revert to official docker images 

Related: 
- https://github.com/getumbrel/umbrel-manager/pull/46
- https://github.com/getumbrel/umbrel-dashboard/pull/218