### PR TITLE
Create app directory before pulling images

### DIFF
--- a/scripts/app
+++ b/scripts/app
@@ -109,12 +109,12 @@ update_installed_apps() {
 # Pulls down images for an app and starts it
 if [[ "$command" = "install" ]]; then
 
-  echo "Pulling images for app ${app}..."
-  compose "${app}" pull
-
   echo "Setting up data dir for app ${app}..."
   mkdir -p "${app_data_dir}"
   rsync --archive --verbose --exclude ".gitkeep" "${app_dir}/." "${app_data_dir}"
+  
+  echo "Pulling images for app ${app}..."
+  compose "${app}" pull
 
   echo "Starting app ${app}..."
   compose "${app}" up --detach


### PR DESCRIPTION
Create the app directory and copy app data before reading the compose file for the first time. For instance, if the compose file uses a local file, it won't find it.

Example :
```
# apps/<app>/docker-compose.yml
...
env_file:
    - ${APP_DATA_DIR}/app.conf
```
currently results in 
```
Pulling images for app <app>...
ERROR: Couldn't find env file: /home/umbrel/umbrel/app-data/<app>/app.conf
```

@lukechilds 