### PR TITLE
Pass APP_HIDDEN_SERVICE environment variable to apps

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -154,6 +154,9 @@ services:
       # Tor proxy environment variables
       # $TOR_PROXY_IP - Local IP of Tor proxy
       # $TOR_PROXY_PORT - Port of Tor proxy
+      #
+      # App specific environment variables
+      # $APP_HIDDEN_SERVICE - The address of the Tor hidden service your app will be exposed at
   # If your app has more services, like a database container, you can define those
   # services below:
   # db:

--- a/scripts/app
+++ b/scripts/app
@@ -76,10 +76,12 @@ compose() {
   local env_file="${UMBREL_ROOT}/.env"
   local app_base_compose_file="${UMBREL_ROOT}/apps/docker-compose.common.yml"
   local app_compose_file="${app_dir}/docker-compose.yml"
+  local app_hidden_servive_file="${UMBREL_ROOT}/tor/data/app-${app}/hostname"
 
   export BITCOIN_DATA_DIR="${UMBREL_ROOT}/bitcoin"
   export LND_DATA_DIR="${UMBREL_ROOT}/lnd"
   export APP_DATA_DIR="${app_data_dir}"
+  export APP_HIDDEN_SERVICE="$(cat "${app_hidden_servive_file}" || echo "")"
   docker-compose \
     --env-file "${env_file}" \
     --project-name "${app}" \


### PR DESCRIPTION
This change passes the address of the Tor hidden service an app will be exposed at in to the apps compose configuration as the environment variable `APP_HIDDEN_SERVICE`.

This is useful for apps that need to display the connection details to users.

If there has not yet been a hidden service create for the app the environment variable will be set to an empty string.