### PR TITLE
Update loop service to v0.11.4 in ride-the-lightning app

### DIFF
--- a/apps/ride-the-lightning/docker-compose.yml
+++ b/apps/ride-the-lightning/docker-compose.yml
@@ -39,7 +39,7 @@ services:
         ipv4_address: $APP_RIDE_THE_LIGHTNING_IP
 
   loop:
-    image: louneskmt/loop:v0.11.2-beta@sha256:97b481a52e3b3f336a21d3be0eb1414dcd72e230de2e22a57287d15aab0a7af0
+    image: louneskmt/loop:v0.11.4-beta@sha256:5e9d882921ca74abdbf613428406e32ffb48a635235cd2c9710fe2a28a225271
     user: "1000:1000"
     logging: *default-logging
     restart: on-failure
@@ -52,7 +52,7 @@ services:
     command:
       - --network=$BITCOIN_NETWORK
       - --lnd.host="$LND_IP:$LND_GRPC_PORT"
-      - --lnd.macaroondir="/lnd/data/chain/bitcoin/$BITCOIN_NETWORK"
+      - --lnd.macaroonpath="/lnd/data/chain/bitcoin/$BITCOIN_NETWORK/admin.macaroon"
       - --lnd.tlspath="/lnd/tls.cert"
       - --restlisten=0.0.0.0:8081
     networks:


### PR DESCRIPTION
This PR updates loop service to latest v0.11.4-beta.

Don't forget to also merge #445, providing a fix for Loop (which cannot work on RTL without it).