### PR TITLE
Update documentation - Raspberry PI 3 should no longer be supported, amend to RPI4 or 64-bit linux system

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ We run it on Raspbery Pis (ARMv8) as a part of [Umbrel OS](https://github.com/ge
 
 If you're looking to run Umbrel on:
 
-- A Raspberry Pi 3 or 4 (recommended) - [Download Umbrel OS](https://github.com/getumbrel/umbrel-os)
+- A Raspberry Pi 4 (recommended) - [Download Umbrel OS](https://github.com/getumbrel/umbrel-os)
+- 1 TB of disk space (for bitcoin blockchain and electrum files)
 - Anything else (**not recommended** as it's experimental at the moment) - [Install Umbrel](#-installation)
 
 ## 🛠 Installation

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ We run it on Raspbery Pis (ARMv8) as a part of [Umbrel OS](https://github.com/ge
 
 If you're looking to run Umbrel on:
 
-- A Raspberry Pi 4 (recommended) - [Download Umbrel OS](https://github.com/getumbrel/umbrel-os)
+- A Raspberry Pi 4 with at least 2 Gb RAM - [Download Umbrel OS](https://github.com/getumbrel/umbrel-os) or a 64-bit Linux based system with at least 2 Gb of RAM
 - 1 TB of disk space (for bitcoin blockchain and electrum files)
 - Anything else (**not recommended** as it's experimental at the moment) - [Install Umbrel](#-installation)
 


### PR DESCRIPTION
Because Electrum is a new requirement and because of the RAM requirements. remove references to `raspberry pi 3`

Also add disk space requirements too.