### PR TITLE
Prevent unresolved update status on a failed OTA update

### DIFF
--- a/scripts/update/update
+++ b/scripts/update/update
@@ -128,12 +128,12 @@ rm -f "$UMBREL_ROOT"/statuses/update-in-progress
 # Make sure the update-status file isn't stuck in an 
 # unresolved state (i.e anything except "success" or "failed")
 
-update_state=$(cat "statuses/update-status.json" | jq .state -r)
+update_state=$(cat "${UMBREL_ROOT}/statuses/update-status.json" | jq .state -r)
 
 if [[ "${update_state}" != "success" ]] && [[ "${update_state}" != "failed" ]]; then
-    cat <<EOF > "/statuses/update-status.json"
+    cat <<EOF > "${UMBREL_ROOT}/statuses/update-status.json"
 {"state": "failed", "progress": 0, "description": "An unexpected error occured", "updateTo": ""}
-EOF 
+EOF
 fi
 
 exit 0

--- a/scripts/update/update
+++ b/scripts/update/update
@@ -125,4 +125,15 @@ echo "Deleting cloned repository"
 echo "Removing lock"
 rm -f "$UMBREL_ROOT"/statuses/update-in-progress
 
+# Make sure the update-status file isn't stuck in an 
+# unresolved state (i.e anything except "success" or "failed")
+
+update_state=$(cat "statuses/update-status.json" | jq .state -r)
+
+if [[ "${update_state}" != "success" ]] && [[ "${update_state}" != "failed" ]]; then
+    cat <<EOF > "/statuses/update-status.json"
+{"state": "failed", "progress": 0, "description": "An unexpected error occured", "updateTo": ""}
+EOF 
+fi
+
 exit 0

--- a/scripts/update/update
+++ b/scripts/update/update
@@ -131,6 +131,7 @@ rm -f "$UMBREL_ROOT"/statuses/update-in-progress
 update_state=$(cat "${UMBREL_ROOT}/statuses/update-status.json" | jq .state -r)
 
 if [[ "${update_state}" != "success" ]] && [[ "${update_state}" != "failed" ]]; then
+    sleep 8
     cat <<EOF > "${UMBREL_ROOT}/statuses/update-status.json"
 {"state": "failed", "progress": 0, "description": "An unexpected error occured", "updateTo": ""}
 EOF

--- a/scripts/update/update
+++ b/scripts/update/update
@@ -133,7 +133,7 @@ update_state=$(cat "${UMBREL_ROOT}/statuses/update-status.json" | jq .state -r)
 if [[ "${update_state}" != "success" ]] && [[ "${update_state}" != "failed" ]]; then
     sleep 8
     cat <<EOF > "${UMBREL_ROOT}/statuses/update-status.json"
-{"state": "failed", "progress": 0, "description": "An unexpected error occured", "updateTo": ""}
+{"state": "failed", "progress": 100, "description": "An unexpected error occured", "updateTo": ""}
 EOF
 fi
 

--- a/scripts/update/update
+++ b/scripts/update/update
@@ -131,6 +131,7 @@ rm -f "$UMBREL_ROOT"/statuses/update-in-progress
 update_state=$(cat "${UMBREL_ROOT}/statuses/update-status.json" | jq .state -r)
 
 if [[ "${update_state}" != "success" ]] && [[ "${update_state}" != "failed" ]]; then
+    # Sleep for a few seconds to make sure the user is on the update view
     sleep 8
     cat <<EOF > "${UMBREL_ROOT}/statuses/update-status.json"
 {"state": "failed", "progress": 100, "description": "An unexpected error occured", "updateTo": ""}


### PR DESCRIPTION
This PR helps prevents situations like #205 in the future, where the cause of the error is unknown and the update-status.json is forever stuck in an unresolved state (i.e. anything except `success` or `failed`).