### PR TITLE
Pull new app containers on update

### DIFF
--- a/scripts/app
+++ b/scripts/app
@@ -18,6 +18,7 @@ Commands:
     stop                       Stops an installed app
     start                      Starts an installed app
     compose                    Passes all arguments to docker-compose
+    ls-installed               Lists installed apps
 EOF
 }
 
@@ -31,7 +32,7 @@ check_dependencies () {
 }
 
 list_installed_apps() {
-  cat "${USER_FILE}" | jq -r 'if has("installedApps") then .installedApps else [] end | join("\n")' || true
+  cat "${USER_FILE}" 2> /dev/null | jq -r 'if has("installedApps") then .installedApps else [] end | join("\n")' || true
 }
 
 # Check dependencies
@@ -41,6 +42,13 @@ if [ -z ${1+x} ]; then
   command=""
 else
   command="$1"
+fi
+
+# Lists installed apps
+if [[ "$command" = "ls-installed" ]]; then
+  list_installed_apps
+
+  exit
 fi
 
 if [ -z ${2+x} ]; then

--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -82,7 +82,6 @@ EOF
 docker-compose pull
 
 echo "Pulling new app containers"
-
 # We can just loop over this once everyone has the latest app script
 # "$UMBREL_ROOT/scripts/app" ls-installed
 # but for now we need to implement it here manually

--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -91,7 +91,8 @@ list_installed_apps() {
   cat "${USER_FILE}" 2> /dev/null | jq -r 'if has("installedApps") then .installedApps else [] end | join("\n")' || true
 }
 list_installed_apps | while read app; do
-  scripts/app compose "$app" pull
+  echo "${app}..."
+  scripts/app compose "${app}" pull
 done
 
 # Stop existing containers

--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -81,7 +81,10 @@ cat <<EOF > "$UMBREL_ROOT"/statuses/update-status.json
 EOF
 docker-compose pull
 
-echo "Pulling new app containers"
+echo "Updating installed apps"
+cat <<EOF > "$UMBREL_ROOT"/statuses/update-status.json
+{"state": "installing", "progress": 60, "description": "Updating installed apps", "updateTo": "$RELEASE"}
+EOF
 # We can just loop over this once everyone has the latest app script
 # "$UMBREL_ROOT/scripts/app" ls-installed
 # but for now we need to implement it here manually

--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -80,6 +80,9 @@ cat <<EOF > "$UMBREL_ROOT"/statuses/update-status.json
 {"state": "installing", "progress": 50, "description": "Pulling new containers", "updateTo": "$RELEASE"}
 EOF
 docker-compose pull
+"$UMBREL_ROOT/scripts/app" ls-installed | while read app; do
+  scripts/app compose "$app" pull
+done
 
 # Stop existing containers
 echo "Stopping existing containers"

--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -80,7 +80,17 @@ cat <<EOF > "$UMBREL_ROOT"/statuses/update-status.json
 {"state": "installing", "progress": 50, "description": "Pulling new containers", "updateTo": "$RELEASE"}
 EOF
 docker-compose pull
-"$UMBREL_ROOT/scripts/app" ls-installed | while read app; do
+
+echo "Pulling new app containers"
+
+# We can just loop over this once everyone has the latest app script
+# "$UMBREL_ROOT/scripts/app" ls-installed
+# but for now we need to implement it here manually
+USER_FILE="${UMBREL_ROOT}/db/user.json"
+list_installed_apps() {
+  cat "${USER_FILE}" 2> /dev/null | jq -r 'if has("installedApps") then .installedApps else [] end | join("\n")' || true
+}
+list_installed_apps | while read app; do
   scripts/app compose "$app" pull
 done
 


### PR DESCRIPTION
This change pulls the latest app containers during OTA updates.

**Edit:**

Upon further inspection I'm not sure this really achieves anything. The initial reasoning was to make sure the apps are all started before the user is returned to the dashboard after an OTA update. However the users won't get returned to the dashboard until after the start script exits and I don't think the start script will exit until all app containers have been started. I'm pretty sure `docker-compose` will do a blocking pull if there are container updates so we can already be sure all apps are updated and running before users are returned to the dashboard.

I think this PR is introducing additional complexity for no gain.