### PR TITLE
Kill karen on update

### DIFF
--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -105,9 +105,9 @@ chown -R 1000:1000 "$UMBREL_ROOT"/
 chmod -R 700 "$UMBREL_ROOT"/tor/data/*
 
 # Killing karen
-echo "Killing karen"
+echo "Killing background daemon"
 cat <<EOF > "$UMBREL_ROOT"/statuses/update-status.json
-{"state": "installing", "progress": 75, "description": "Killing karen", "updateTo": "$RELEASE"}
+{"state": "installing", "progress": 75, "description": "Killing background daemon", "updateTo": "$RELEASE"}
 EOF
 pkill -f "\./karen"
 

--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -104,6 +104,13 @@ echo "Fixing permissions"
 chown -R 1000:1000 "$UMBREL_ROOT"/
 chmod -R 700 "$UMBREL_ROOT"/tor/data/*
 
+# Killing karen
+echo "Killing karen"
+cat <<EOF > "$UMBREL_ROOT"/statuses/update-status.json
+{"state": "installing", "progress": 75, "description": "Killing karen", "updateTo": "$RELEASE"}
+EOF
+sudo pkill -f "\./karen"
+
 # Start updated containers
 echo "Starting new containers"
 cat <<EOF > "$UMBREL_ROOT"/statuses/update-status.json

--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -109,7 +109,7 @@ echo "Killing karen"
 cat <<EOF > "$UMBREL_ROOT"/statuses/update-status.json
 {"state": "installing", "progress": 75, "description": "Killing karen", "updateTo": "$RELEASE"}
 EOF
-sudo pkill -f "\./karen"
+pkill -f "\./karen"
 
 # Start updated containers
 echo "Starting new containers"


### PR DESCRIPTION
This kills `karen` before running the start script during an OTA update. This means that after OTA the latest version of `karen` is always running which is important for the new app functionality to work.