### PR TITLE
Upgrade thunderhub app to v0.12.2

### DIFF
--- a/apps/registry.json
+++ b/apps/registry.json
@@ -119,7 +119,7 @@
         "id": "thunderhub",
         "category": "Lightning Node Management",
         "name": "ThunderHub",
-        "version": "0.12.1",
+        "version": "0.12.2",
         "tagline": "Take full control of your Lightning node",
         "description": "ThunderHub allows you to take full control of your Lightning node with a slick and awesome UI. Explore all the options that ThunderHub has to offer, from sending and receiving Lightning payments, to checking your node's health statistics, and even more advanced options like channel rebalancing and multi-path lightning payments.\n\nManaging and monitoring your node has never been easier with transaction reports, graphs and a huge assortment of different features all bundled inside of this great tool.",
         "developer": "Anthony Potdevin",

--- a/apps/thunderhub/docker-compose.yml
+++ b/apps/thunderhub/docker-compose.yml
@@ -8,7 +8,7 @@ x-logging:
 
 services:
   web:
-    image: apotdevin/thunderhub:v0.12.1@sha256:d78fd60c8eec6fced800c254593e76cb5cd75608a35bdbde7eca5f5f533781b5
+    image: apotdevin/thunderhub:v0.12.2@sha256:c6e22cd3f489924185da20b1a10c07ecce219b874adf35b9c0be46725033840f
     user: "1000:1000"
     logging: *default-logging
     restart: on-failure


### PR DESCRIPTION
This PR upgrades thunderhub app to the latest version v0.12.2.

Changelog:
```
refactor: ♻️ boltz resolvers
chore: 🔧 enable tor proxy config
fix: 🐛 boltz swap
```
https://github.com/apotdevin/thunderhub/releases/tag/v0.12.2