### PR TITLE
Run karen as systemd service

### DIFF
--- a/scripts/karen
+++ b/scripts/karen
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Simple wrapper script for karen to log to the correct logfile
+
+UMBREL_ROOT="$(dirname $(readlink -f "${BASH_SOURCE[0]}"))/.."
+UMBREL_LOGS="${UMBREL_ROOT}/logs"
+
+./karen &>> "${UMBREL_LOGS}/karen.log" &

--- a/scripts/start
+++ b/scripts/start
@@ -71,7 +71,7 @@ cd "$UMBREL_ROOT"
 
 echo "Starting karen..."
 echo
-./karen &>> "${UMBREL_LOGS}/karen.log" &
+./scripts/karen
 
 echo "Starting backup monitor..."
 echo

--- a/scripts/umbrel-os/services/karen.service
+++ b/scripts/umbrel-os/services/karen.service
@@ -1,0 +1,22 @@
+# Umbrel Karen Service
+# Installed at /etc/systemd/system/karen.service
+
+[Unit]
+Description=Umbrel Karen Service
+Requires=umbrel-external-storage.service
+After=umbrel-external-storage.service
+
+[Service]
+Type=forking
+TimeoutStartSec=infinity
+TimeoutStopSec=16min
+ExecStart=/home/umbrel/umbrel/scripts/karen
+User=root
+Group=root
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=karen
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/umbrel-os/services/umbrel-startup.service
+++ b/scripts/umbrel-os/services/umbrel-startup.service
@@ -9,6 +9,8 @@ Wants=network-online.target
 After=network-online.target
 Wants=docker.service
 After=docker.service
+Requires=karen.service
+After=karen.service
 
 [Service]
 Type=forking


### PR DESCRIPTION
Fixes https://github.com/orgs/getumbrel/projects/3#card-50139347

This also makes sure that systemd services are always updated if Umbrel is updated.

This works because karen refuses to start if there already is one (two Karens in one store are too much), so the start script doesn't start karen.