### PR TITLE
Upgrade sphinx-relay app to v1.3.6

### DIFF
--- a/apps/sphinx-relay/docker-compose.yml
+++ b/apps/sphinx-relay/docker-compose.yml
@@ -8,7 +8,7 @@ x-logging: &default-logging
 services:
   sphinx-relay:
     container_name: sphinx-relay
-    image: sphinxlightning/sphinx-relay:v1.3.6
+    image: sphinxlightning/sphinx-relay:v1.3.6@sha256:f4c61197738a5735942282959e256bad7add18a84fa157efc161423b041446e8
     init: true
     restart: on-failure
     stop_grace_period: 1m

--- a/apps/sphinx-relay/docker-compose.yml
+++ b/apps/sphinx-relay/docker-compose.yml
@@ -8,7 +8,7 @@ x-logging: &default-logging
 services:
   sphinx-relay:
     container_name: sphinx-relay
-    image: sphinxlightning/sphinx-relay:v1.3.2@sha256:84d54879ca6f1b593210ffa93d8cbaa6f28d796d2838575764d2e5ac50ea6601
+    image: sphinxlightning/sphinx-relay:v1.3.6
     init: true
     restart: on-failure
     stop_grace_period: 1m


### PR DESCRIPTION
This PR upgrades sphinx-relay app to the latest version v1.3.6.

Changelog:
```
- bugfix
- better auditing for Accounting records
- GET app_versions route
- fix an issue with join tribe key exchange
- fixed memory leak (node-fetch in a setInterval)
```