### PR TITLE
Enable Bitcoin Core to serve SPV peers

### DIFF
--- a/templates/bitcoin-sample.conf
+++ b/templates/bitcoin-sample.conf
@@ -24,3 +24,7 @@ zmqpubhashblock=tcp://0.0.0.0:<zmq-hashblock-port>
 # Indexes
 txindex=1
 blockfilterindex=1
+
+# SPV
+peerbloomfilters=1
+peerblockfilters=1


### PR DESCRIPTION
This enables Bitcoin Core to serve both BIP37 (bloom filter) and BIP157 (Neutrino) SPV peers.

There are some minor DoS attack vectors when serving BIP37 SPV peers. However this doesn't affect us since we don't allow public incoming connections. In Umbrel the P2P port is only accessible remotely via a Tor hidden service and the address is not broadcast publicly.

This allows Umbrel to serve traditional SPV wallets like Blockstream Green and Bisq, as well as modern Neutrino "light client" style wallets like Breez.