### PR TITLE
DOC: use new brew cask install method in readme

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -258,7 +258,7 @@ Umbrel development environment ([`umbrel-dev`](https://github.com/getumbrel/umbr
 
 ```sh
 brew install lukechilds/tap/umbrel-dev
-brew cask install virtualbox vagrant
+brew install --cask virtualbox vagrant
 ```
 
 2\. Now let's initialize our development environment and boot the VM:


### PR DESCRIPTION
previous command show an error:
```
$ brew cask install virtualbox vagrant
...
Error: Calling brew cask install is disabled! Use brew install [--cask] instead.
```
on latest version of homebrew:
```
$ brew -v
Homebrew 2.7.4
```