### PR TITLE
Add a '--all' flag to stop script for background processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ To stop Umbrel, run:
 sudo ./scripts/stop
 ```
 
+To stop background processes as well, use the `--all` flag:
+
+```bash
+sudo ./scripts/stop --all
+```
+
 ## 🎹 Services orchestrated
 
 - [`Umbrel Dashboard`](https://github.com/getumbrel/umbrel-dashboard)

--- a/scripts/start
+++ b/scripts/start
@@ -92,8 +92,27 @@ if [[ ! -z "${hidden_service_url:-}" ]]; then
     echo "  http://${hidden_service_url}"
 fi
 
+
 # Store Process Group ID for killing all child processes later
-PGID_FILE="${UMBREL_ROOT}/start_pgid.log"
 PGID=$(ps -o pgid= $$ | grep -o '[0-9]*')
-echo $PGID > ${PGID_FILE}
-echo "Start script process group ID: ${PGID}"
+PGID_FILE="${UMBREL_ROOT}/start_pgid.log"
+
+pgid_processes () {
+  ps -e -o pgid,pid | awk -v p=$1 '$1 == p {print $2}'
+}
+
+save_new_pgid () {
+  echo $PGID > ${PGID_FILE}
+  echo "Start script process group ID: ${PGID}"
+}
+
+if [[ -e "${PGID_FILE}" ]]; then
+  EXISTING_PGID=$(cat ${PGID_FILE} | head -n 1)
+  if [[ -z "$(pgid_processes ${EXISTING_PGID})" ]]; then
+    save_new_pgid
+  else
+    echo "Existing PGID with running processes found"
+  fi
+else
+  save_new_pgid
+fi

--- a/scripts/start
+++ b/scripts/start
@@ -91,3 +91,9 @@ echo "  http://${DEVICE_IP}"
 if [[ ! -z "${hidden_service_url:-}" ]]; then
     echo "  http://${hidden_service_url}"
 fi
+
+# Store Process Group ID for killing all child processes later
+PGID_FILE="${UMBREL_ROOT}/start_pgid.log"
+PGID=$(ps -o pgid= $$ | grep -o '[0-9]*')
+echo $PGID > ${PGID_FILE}
+echo "Start script process group ID: ${PGID}"

--- a/scripts/stop
+++ b/scripts/stop
@@ -27,3 +27,17 @@ export COMPOSE_HTTP_TIMEOUT=240
 echo "Stopping Docker services..."
 echo
 docker-compose down
+
+stop_all () {
+  PGID_FILE="${UMBREL_ROOT}/start_pgid.log"
+  PGID=$(cat ${PGID_FILE} | head -n 1)
+  kill -9 -${PGID}
+  rm ${PGID_FILE}
+}
+
+if [[ "${1:-}" == "--all" ]]; then
+  echo
+  echo "Stopping background processes..."
+  stop_all
+  echo "Stopped"
+fi


### PR DESCRIPTION
### Description

This PR adds a `--all` flag to the `scripts/stop` script which looks for the background scripts that currently get kicked off in Umbrel and kills them with a `-9` sigterm.

This option could be useful when doing dev and debug work on a manual install and shouldn't affect the other scripts that use the `stop` script internally.