### PR TITLE
Redirect OTA update's logs to a designated log file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ db/*
 electrs/*
 events/signals/*
 lnd/*
+logs/*
 statuses/*
 tor/*
 
@@ -33,5 +34,6 @@ tor/*
 !db/.gitkeep
 !events/signals/.gitkeep
 !lnd/.gitkeep
+!logs/.gitkeep
 !tor/data/.gitkeep
 !tor/run/.gitkeep

--- a/scripts/start
+++ b/scripts/start
@@ -68,6 +68,10 @@ export COMPOSE_HTTP_TIMEOUT=240
 
 cd "$UMBREL_ROOT"
 
+echo "Rotating log files..."
+echo
+rm -rf logs/*
+
 echo "Starting karen..."
 echo
 ./karen &

--- a/scripts/start
+++ b/scripts/start
@@ -68,10 +68,6 @@ export COMPOSE_HTTP_TIMEOUT=240
 
 cd "$UMBREL_ROOT"
 
-echo "Rotating log files..."
-echo
-rm -rf logs/*
-
 echo "Starting karen..."
 echo
 ./karen &

--- a/scripts/update/update
+++ b/scripts/update/update
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/../..)"
+
+exec &>> "${UMBREL_ROOT}/logs/update.log"
 
 if [[ $UID != 0 ]]; then
     echo "Update script must be run as root"
@@ -15,8 +18,6 @@ check_dependencies () {
 }
 
 check_dependencies jq curl rsync
-
-UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/../..)"
 
 update_type=""
 if [[ "${1}" == "--ota" ]]; then


### PR DESCRIPTION
This seems to fix https://github.com/getumbrel/umbrel/issues/205 (please don't ask me how or why cuz I have no clue lol).

Also, since we're making changes to the parent update script, it wouldn't be executed on the next immediate OTA update, but on all the updates post it. It means that users will still encounter issue #205 one more time on the next update (the last time, I hope).

The new `logs/` directory can further be used to store logs from other background processes and docker containers going forward (#206).