### PR TITLE
Only ignore top level dotfiles on OTA update

### DIFF
--- a/scripts/update/.updateignore
+++ b/scripts/update/.updateignore
@@ -1,4 +1,4 @@
-.*
+/.*
 bitcoin/*
 db
 lnd/*


### PR DESCRIPTION
Without this change all dotfiles at any level get ignored during OTA updates.

This means `templates/.env-sample` and any other dotfiles have not been getting updated via OTA updates.

We should really be explicitly ignoring every single specific file/dir we want to exclude to prevent bugs like this occuring again. If we rely on wildcards they may end up matching files added in the future that will be assumed to be updated via OTA unless explicitly ignored. But this emergency fix has been tested extensively and is known to work so it's sufficient for now.