### PR TITLE
Update btcpay-server app to v1.0.6.8

### DIFF
--- a/apps/btcpay-server/docker-compose.yml
+++ b/apps/btcpay-server/docker-compose.yml
@@ -8,7 +8,7 @@ x-logging:
 
 services:
   nbxplorer:
-    image: "nicolasdorier/nbxplorer:2.1.46@sha256:368789f27867c54fc7435424e05a8c8440a4c2355afad237f1845b62c9aa9d1c"
+    image: "nicolasdorier/nbxplorer:2.1.49@sha256:b247343d3127c737ed2ce250e780e52a958241fff1d897a5b6e8cd20fb5f142a"
     user: "1000:1000"
     logging: *default-logging
     restart: on-failure
@@ -31,7 +31,7 @@ services:
         ipv4_address: $APP_BTCPAY_SERVER_NBXPLORER_IP
 
   web:
-    image: btcpayserver/btcpayserver:1.0.6.7@sha256:01a5636fd24841eb382cc2ee9c3387f9ff0c818bd7ef34330008ef0f1d694f2d
+    image: btcpayserver/btcpayserver:1.0.6.8@sha256:10c6acff736b869b731ebb1609c6bd33ecab469b5be4bb5ede8614347466abfc
     user: "1000:1000"
     logging: *default-logging
     restart: on-failure

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -3,7 +3,7 @@
         "id": "btcpay-server",
         "category": "Payments",
         "name": "BTCPay Server",
-        "version": "1.0.6.7",
+        "version": "1.0.6.8",
         "tagline": "Accept Bitcoin payments with 0 fees & no 3rd party",
         "description": "BTCPay Server is a payment processor that allows you to receive payments in Bitcoin (and altcoins) directly, with no fees, transaction cost or a middleman. It is a non-custodial invoicing system which eliminates the involvement of a third-party.\n\nPayments with BTCPay Server go directly to your wallet, which increases the privacy and security. Your private keys are never uploaded to your Umbrel. There is no address re-use, since each invoice generates a new address deriving from your xpubkey.\n\nYou can not only to attach an unlimited number of stores and use the Lightning Network but also become a payment processor for others. Thanks to the apps built on top of it, you can use BTCPay to receive donations, start a crowdfunding campaign or have an in-store Point of Sale.",
         "developer": "BTCPay Server Foundation",


### PR DESCRIPTION
BTCPayServer update
```
This release is trying some improvement to decrease the chances of being falsy flagged by Google Safe Browsing.

Remove Tor URL from login page (useless now thanks to the url bar link) @dennisreimann
Remove allowtransparency from checkout overlay @dennisreimann
Remove clipboard code from the login page (was used to copy the tor url) @dennisreimann
Rename some pages from PascalCase to lowercase. (Register => register, Login => login) @dennisreimann
```