### PR TITLE
Update to Tor v0.4.4.7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ x-logging: &default-logging
 services:
         tor:
                 container_name: tor
-                image: getumbrel/tor:v0.4.1.9
+                image: lncm/tor:0.4.4.7
                 user: toruser
                 restart: on-failure
                 logging: *default-logging


### PR DESCRIPTION
This release has mitigations against the DoS attacks on Tor v3 hidden services.

```
Major bugfixes (onion service v3, backport from 0.4.5.3-rc):
Stop requiring a live consensus for v3 clients and services, and allow a "reasonably live" consensus instead. This allows v3 onion services to work even if the authorities fail to generate a consensus for more than 2 hours in a row. Fixes bug 40237; bugfix on 0.3.5.1-alpha.

Major feature (exit, backport from 0.4.5.5-rc):
Re-entry into the network is now denied at the Exit level to all relays' ORPorts and authorities' ORPorts and DirPorts. This change should help mitgate a set of denial-of-service attacks. Closes ticket 2667.
```

- https://blog.torproject.org/node/1990