### PR TITLE
Update specter-desktop app to v1.0.0

### DIFF
--- a/apps/registry.json
+++ b/apps/registry.json
@@ -27,7 +27,7 @@
         "id": "specter-desktop",
         "category": "Wallets",
         "name": "Specter Desktop",
-        "version": "0.10.4",
+        "version": "1.0.0",
         "tagline": "Multisig with hardware wallets made easy",
         "description": "Specter Desktop connects to the Bitcoin Core running on your Umbrel and functions as a watch-only coordinator for multi-signature and single-key Bitcoin wallets. At the moment Specter Desktop is working with all major hardware wallets including:\n\n- Trezor\n- Ledger\n- KeepKey\n- BitBox02\n- ColdCard (optionally airgapped, using an SD card)\n- Electrum (optionally airgapped, if running Electrum on an airgapped computer/phone)\n- Specter DIY (optionally airgapped, using QR codes)\n- Cobo (airgapped, using QR codes)\n\nSpecter Desktop also supports using the Bitcoin Core on your Umbrel as a hot wallet, by importing or generating a random BIP39 mnemonic, but this feature is experimental and we do not recommend using it at this stage. We plan to add support for other hardware wallets as they come up.",
         "developer": "Crypto Advance",

--- a/apps/specter-desktop/docker-compose.yml
+++ b/apps/specter-desktop/docker-compose.yml
@@ -8,7 +8,7 @@ x-logging:
 
 services:
   web:
-    image: lncm/specter-desktop:v0.10.4@sha256:bca14d04397d26fd9da085e0f5c97c6fc89dccff39a22719584d13b352fe1800
+    image: lncm/specter-desktop:v1.0.0@sha256:d9bba765ab494b3d39aae4c763c91c3d640ae2a1c56cf4caee9d447318ca5157
     stop_signal: SIGINT
     logging: *default-logging
     restart: on-failure


### PR DESCRIPTION
Update Specter Desktop to [v1.0.0](https://github.com/cryptoadvance/specter-desktop/releases/tag/v1.0.0)

/cc @k9ert 