### PR TITLE
Bump LND version to 0.11.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
                         ipv4_address: 10.11.1.1
         lnd:
                 container_name: lnd
-                image: lncm/lnd:v0.11.0
+                image: lncm/lnd:v0.11.1
                 logging: *default-logging
                 depends_on: [ tor, manager ]
                 volumes:


### PR DESCRIPTION
Upgrade LND to 0.11.1

## Changelog
- This is a fix for [CVE-2020-26896](http://cve.circl.lu/cve/CVE-2020-26896)
- addressed the issue where build info is not showing (https://github.com/lncm/docker-lnd/issues/47)
- Other `v0.11.1` upstream changes