### PR TITLE
Fix karen sometimes reacting even if no trigger is present

### DIFF
--- a/karen
+++ b/karen
@@ -54,7 +54,10 @@ fswatch -0 --event=PlatformSpecific $signal_dir | while read -d "" event; do
   trigger="$trigger_dir/$signal"
   args=""
 
-  echo "Got signal: $signal"
+  if [[ ! -z "$signal" ]]; then
+    echo "Got signal: $signal"
+  fi
+
 
   app_prefix="app-"
   if [[ "$signal" == "$app_prefix"* ]]; then
@@ -63,10 +66,13 @@ fswatch -0 --event=PlatformSpecific $signal_dir | while read -d "" event; do
     args="${signal#$app_prefix}"
   fi
 
-  if test -x "$trigger"; then
+  if [[ -x "$trigger" ]] && [[ ! -d "$trigger" ]]; then
     echo "karen is getting triggered!"
     "$trigger" $args &
   else
-    echo "No trigger found"
+    if [[ ! -z "$signal" ]]; then
+      echo "No trigger found"
+    fi
   fi
 done
+


### PR DESCRIPTION
For some reasons, karen reacts to nonexistent triggers, and the -x test returns true on a dir (`trigger="$trigger_dir/$signal" &&test -x trigger` if signal is empty there, it says it exists, but it actually doesn't). This prevents that from happening by making sure the signal actually exists. Nothing bad would happen in this case, this just makes the output cleaner.