### PR TITLE
Umbrel v0.2.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Make sure your User ID is `1000` (verify it by running `id -u`) and ensure that 
 > Run this in an empty directory where you want to install Umbrel. If using an external storage such as an SSD or HDD, run this inside an empty directory on that drive.
 
 ```bash
-curl -L https://github.com/getumbrel/umbrel/archive/v0.2.10.tar.gz | tar -xz --strip-components=1
+curl -L https://github.com/getumbrel/umbrel/archive/v0.2.11.tar.gz | tar -xz --strip-components=1
 ```
 
 ### Step 2. Run Umbrel

--- a/info.json
+++ b/info.json
@@ -2,5 +2,5 @@
     "version": "0.2.11",
     "name": "Umbrel v0.2.11",
     "requires": ">=0.2.1",
-    "notes": "Knock knock! Who’s there? Wallets! Wallets who? Electrum, Blockstream Green, BlueWallet, Phoenix, Sparrow, Wasabi, Zap, and Zeus! You can now connect your favorite wallets directly to your Umbrel. Due to performance constraints of running an Electrum server, this update isn’t compatible with devices with less than 2GB RAM, such as the Raspberry Pi 3. We strongly recommend upgrading to a device with more RAM, such as the Raspberry Pi 4 with 4GB or 8GB RAM. Chat with us on telegram for any questions: https://t.me/getumbrel"
+    "notes": "Knock knock! Who’s there? Wallets! Wallets who? Electrum, Blockstream Green, BlueWallet, Phoenix, Sparrow, Wasabi, Zap, and Zeus! You can now connect your favorite wallets directly to your Umbrel. It may take 4-8 hours for the Electrum server to be available after the update. Due to performance constraints of running an Electrum server, this update isn’t compatible with devices with less than 2GB RAM, such as the Raspberry Pi 3. We strongly recommend upgrading to a device with more RAM, such as the Raspberry Pi 4 with 4GB or 8GB RAM. Chat with us on telegram for any questions: https://t.me/getumbrel"
 }

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
-    "version": "0.2.10",
-    "name": "Umbrel v0.2.10",
+    "version": "0.2.11",
+    "name": "Umbrel v0.2.11",
     "requires": ">=0.2.1",
-    "notes": "This update brings some minor bugfixes and adds monitoring functionality to ensure your external storage device is running reliably."
+    "notes": "Knock knock! Who’s there? Wallets! Wallets who? Electrum, Blockstream Green, BlueWallet, Phoenix, Sparrow, Wasabi, Zap, and Zeus! You can now connect your favorite wallets directly to your Umbrel. Due to performance constraints of running an Electrum server, this update isn’t compatible with devices with less than 2GB RAM, such as Raspberry Pi 3 and we strongly recommend upgrading to a device with a larger RAM size, such as the Raspberry Pi 4 with 4GB or 8GB RAM. Chat with us on telegram for any questions: https://t.me/getumbrel"
 }

--- a/info.json
+++ b/info.json
@@ -2,5 +2,5 @@
     "version": "0.2.11",
     "name": "Umbrel v0.2.11",
     "requires": ">=0.2.1",
-    "notes": "Knock knock! Who’s there? Wallets! Wallets who? Electrum, Blockstream Green, BlueWallet, Phoenix, Sparrow, Wasabi, Zap, and Zeus! You can now connect your favorite wallets directly to your Umbrel. Due to performance constraints of running an Electrum server, this update isn’t compatible with devices with less than 2GB RAM, such as Raspberry Pi 3 and we strongly recommend upgrading to a device with a larger RAM size, such as the Raspberry Pi 4 with 4GB or 8GB RAM. Chat with us on telegram for any questions: https://t.me/getumbrel"
+    "notes": "Knock knock! Who’s there? Wallets! Wallets who? Electrum, Blockstream Green, BlueWallet, Phoenix, Sparrow, Wasabi, Zap, and Zeus! You can now connect your favorite wallets directly to your Umbrel. Due to performance constraints of running an Electrum server, this update isn’t compatible with devices with less than 2GB RAM, such as the Raspberry Pi 3. We strongly recommend upgrading to a device with more RAM, such as the Raspberry Pi 4 with 4GB or 8GB RAM. Chat with us on telegram for any questions: https://t.me/getumbrel"
 }


### PR DESCRIPTION
This release of Umbrel adds an Electrum server along with lndconnect to expand wallet compatibility. You can now connect Electrum, Blockstream Green, BlueWallet, Phoenix, Sparrow, Wasabi, Zap, and Zeus directly to your Umbrel.

Due to the performance constraints of running an Electrum server, this update isn’t compatible with devices with less than 2GB RAM, such as the Raspberry Pi 3. We strongly recommend upgrading to a device with more RAM, such as the Raspberry Pi 4 with 4GB or 8GB RAM.

Chat with us on telegram for any questions: https://t.me/getumbrel