### PR TITLE
Update lightning-terminal to v0.4.0-alpha

### DIFF
--- a/apps/lightning-terminal/docker-compose.yml
+++ b/apps/lightning-terminal/docker-compose.yml
@@ -8,7 +8,7 @@ x-logging:
 
 services:
   web:
-    image: lightninglabs/lightning-terminal:v0.3.4-alpha@sha256:ae0b30a73d141bfc24505892b6c23b8faf0acbf93275410aa95118e01f794166
+    image: lightninglabs/lightning-terminal:v0.4.0-alpha@sha256:1273ffa9e818dea2d21adc9a226692b8117ab29582b80c6d6e4c53316392da05
     user: "1000:1000"
     logging: *default-logging
     restart: on-failure

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -96,7 +96,7 @@
         "id": "lightning-terminal",
         "category": "Lightning Node Management",
         "name": "Lightning Terminal",
-        "version": "0.3.4-alpha",
+        "version": "0.4.0-alpha",
         "tagline": "The easiest way to manage channel liquidity",
         "description": "Lightning Terminal is the easiest way to manage inbound and outbound liquidity on the Lightning Network. Keep your channels open and the funds flowing. It provides a visual interface for interacting with your channels and balances using Loop. Making the process of managing your funds easier and more intuitive allows you to focus on running your business, not on your liquidity. Loop is the first of several upcoming Terminal features that enable new use cases and open up a new world of possibilities on Lightning.\n\nWhy use Loop?\n\n- Add \"inbound liquidity\" to receive payments\n- Reduce transaction fees by recycling and reusing Lightning channels\n- Send funds to and from users or services that aren't yet Lightning enabled\n- Configurable wait times and \"batching\" allow for further fee savings\n- Refill and offload funds from any number of Lightning channels in a single on-chain transaction\n\nPricing:\n\nLoop Out: 0.05-0.5%\nLoop In: 0.10-1%\nLoop pricing varies based on wait time and on-chain fee conditions.",
         "developer": "Lightning Labs",


### PR DESCRIPTION
Release notes on the [official Lightning Terminal repo](https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.4.0-alpha).

Can someone test this on mainnet? There are issues with Pool on testnet. @lukechilds 