### PR TITLE
Check for invalid 'RELEASE' values in update script

### DIFF
--- a/events/triggers/update
+++ b/events/triggers/update
@@ -2,4 +2,4 @@
 
 UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/../..)"
 
-"${UMBREL_ROOT}/scripts/update/update" --ota
+"${UMBREL_ROOT}/scripts/update/update" --ota || "${UMBREL_ROOT}/scripts/update/catch"

--- a/scripts/update/catch
+++ b/scripts/update/catch
@@ -31,6 +31,7 @@ RELEASE=$(cat ${STATUS_FILE} | jq -r .updateTo)
 
 NEW_DESCRIPTION="Update failed at ${PROGRESS}% during '${STATE}' for release version '${RELEASE}'"
 
+sleep 5
 cat <<EOF > "${STATUS_FILE}"
 {"state": "failed", "progress": 100, "description": "$NEW_DESCRIPTION", "updateTo": "$RELEASE"}
 EOF

--- a/scripts/update/catch
+++ b/scripts/update/catch
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo
+echo "======================================="
+echo "=============== UPDATE ================"
+echo "======================================="
+echo "======== Stage: Catching error ========"
+echo "======================================="
+echo
+
+
+check_dependencies () {
+  for cmd in "$@"; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      echo "This script requires \"${cmd}\" to be installed"
+      exit 1
+    fi
+  done
+}
+
+check_dependencies jq
+
+UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/../..)"
+STATUS_FILE="$UMBREL_ROOT"/statuses/update-status.json
+
+STATE=$(cat ${STATUS_FILE} | jq -r .state)
+PROGRESS=$(cat ${STATUS_FILE} | jq -r .progress)
+RELEASE=$(cat ${STATUS_FILE} | jq -r .updateTo)
+
+NEW_DESCRIPTION="Update failed at ${PROGRESS}% during '${STATE}' for release version '${RELEASE}'"
+
+cat <<EOF > "${STATUS_FILE}"
+{"state": "failed", "progress": 100, "description": "$NEW_DESCRIPTION", "updateTo": "$RELEASE"}
+EOF
+
+
+# Delete cloned repo
+echo "Deleting cloned repository"
+[[ -d "$UMBREL_ROOT"/.umbrel-"$RELEASE" ]] && rm -rf "$UMBREL_ROOT"/.umbrel-"$RELEASE"
+
+echo "Removing lock"
+rm -f "$UMBREL_ROOT"/statuses/update-in-progress
+
+exit 0

--- a/scripts/update/update
+++ b/scripts/update/update
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 if [[ $UID != 0 ]]; then
     echo "Update script must be run as root"
     exit 1

--- a/scripts/update/update
+++ b/scripts/update/update
@@ -17,12 +17,7 @@ check_dependencies () {
 }
 
 curl_check () {
-  status=$(curl -L --head --silent ${1} | grep 'HTTP.*200')
-  if echo $status | grep -q 200; then
-    return 0
-  else
-    return 1
-  fi
+  curl -LIs -o /dev/null -w "%{http_code}" "$1" | grep -q 200
 }
 
 check_dependencies jq curl rsync

--- a/scripts/update/update
+++ b/scripts/update/update
@@ -14,6 +14,15 @@ check_dependencies () {
   done
 }
 
+curl_check () {
+  status=$(curl -L --head --silent ${1} | grep 'HTTP.*200')
+  if echo $status | grep -q 200; then
+    return 0
+  else
+    return 1
+  fi
+}
+
 check_dependencies jq curl rsync
 
 UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/../..)"
@@ -59,6 +68,11 @@ elif [[ "${update_type}" == "path" ]]; then
   RELEASE=$(cat "$update_path"/info.json | jq .version -r)
 fi
 
+if [[ -z "${RELEASE}" ]]; then
+  echo "Empty release version found in update-status.json file, aborting..."
+  exit 1
+fi
+
 echo
 echo "======================================="
 echo "=============== UPDATE ================"
@@ -71,6 +85,14 @@ echo
 if [[ -f "$UMBREL_ROOT/statuses/update-in-progress" ]]; then
     echo "An update is already in progress. Exiting now."
     exit 2
+fi
+
+RELEASE_URL="https://github.com/getumbrel/umbrel/archive/$RELEASE.tar.gz"
+
+# Check that release url is valid
+if ! curl_check "${RELEASE_URL}"; then
+  echo "Could not reach any release files hosted at ${RELEASE_URL}"
+  exit 1
 fi
 
 echo "Creating lock"
