### PR TITLE
Remove redundant bitcoin.conf options

### DIFF
--- a/templates/bitcoin-sample.conf
+++ b/templates/bitcoin-sample.conf
@@ -12,11 +12,9 @@ rpcallowip=<gateway-ip>/16
 rpcallowip=127.0.0.1
 rpcauth=<rpcauth>
 
-# Optimizations
+# Memory
 dbcache=<size>
 maxmempool=300
-maxconnections=40
-maxuploadtarget=1000
 
 # zmq
 zmqpubrawblock=tcp://0.0.0.0:<zmq-rawblock-port>


### PR DESCRIPTION
These options are not needed and are redundant since we don't allow public incoming connections.