### PR TITLE
Update to getumbrel/neutrino-switcher:v1.2.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,7 +155,7 @@ services:
                         ipv4_address: $MIDDLEWARE_IP
         neutrino-switcher:
                 container_name: neutrino-switcher
-                image: getumbrel/neutrino-switcher:v1.1.1
+                image: getumbrel/neutrino-switcher:v1.2.0
                 logging: *default-logging
                 depends_on: [ bitcoin, lnd ]
                 restart: on-failure


### PR DESCRIPTION
This removes the `feeurl` param from #518 after IBD.