@@ -90,7 +112,7 @@ if [[ "${update_type}" == "ota" ]]; then
   echo "Downloading Umbrel ${RELEASE}"
   mkdir -p "${UMBREL_ROOT}/.umbrel-${RELEASE}"
   cd "${UMBREL_ROOT}/.umbrel-${RELEASE}"
-  curl -L "https://github.com/getumbrel/umbrel/archive/$RELEASE.tar.gz" | tar -xz --strip-components=1
+  curl -L "${RELEASE_URL}" | tar -xz --strip-components=1
 fi
 
 # Copy over new release from path

--- a/scripts/update/update
+++ b/scripts/update/update
@@ -91,12 +91,6 @@ fi
 
 RELEASE_URL="https://github.com/getumbrel/umbrel/archive/$RELEASE.tar.gz"
 
-# Check that release url is valid
-if ! curl_check "${RELEASE_URL}"; then
-  echo "Could not reach any release files hosted at ${RELEASE_URL}"
-  exit 1
-fi
-
 echo "Creating lock"
 touch "$UMBREL_ROOT"/statuses/update-in-progress
 
@@ -111,6 +105,13 @@ EOF
 
 # Download new release
 if [[ "${update_type}" == "ota" ]]; then
+  # Check that release url is valid
+  if ! curl_check "${RELEASE_URL}"; then
+    echo "Could not reach any release files hosted at ${RELEASE_URL}"
+    exit 1
+  fi
+
+  # Download update is url is valid
   echo "Downloading Umbrel ${RELEASE}"
   mkdir -p "${UMBREL_ROOT}/.umbrel-${RELEASE}"
   cd "${UMBREL_ROOT}/.umbrel-${RELEASE}"

--- a/scripts/update/update
+++ b/scripts/update/update
@@ -16,10 +16,6 @@ check_dependencies () {
   done
 }
 
-curl_check () {
-  curl -LIs -o /dev/null -w "%{http_code}" "$1" | grep -q 200
-}
-
 check_dependencies jq curl rsync
 
 UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/../..)"
@@ -100,17 +96,14 @@ EOF
 
 # Download new release
 if [[ "${update_type}" == "ota" ]]; then
-  # Check that release url is valid
-  if ! curl_check "${RELEASE_URL}"; then
-    echo "Could not reach any release files hosted at ${RELEASE_URL}"
-    exit 1
-  fi
-
-  # Download update is url is valid
+  # Download update, exit if url is invalid
   echo "Downloading Umbrel ${RELEASE}"
   mkdir -p "${UMBREL_ROOT}/.umbrel-${RELEASE}"
   cd "${UMBREL_ROOT}/.umbrel-${RELEASE}"
-  curl -L "${RELEASE_URL}" | tar -xz --strip-components=1
+  if ! curl -L "${RELEASE_URL}" | tar -xz --strip-components=1; then
+    echo "Could not reach any release files hosted at ${RELEASE_URL}"
+    exit 1
+  fi
 fi
 
 # Copy over new release from path


### PR DESCRIPTION
This adds two checks for invalid `RELEASE` values that can potentially come from the `update-status.json` file:

- check that `RELEASE` is not an empty value. This can happen if for example the update script was run when 
the `update-status.json` file is in its default success state and the `"updateTo"` value is an empty string

- check that `RELEASE` points to a valid URL to avoid any further error from attempting to do operations on an invalid curl call

 ---

### Error details
These changes would help the `update` script to not change the `update-status.json` to an invalid `Downloading...` state if [`Ln106`](https://github.com/getumbrel/umbrel/blob/836026624b843114d180e9860b79b7f217ed7915/scripts/update/update#L106) runs and the script fails, which then blocks the dashboard from loading permanently (see issue #205).

#### on unexpected `update` script run

- the `update` script errors as follows

    ![image](https://user-images.githubusercontent.com/17693119/93686260-18165d00-fa83-11ea-8f62-d5095f4e6617.png)

- the update status file changes from 'success' to 'installing'

    ![image](https://user-images.githubusercontent.com/17693119/93686327-83602f00-fa83-11ea-8023-6e6a26b44d56.png)

 - the dashboard becomes inaccessible and shows this Downloading message incorrectly instead

    ![image](https://user-images.githubusercontent.com/17693119/93686671-c6bb9d00-fa85-11ea-93b7-dfaf5df58b6c.png)
