### PR TITLE
support custom DNS resolvers

### DIFF
--- a/scripts/configure
+++ b/scripts/configure
@@ -193,8 +193,27 @@ sed -i "s#DOCKER_BINARY=<path>#DOCKER_BINARY=$DOCKER_BINARY#g;" "$ENV_FILE"
 sed -i "/server_banner/s/<version>/$UMBREL_VERSION/g;" "$ELECTRS_CONF_FILE"
 
 # Add hostname to lnd.conf for TLS certificate
+RESOLV_CONF="/etc/resolv.conf"
+if [[ -f "$RESOLV_CONF" ]]; then
+  # Try to parse dns suffix from resolv.conf
+  DEVICE_DNS_SUFFIX=$(sed -n 's/search \(.\+\)/\1/p' $RESOLV_CONF)
+  if [ -z "$DEVICE_DNS_SUFFIX" ]; then
+    DEVICE_DNS_SUFFIX=$(sed -n 's/domain \(.\+\)/\1/p' $RESOLV_CONF)
+  fi
+  if [ -n "$DEVICE_DNS_SUFFIX" ]; then
+    DEVICE_DNS_SUFFIX=".${DEVICE_DNS_SUFFIX}"
+  fi
+fi
+# Fall back to .local if we don't detect another dns suffix above.
+# This requires a mDNS resolver on machines that want to connect
+# to umbrel and a mDNS daemon (usually avahi) on the machine that
+# runs umbrel in order to annouce the local IP address in the network.
+DEVICE_DNS_SUFFIX="${DEVICE_DNS_SUFFIX:-.local}"
 DEVICE_HOSTNAME="$(hostname)"
-sed -i "s/tlsextradomain=<hostname>/tlsextradomain=$DEVICE_HOSTNAME.local/g;" "$LND_CONF_FILE"
+sed -i "s/tlsextradomain=<hostname>/tlsextradomain=${DEVICE_HOSTNAME}${DEVICE_DNS_SUFFIX}/g;" "$LND_CONF_FILE"
+
+# Store configured DEVICE_DNS_SUFFIX for later use in ./start script.
+sed -i "s/DEVICE_DNS_SUFFIX=.*/DEVICE_DNS_SUFFIX=${DEVICE_DNS_SUFFIX}/g;" "$ENV_FILE"
 
 # If node is already synced, do not reset to neutrino
 if [[ -f "${STATUS_DIR}/node-status-bitcoind-ready" ]]; then

--- a/scripts/start
+++ b/scripts/start
@@ -30,6 +30,7 @@ check_dependencies rsync jq curl
 
 UMBREL_ROOT="$(dirname $(readlink -f "${BASH_SOURCE[0]}"))/.."
 UMBREL_LOGS="${UMBREL_ROOT}/logs"
+ENV_FILE="${UMBREL_ROOT}/.env"
 
 if [[ ! -d "$UMBREL_ROOT" ]]; then
   echo "Root dir does not exist '$UMBREL_ROOT'"
@@ -51,16 +52,19 @@ echo
 echo "Setting environment variables..."
 echo
 
+# Source persisted environment variables.
+. $ENV_FILE
+
 # Whitelist device IP, hostname and hidden service for CORS
 DEVICE_IP="$(ip -o route get to 8.8.8.8 | sed -n 's/.*src \([0-9.]\+\).*/\1/p')"
 DEVICE_HOSTNAME="$(hostname)"
-DEVICE_HOSTS="http://${DEVICE_IP},http://${DEVICE_HOSTNAME}.local,https://${DEVICE_HOSTNAME}.local,http://${DEVICE_HOSTNAME},https://${DEVICE_HOSTNAME}"
+DEVICE_HOSTS="http://${DEVICE_IP},http://${DEVICE_HOSTNAME}.local,https://${DEVICE_HOSTNAME}.local,http://${DEVICE_HOSTNAME},https://${DEVICE_HOSTNAME},http://${DEVICE_HOSTNAME}${DEVICE_DNS_SUFFIX},https://${DEVICE_HOSTNAME}${DEVICE_DNS_SUFFIX}"
 if [[ -f "${UMBREL_ROOT}/tor/data/web/hostname" ]]; then
     hidden_service_url=$(cat "${UMBREL_ROOT}/tor/data/web/hostname")
     DEVICE_HOSTS="${DEVICE_HOSTS},http://${hidden_service_url}"
 fi
 export DEVICE_HOSTS=$DEVICE_HOSTS
-export DEVICE_HOSTNAME="${DEVICE_HOSTNAME}.local"
+export DEVICE_HOSTNAME="${DEVICE_HOSTNAME}${DEVICE_DNS_SUFFIX}"
 
 # Increase default Docker and Compose timeouts to 240s
 # as bitcoin can take a long while to respond

--- a/templates/.env-sample
+++ b/templates/.env-sample
@@ -7,3 +7,4 @@ BITCOIN_RPC_AUTH=<rpcauth>
 TOR_PASSWORD=<password>
 TOR_HASHED_PASSWORD=<password>
 DOCKER_BINARY=<path>
+DEVICE_DNS_SUFFIX=<suffix>


### PR DESCRIPTION
At the moment, umbrel expects that a) you have a mDNS daemon (e.g. avahi) on the machine that runs umbrel (which is a reasonable assumption for umbrel-os, but not for custom installs) and b) that the client accessing umbrel has a mDNS resolver (some Linux distros don't have one by default). If you don't fulfill both requirements, you cannot access `umbrel.local`, since it will not resolve.

Some routers seem to implement a custom DNS resolver and send this to all clients in order to do domain lookups. This is e.g. the case for fritzbox routers (which are very popular in Germany). With these routers, you can simply resolve any hostname in the local network by name (e.g. `http://umbrel.fritz.box/`) and you can even omit the trailing domain, i.e. `http://umbrel/` will resolve just fine as well. This is achieved by some kind of handshake between the router and the host system during dhcp, which updates `/etc/resolv.conf` to contain the domain search path, e.g.:
```
# Generated by resolvconf
search fritz.box
nameserver 192.168.1.1
nameserver 1.1.1.1
nameserver 1.0.0.1
options edns0
```
or 
```
#PROTO: DHCP
domain fritz.box
nameserver 192.168.1.1
bootserver 192.168.1.1
```

In order to support to connect to umbrel via these custom domain suffixes, they must be added to the CORS whitelist, which is done with this PR. If no custom domain search path was found it `/etc/resolv.conf`, this PR falls back to `.local` as before, so setups without a custom DNS suffix should not be affected.

One thing that I just thought of was that we might still want to add the `.local` url to the CORS whitelist as well, just to make sure that you can use both, your custom domain name or `.local`, if your network supports both (which I have not tested). Please let me know if this is more reasonable, then I'll try to integrate that.

@lukechilds we discussed this a few weeks back in telegram, but somehow I never put up the PR for this. I'm using this in my local network since a few weeks without problems.