### PR TITLE
Allow WebSocket connections to be proxied to dashboard container

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -17,9 +17,11 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
     }
-    
+
     location / {
         proxy_pass http://10.11.0.3:3004/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
     }
- 
 }


### PR DESCRIPTION
This allows WebSocket connections to be proxied through NGINX to the dashboard container which is needed for HMR during development.