### PR TITLE
Add txindex=1 to bitcoin.conf

### DIFF
--- a/templates/bitcoin-sample.conf
+++ b/templates/bitcoin-sample.conf
@@ -21,3 +21,6 @@ maxuploadtarget=1000
 # zmq
 zmqpubrawblock=tcp://0.0.0.0:28332
 zmqpubrawtx=tcp://0.0.0.0:28333
+
+# Indexes
+txindex=1


### PR DESCRIPTION
Adding this in advance for upcoming wider app support.

Many apps using Bitcoin Core RPC will expect txindex to be enabled to query arbitrary transactions. It probably makes more sense to enable this by default.

Thanks to a recent rewrite of Bitcoin Core's indexer we can just enable this in the config and Core will build the index in the background for existing users without any interruptions.