### PR TITLE
Add blockfilterindex=1 to bitcoin.conf

### DIFF
--- a/templates/bitcoin-sample.conf
+++ b/templates/bitcoin-sample.conf
@@ -24,3 +24,4 @@ zmqpubrawtx=tcp://0.0.0.0:28333
 
 # Indexes
 txindex=1
+blockfilterindex=1


### PR DESCRIPTION
This enables the creation of BIP158 block filters for the entire blockchain. Filters will be created in the background and currently use about 4 GB.

This currently allows significantly faster rescans via RPC.

In the future the filters can be served over the P2P port via `peerblockfilters` to serve BIP157 (Neutrino) SPV nodes.