### PR TITLE
Update to getumbrel/electrs:v0.8.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -183,7 +183,7 @@ services:
                     ipv4_address: 10.11.3.0
         electrs:
               container_name: electrs
-              image: getumbrel/electrs:v0.8.5
+              image: getumbrel/electrs:v0.8.6
               logging: *default-logging
               depends_on: [ bitcoin ]
               volumes:


### PR DESCRIPTION
This release of electrs fixes a vulnerability: https://github.com/romanz/electrs/pull/334

The vulnerability was in Prometheus and we don't expose the Prometheus port so it's unlikely to affect us.

This release of electrs also resolves issues when connecting from Electrum 4.0.5 https://github.com/spesmilo/electrum/issues/6772#issuecomment-733540415