### PR TITLE
Correctly set project name for apps

### DIFF
--- a/scripts/app
+++ b/scripts/app
@@ -82,6 +82,7 @@ compose() {
   export APP_DATA_DIR="${app_data_dir}"
   docker-compose \
     --env-file "${env_file}" \
+    --project-name "${app}" \
     --file "${app_base_compose_file}" \
     --file "${app_compose_file}" \
     "${@}"


### PR DESCRIPTION
By default Docker Compose sets the project name to the containing directory of the first yaml file passed into `docker-compose` which is currently always `apps`.

This makes it really hard to identify containers in logs and docker commands.

This PR sets the project name to the app id.

So for example previously the `web` container in the `btc-rpc-explorer` app would show up in logs as `apps_web_1`. Now it will show up as `btc-rpc-explorer_web_1`.