### PR TITLE
Add mempool v1.0

### DIFF
--- a/apps/mempool/docker-compose.yml
+++ b/apps/mempool/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.7"
+
+x-logging:
+  &default-logging
+  driver: journald
+  options:
+    tag: "umbrel-app {{.Name}}"
+
+services:
+  web:
+    image: mempool/mempool:v1.0@sha256:aad79c7ad76ccb05505800c0071c5bde6fb9be201883d44268f894b799b6728e
+    logging: *default-logging
+    restart: on-failure
+    stop_grace_period: 1m
+    ports:
+      - 3012:80
+    environment:
+      BITCOIN_NODE_HOST: $BITCOIN_IP
+      BITCOIN_NODE_USER: $BITCOIN_RPC_USER
+      BITCOIN_NODE_PASS: $BITCOIN_RPC_PASS
+      BITCOIN_NODE_PORT: $BITCOIN_RPC_PORT


### PR DESCRIPTION
Adding the v1.0 of mempool.space.
I'm looking how to do it with the v2.0.1

# App Submission

### App name
Mempool

### Version
1.0

### One line description of the app
_(max 50 characters)_

A mempool visualizer and explorer for Bitcoin

### Summary of the app
_(50 to 200 words)_

Bitcoin block explorer, mempool visualizer, transaction tracker, and fee estimator

### Developed by
Mempool

### Developer website
https://mempool.space/

### Source code repository
https://github.com/mempool/mempool

### Support link
_(Link to your Telegram support channel, GitHub issues/discussions, support portal, or any other place where users could contact you for support.)_

https://mempool.space/about

### Uses
- [x] Bitcoin Core
- [ ] Electrum server
- [ ] LND

### 256x256 SVG icon
_(GitHub doesn't allow uploadig SVGs directly. Upload your file to an alternate service, like https://svgur.com, and paste the link below.)_



### App screenshots
_(Upload 3 to 5 high-quality screenshots (at least 1280x800px) of your app in PNG format.)_



### I have tested my app on:
- [x] [Umbrel dev environment](https://github.com/getumbrel/umbrel-dev)
- [ ] [Umbrel OS on a Raspberry Pi 4](https://github.com/getumbrel/umbrel-os)
- [ ] [Custom Umbrel install on Linux](https://github.com/getumbrel/umbrel#-installation)