### PR TITLE
Reduce dbcache post IBD

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,12 +155,13 @@ services:
                         ipv4_address: $MIDDLEWARE_IP
         neutrino-switcher:
                 container_name: neutrino-switcher
-                image: getumbrel/neutrino-switcher:v1.0.3
+                image: getumbrel/neutrino-switcher:v1.1.1
                 logging: *default-logging
                 depends_on: [ bitcoin, lnd ]
                 restart: on-failure
                 volumes:
                     - ${PWD}/lnd:/lnd
+                    - ${PWD}/bitcoin:/bitcoin
                     - ${PWD}/statuses:/statuses
                     - /var/run/docker.sock:/var/run/docker.sock
                 environment:
@@ -168,6 +169,7 @@ services:
                     RPCUSER: $BITCOIN_RPC_USER
                     RPCPASS: $BITCOIN_RPC_PASS
                     LND_CONTAINER_NAME: lnd
+                    BITCOIN_CONTAINER_NAME: bitcoin
                     SLEEPTIME: 3600
                 networks:
                     default:

--- a/scripts/configure
+++ b/scripts/configure
@@ -258,7 +258,13 @@ echo
 
 echo "Setting dbcache size"
 echo
-DBCACHE_SIZE=$(awk '/MemTotal/{printf "%d\n", ($2/2^10 * 0.5) - 300}' /proc/meminfo)
+if [[ -f "${STATUS_DIR}/node-status-bitcoind-ready" ]]; then
+  # Limit dbcache to 200 after IBD
+  DBCACHE_SIZE="200"
+else
+  # Allocate (50% of RAM) - 300MB to dbcache for IDB
+  DBCACHE_SIZE=$(awk '/MemTotal/{printf "%d\n", ($2/2^10 * 0.5) - 300}' /proc/meminfo)
+fi
 sed -i -e "s/dbcache=<size>/dbcache=$DBCACHE_SIZE/g" "$BITCOIN_CONF_FILE"
 
 # TODO: Adjust prune size based on available disk space


### PR DESCRIPTION
By default we set `dbcache` to 50% total ram - 300MB since it helps significantly speed up IBD.

300MB is the default mempool size so we end up allocating ~50% of total system memory to Bitcoin Core.

However this is incredibly wasteful once IBD has completed, especially on high memory systems, a huge amount of RAM is being allocated to Bitcoin Core when it really isn't needed.

This PR reduces `dbcache` to 200MB once IBD has completed. That means post IBD 200MB `dbcache` and 300MB `maxmempool` are allocated to Bitcoin Core for a total of ~500MB.

This should be plenty since `dbcache` is only used to cache the UTXO set to speed up block validation. Post IBD we only need to validate one block every ~10 minutes so it's not particularly time critical.

We can probably reduce this value even further, the minimum allowed value for `dbcache` is 4. 200 seems sensible for now but we should test reducing right down to 4.