### PR TITLE
Umbrel v0.2.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Make sure your User ID is `1000` (verify it by running `id -u`) and ensure that 
 > Run this in an empty directory where you want to install Umbrel. If using an external storage such as an SSD or HDD, run this inside an empty directory on that drive.
 
 ```bash
-curl -L https://github.com/getumbrel/umbrel/archive/v0.2.13.tar.gz | tar -xz --strip-components=1
+curl -L https://github.com/getumbrel/umbrel/archive/v0.2.14.tar.gz | tar -xz --strip-components=1
 ```
 
 ### Step 2. Run Umbrel

--- a/info.json
+++ b/info.json
@@ -2,5 +2,5 @@
     "version": "0.2.14",
     "name": "Umbrel v0.2.14",
     "requires": ">=0.2.1",
-    "notes": "This Umbrel release brings LND v0.11.1, native segwit addresses for on-chain deposits and some tiny but mighty changes that will silently prepare your Umbrel for some big upcoming updates."
+    "notes": "This Umbrel release brings LND v0.11.1, native segwit addresses for on-chain deposits and a few tiny but mighty changes that will silently prepare your Umbrel for some big upcoming updates."
 }

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
-    "version": "0.2.13",
-    "name": "Umbrel v0.2.13",
+    "version": "0.2.14",
+    "name": "Umbrel v0.2.14",
     "requires": ">=0.2.1",
-    "notes": "This update fixes an important bug with the background processes. If you're unable to start this update or it gets stuck at \"Starting Update...\" please follow the instructions here: https://gist.github.com/lukechilds/8dc223885f47579a77407ba7f5beaaec"
+    "notes": "This Umbrel release brings LND v0.11.1, native segwit addresses for on-chain deposits and some tiny but mighty changes that will silently prepare your Umbrel for some big upcoming updates."
 }


### PR DESCRIPTION
This Umbrel release brings LND v0.11.1, native segwit addresses for on-chain deposits and a few tiny but mighty changes that will silently prepare your Umbrel for some big upcoming updates.

Diff: https://github.com/getumbrel/umbrel/compare/v0.2.13...v0.2.14