### PR TITLE
Upgrade bitcoind to 0.21.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
                         ipv4_address: $NGINX_IP
         bitcoin:
                 container_name: bitcoin
-                image: lncm/bitcoind:v0.20.1
+                image: lncm/bitcoind:v0.21.0
                 logging: *default-logging
                 depends_on: [ tor, manager ]
                 volumes:


### PR DESCRIPTION
Some stuff in this release:

```
 - Descriptor wallets
 - Compact block filters over P2P network 
 - Fewer rebroadcast attempts
 - Tor V3 support
 - Schnorr/Taproot code
 ```

[Release notes (Courtesy of bitcoinmagazine)](https://bitcoinmagazine.com/articles/bitcoin-core-0-21-0-released-whats-new)

Now every bitcoin node can serve stuff over neutrino