### PR TITLE
Allow running from SSD only

### DIFF
--- a/scripts/umbrel-os/external-storage/mount
+++ b/scripts/umbrel-os/external-storage/mount
@@ -148,6 +148,10 @@ main () {
   # At this point we know there is only one block device attached
   block_device=$(list_block_devices)
   partition_path="/dev/${block_device}1"
+  if [[ $(eval $(lsblk -oMOUNTPOINT,PKNAME -P -M | grep 'MOUNTPOINT="/"'); echo $PKNAME) == $partition_path ]]; then
+    exit 0
+  fi
+
   block_device_model=$(get_block_device_model $block_device)
   echo "Found device \"${block_device_model}\""
 


### PR DESCRIPTION
I'm not sure if you actually want that (probably not, there are good reasons for using two separate devices), but it has been requested a few times now, like https://github.com/getumbrel/umbrel-os/issues/162.