### PR TITLE
Display 'umbrel.local' instead of 'umbrel.local.local'

### DIFF
--- a/scripts/start
+++ b/scripts/start
@@ -88,7 +88,7 @@ docker-compose up --detach --build --remove-orphans
 echo
 
 echo "Umbrel is now accessible at"
-echo "  http://${DEVICE_HOSTNAME}.local"
+echo "  http://${DEVICE_HOSTNAME}"
 echo "  http://${DEVICE_IP}"
 if [[ ! -z "${hidden_service_url:-}" ]]; then
     echo "  http://${hidden_service_url}"


### PR DESCRIPTION
Fixes #275 

```shell
DEVICE_HOSTNAME="$(hostname)"
export DEVICE_HOSTNAME="${DEVICE_HOSTNAME}.local"

# Unnecessary ".local" as DEVICE_HOSTNAME has already been exported as "${DEVICE_HOSTNAME}.local"
echo "  http://${DEVICE_HOSTNAME}.local"
```