### PR TITLE
Pass Umbrel seed into app script during updates

### DIFF
--- a/scripts/app
+++ b/scripts/app
@@ -37,8 +37,15 @@ list_installed_apps() {
 
 # Deterministically derives 128 bits of cryptographically secure entropy
 derive_entropy () {
+  # Make sure we use the seed from the real Umbrel installation if this is
+  # an OTA update.
+  SEED_FILE="${UMBREL_ROOT}/db/umbrel-seed/seed"
+  if [[ -f "${UMBREL_ROOT}/../.umbrel" ]]; then
+    SEED_FILE="${UMBREL_ROOT}/../db/umbrel-seed/seed"
+  fi
+
   identifier="${1}"
-  umbrel_seed=$(cat "${UMBREL_ROOT}/db/umbrel-seed/seed") || true
+  umbrel_seed=$(cat "${SEED_FILE}") || true
 
   if [[ -z "$umbrel_seed" ]] || [[ -z "$identifier" ]]; then
     >&2 echo "Missing derivation parameter, this is unsafe, exiting."

--- a/scripts/app
+++ b/scripts/app
@@ -40,7 +40,7 @@ derive_entropy () {
   # Make sure we use the seed from the real Umbrel installation if this is
   # an OTA update.
   SEED_FILE="${UMBREL_ROOT}/db/umbrel-seed/seed"
-  if [[ -f "${UMBREL_ROOT}/../.umbrel" ]]; then
+  if [[ ! -f "${SEED_FILE}" ]] && [[ -f "${UMBREL_ROOT}/../.umbrel" ]]; then
     SEED_FILE="${UMBREL_ROOT}/../db/umbrel-seed/seed"
   fi
 


### PR DESCRIPTION
This PR makes sure we use the seed from the real Umbrel installation in the entropy generator function during an OTA update.

@lukechilds 