### PR TITLE
Add docker-compose.override.ym to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 .ssh
 .viminfo
 
+# umbrel-dev
+docker-compose.override.yml
+
 # Files and data directories created by services
 # that we shouldn't accidently commit
 


### PR DESCRIPTION
This .gitignores `docker-compose.override.yml` which umbrel-dev adds to override some compose values.