### PR TITLE
Umbrel v0.3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Make sure your User ID is `1000` (verify it by running `id -u`) and ensure that 
 > Run this in an empty directory where you want to install Umbrel. If using an external storage such as an SSD or HDD, run this inside an empty directory on that drive.
 
 ```bash
-curl -L https://github.com/getumbrel/umbrel/archive/v0.3.3.tar.gz | tar -xz --strip-components=1
+curl -L https://github.com/getumbrel/umbrel/archive/v0.3.4.tar.gz | tar -xz --strip-components=1
 ```
 
 ### Step 2. Run Umbrel

--- a/info.json
+++ b/info.json
@@ -2,5 +2,5 @@
     "version": "0.3.3",
     "name": "Umbrel v0.3.3",
     "requires": ">=0.2.1",
-    "notes": "Umbrel v0.3.3 is here with 3 brand new apps in the Umbrel App Store — Samourai Server (Dojo + Whirlpool), Mempool, LNbits —  a totally redesigned wallet connector, Lightning Pool, Bitcoin Core v0.21.0, and more.\n\nIf your update gets stuck for some reason, please message us on Telegram: https://t.me/getumbrel"
+    "notes": "Umbrel v0.3.4 fixes a minor bug in v0.3.3 that was causing the update process to fail for some users.\n\nHere's the release notes for Umbrel v0.3.3:\n\nUmbrel v0.3.3 is here with 3 brand new apps in the Umbrel App Store — Samourai Server (Dojo + Whirlpool), Mempool, LNbits —  a totally redesigned wallet connector, Lightning Pool, Bitcoin Core v0.21.0, and more.\n\nIf your update gets stuck for some reason, please message us on Telegram: https://t.me/getumbrel"
 }

--- a/info.json
+++ b/info.json
@@ -2,5 +2,5 @@
     "version": "0.3.3",
     "name": "Umbrel v0.3.3",
     "requires": ">=0.2.1",
-    "notes": "Umbrel v0.3.4 fixes a minor bug in v0.3.3 that was causing the update process to fail for some users.\n\nHere's the release notes for Umbrel v0.3.3:\n\nUmbrel v0.3.3 is here with 3 brand new apps in the Umbrel App Store — Samourai Server (Dojo + Whirlpool), Mempool, LNbits —  a totally redesigned wallet connector, Lightning Pool, Bitcoin Core v0.21.0, and more.\n\nIf your update gets stuck for some reason, please message us on Telegram: https://t.me/getumbrel"
+    "notes": "Umbrel v0.3.4 fixes a minor bug in v0.3.3 that was causing the update process to fail for some users.\n\nHere's what new in Umbrel v0.3.3:\n\nUmbrel v0.3.3 is here with 3 brand new apps in the Umbrel App Store — Samourai Server (Dojo + Whirlpool), Mempool, LNbits —  a totally redesigned wallet connector, Lightning Pool, Bitcoin Core v0.21.0, and more.\n\nIf your update gets stuck for some reason, please message us on Telegram: https://t.me/getumbrel"
 }


### PR DESCRIPTION
Umbrel v0.3.4 fixes a minor bug in v0.3.3 that was causing the update process to fail for some users.

Here's what new in Umbrel v0.3.3:

Umbrel v0.3.3 is here with 3 brand new apps in the Umbrel App Store — Samourai Server (Dojo + Whirlpool), Mempool, LNbits —  a totally redesigned wallet connector, Lightning Pool, Bitcoin Core v0.21.0, and more.

If your update gets stuck for some reason, please message us on Telegram: https://t.me/getumbrel"