### PR TITLE
Expose Bitcoin Core RPC port to the local network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
                 restart: on-failure
                 stop_grace_period: 15m30s
                 ports:
+                    - "$BITCOIN_RPC_PORT:$BITCOIN_RPC_PORT"
                     - "$BITCOIN_P2P_PORT:$BITCOIN_P2P_PORT"
                 networks:
                     default:


### PR DESCRIPTION
This exposes the RPC port to the local network to allow connections to wallets like Specter, Caravan, Ledger Live, Lily Wallet and Nunchuk without requiring Tor.

RPC is not really designed to be exposed like this, it's a potential DoS attack vector. However this is not an issue during beta while we make the assumption that the local network is secure.

Before a stable release we should have an auth proxy sat in front of Bitcoin Core RPC that is designed to be exposed and is resistant to DoS attacks.

Resolves #506 