### PR TITLE
Exclude app-data from UMBREL_ROOT chown

### DIFF
--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -101,7 +101,7 @@ rsync --archive \
 
 # Fix permissions
 echo "Fixing permissions"
-chown -R 1000:1000 "$UMBREL_ROOT"/
+find "$UMBREL_ROOT" -path "$UMBREL_ROOT/app-data" -prune -o -exec chown 1000:1000 {} +
 chmod -R 700 "$UMBREL_ROOT"/tor/data/*
 
 # Start updated containers


### PR DESCRIPTION
I've implemented this since we have it down as a task to complete before the next update but I'm not really happy with this solution.

Instead of chowning everything and excluding app-data, we should explicitly chown just what we need to and nothing else. I'm not sure why this chown was implemented and what issues it was resolving so this should be ok for now, but it should be cleaned up at some point.