### PR TITLE
Fix missing file descriptors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ db/*
 electrs/*
 events/signals/*
 lnd/*
+logs/*
 statuses/*
 tor/*
 
@@ -33,5 +34,6 @@ tor/*
 !db/.gitkeep
 !events/signals/.gitkeep
 !lnd/.gitkeep
+!logs/.gitkeep
 !tor/data/.gitkeep
 !tor/run/.gitkeep

--- a/scripts/start
+++ b/scripts/start
@@ -72,15 +72,15 @@ cd "$UMBREL_ROOT"
 
 echo "Starting karen..."
 echo
-./karen &> "${UMBREL_LOGS}/karen" &
+./karen &>> "${UMBREL_LOGS}/karen" &
 
 echo "Starting backup monitor..."
 echo
-./scripts/backup/monitor &> "${UMBREL_LOGS}/backup-monitor" &
+./scripts/backup/monitor &>> "${UMBREL_LOGS}/backup-monitor" &
 
 echo "Starting decoy backup trigger..."
 echo
-./scripts/backup/decoy-trigger &> "${UMBREL_LOGS}/backup-decoy-trigger" &
+./scripts/backup/decoy-trigger &>> "${UMBREL_LOGS}/backup-decoy-trigger" &
 
 echo
 echo "Starting Docker services..."

--- a/scripts/start
+++ b/scripts/start
@@ -29,6 +29,8 @@ check_dependencies fswatch
 check_dependencies rsync jq curl
 
 UMBREL_ROOT="$(dirname $(readlink -f "${BASH_SOURCE[0]}"))/.."
+UMBREL_LOGS="${UMBREL_ROOT}/logs"
+mkdir -p "${UMBREL_LOGS}"
 
 if [[ ! -d "$UMBREL_ROOT" ]]; then
   echo "Root dir does not exist '$UMBREL_ROOT'"
@@ -70,15 +72,15 @@ cd "$UMBREL_ROOT"
 
 echo "Starting karen..."
 echo
-./karen &
+./karen &> "${UMBREL_LOGS}/karen" &
 
 echo "Starting backup monitor..."
 echo
-./scripts/backup/monitor &
+./scripts/backup/monitor &> "${UMBREL_LOGS}/backup-monitor" &
 
 echo "Starting decoy backup trigger..."
 echo
-./scripts/backup/decoy-trigger &
+./scripts/backup/decoy-trigger &> "${UMBREL_LOGS}/backup-decoy-trigger" &
 
 echo
 echo "Starting Docker services..."

--- a/scripts/start
+++ b/scripts/start
@@ -72,15 +72,15 @@ cd "$UMBREL_ROOT"
 
 echo "Starting karen..."
 echo
-./karen &>> "${UMBREL_LOGS}/karen" &
+./karen &>> "${UMBREL_LOGS}/karen.log" &
 
 echo "Starting backup monitor..."
 echo
-./scripts/backup/monitor &>> "${UMBREL_LOGS}/backup-monitor" &
+./scripts/backup/monitor &>> "${UMBREL_LOGS}/backup-monitor.log" &
 
 echo "Starting decoy backup trigger..."
 echo
-./scripts/backup/decoy-trigger &>> "${UMBREL_LOGS}/backup-decoy-trigger" &
+./scripts/backup/decoy-trigger &>> "${UMBREL_LOGS}/backup-decoy-trigger.log" &
 
 echo
 echo "Starting Docker services..."

--- a/scripts/start
+++ b/scripts/start
@@ -30,7 +30,6 @@ check_dependencies rsync jq curl
 
 UMBREL_ROOT="$(dirname $(readlink -f "${BASH_SOURCE[0]}"))/.."
 UMBREL_LOGS="${UMBREL_ROOT}/logs"
-mkdir -p "${UMBREL_LOGS}"
 
 if [[ ! -d "$UMBREL_ROOT" ]]; then
   echo "Root dir does not exist '$UMBREL_ROOT'"

--- a/scripts/update/.updateignore
+++ b/scripts/update/.updateignore
@@ -6,3 +6,4 @@ statuses
 tor/*
 electrs/*
 events/signals
+logs


### PR DESCRIPTION
Resolves #205 
Replaces #262 

See https://github.com/getumbrel/umbrel/pull/262#issuecomment-703765275 for reasoning:

>>This seems to fix #205 (please don't ask me how or why cuz I have no clue lol).
>
>Lol. Pretty cryptic but what's happening is when people manually run the `start` script and then close the shell session (or exit SSH) the file descriptors (stdout/stderr) no longer exist. So any scripts that get fired as a sub process of the start script (basically any event triggered by karen) that tries to write to stdout or stderr fails.
>
>This is why OTA update's are failing on most custom Umbrel installs. Users are probably running the start script and logging out of SSH. As soon as the OTA update script gets triggered and needs stdout/stderr it fails. On Umbrel OS we launch the start script via systemd and [pipe stdout/stderr to syslog](https://github.com/getumbrel/umbrel/blob/771affe0e595ff1b46f58898562de8f758fbd1b0/scripts/umbrel-os/services/umbrel-startup.service#L21-L22) so the file descriptors always exist.
>
>If users with custom installs launch the start script with `sudo ./start &> output.log`, (pipe stdout and stderr to a file called output.log) everything will work with the current setup.
>
>While the solution in this PR does allow OTA updates to work without issue, we should probably handle this better directly in the start script. It could also cause other scripts to fail. I'd suggest explicitly piping the output of all child processes of the start script to their own log file. I've submitted a PR here: https://github.com/getumbrel/umbrel/pull/269