### PR TITLE
Fix lncli and bitcoin-cli wrapper scripts

### DIFF
--- a/bin/bitcoin-cli
+++ b/bin/bitcoin-cli
@@ -4,7 +4,10 @@ set -euo pipefail
 
 UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/..)"
 
-result=$(docker-compose --file "${UMBREL_ROOT}/docker-compose.yml" exec bitcoin bitcoin-cli $@)
+result=$(docker-compose \
+  --file "${UMBREL_ROOT}/docker-compose.yml" \
+  --env-file "${UMBREL_ROOT}/.env" \
+  exec bitcoin bitcoin-cli $@)
 
 # We need to echo with quotes to preserve output formatting
 echo "$result"

--- a/bin/bitcoin-cli
+++ b/bin/bitcoin-cli
@@ -4,9 +4,7 @@ set -euo pipefail
 
 UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/..)"
 
-pushd $UMBREL_ROOT
-result=$(docker-compose exec bitcoin bitcoin-cli $@)
-popd
+result=$(docker-compose --file "${UMBREL_ROOT}/docker-compose.yml" exec bitcoin bitcoin-cli $@)
 
 # We need to echo with quotes to preserve output formatting
 echo "$result"

--- a/bin/bitcoin-cli
+++ b/bin/bitcoin-cli
@@ -4,7 +4,9 @@ set -euo pipefail
 
 UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/..)"
 
-result=$(docker-compose --file "${UMBREL_ROOT}/docker-compose.yml" exec bitcoin bitcoin-cli $@)
+pushd $UMBREL_ROOT
+result=$(docker-compose exec bitcoin bitcoin-cli $@)
+popd
 
 # We need to echo with quotes to preserve output formatting
 echo "$result"

--- a/bin/lncli
+++ b/bin/lncli
@@ -4,7 +4,10 @@ set -euo pipefail
 
 UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/..)"
 
-result=$(docker-compose --file "${UMBREL_ROOT}/docker-compose.yml" exec lnd lncli $@)
+result=$(docker-compose \
+  --file "${UMBREL_ROOT}/docker-compose.yml" \
+  --env-file "${UMBREL_ROOT}/.env" \
+  exec lnd lncli $@)
 
 # We need to echo with quotes to preserve output formatting
 echo "$result"

--- a/bin/lncli
+++ b/bin/lncli
@@ -4,9 +4,7 @@ set -euo pipefail
 
 UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/..)"
 
-pushd $UMBREL_ROOT
-result=$(docker-compose exec lnd lncli $@)
-popd
+result=$(docker-compose --file "${UMBREL_ROOT}/docker-compose.yml" exec lnd lncli $@)
 
 # We need to echo with quotes to preserve output formatting
 echo "$result"

--- a/bin/lncli
+++ b/bin/lncli
@@ -4,7 +4,9 @@ set -euo pipefail
 
 UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/..)"
 
-result=$(docker-compose --file "${UMBREL_ROOT}/docker-compose.yml" exec lnd lncli $@)
+pushd $UMBREL_ROOT
+result=$(docker-compose exec lnd lncli $@)
+popd
 
 # We need to echo with quotes to preserve output formatting
 echo "$result"


### PR DESCRIPTION
I assume the problem was the .env file not being loaded correctly. By temporarily going into the Umbrel root folder and going back later, the problem can be solved.