### PR TITLE
Fix lnd refreshing TLS certificate at each restart

### DIFF
--- a/templates/lnd-sample.conf
+++ b/templates/lnd-sample.conf
@@ -8,6 +8,7 @@ accept-keysend=true
 tlsextraip=10.11.1.2
 tlsextradomain=<hostname>
 tlsautorefresh=1
+tlsdisableautofill=1
 
 [Bitcoind]
 bitcoind.rpchost=10.11.1.1


### PR DESCRIPTION
This PR adds a setting to not include the container hostname (its Docker container ID) in the certificate. Thus, lnd won't detect changes at each restart and won't create a new certificate, which was leading to invalid connection on Lightning wallets like Zap after a restart.