### PR TITLE
Remove duplicated depends_on

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,7 +136,6 @@ services:
                 depends_on: [ manager, bitcoin, lnd ]
                 command: ["./wait-for-node-manager.sh", $MANAGER_IP, "npm", "start"]
                 restart: on-failure
-                depends_on: [ manager ]
                 volumes:
                         - ${PWD}/lnd:/lnd
                         - jwt-public-key:/jwt-public-key


### PR DESCRIPTION
This is not in this PR, it's just my opinion:

In my opinion it would make more sense to have manager & middleware depend on BTC & LND instead of making it the other way around, is there any reason for not doing that? Also, I think lnd should depend on bitcoind