### PR TITLE
Only set LND feeurl on Neutrino mainnet

### DIFF
--- a/scripts/configure
+++ b/scripts/configure
@@ -255,6 +255,12 @@ if [[ -f "${STATUS_DIR}/node-status-bitcoind-ready" ]]; then
   sed -i "s/bitcoin.node=.*/bitcoin.node=bitcoind/g;" "$LND_CONF_FILE"
 fi
 
+# Set LND fee URL (but only for mainnet Neutrino)
+LND_FEE_URL=""
+if [[ "$BITCOIN_NETWORK" == "mainnet" ]] && [[ ! -f "${STATUS_DIR}/node-status-bitcoind-ready" ]]; then
+  LND_FEE_URL="https://nodes.lightning.computer/fees/v1/btc-fee-estimates.json"
+fi
+
 # TODO: Update all the above code to use this simpler logic
 for template in "${NGINX_CONF_FILE}" "${BITCOIN_CONF_FILE}" "${LND_CONF_FILE}" "${TOR_CONF_FILE}" "${ELECTRS_CONF_FILE}" "${ENV_FILE}"; do
   # Umbrel
@@ -277,6 +283,7 @@ for template in "${NGINX_CONF_FILE}" "${BITCOIN_CONF_FILE}" "${LND_CONF_FILE}" "
   sed -i "s/<zmq-rawblock-port>/${BITCOIN_ZMQ_RAWBLOCK_PORT}/g;" "${template}"
   sed -i "s/<zmq-rawtx-port>/${BITCOIN_ZMQ_RAWTX_PORT}/g;" "${template}"
   sed -i "s/<zmq-hashblock-port>/${BITCOIN_ZMQ_HASHBLOCK_PORT}/g;" "${template}"
+  sed -i "s#<lndfeeurl>#${LND_FEE_URL}#g;" "${template}"
 
   # Apps
   sed -i "s/<app-btc-rpc-explorer-ip>/${APP_BTC_RPC_EXPLORER_IP}/g" "${template}"

--- a/templates/lnd-sample.conf
+++ b/templates/lnd-sample.conf
@@ -9,7 +9,7 @@ tlsextraip=<lnd-ip>
 tlsextradomain=<hostname>
 tlsautorefresh=1
 tlsdisableautofill=1
-feeurl=https://nodes.lightning.computer/fees/v1/btc-fee-estimates.json
+feeurl=<lndfeeurl>
 
 [Bitcoind]
 bitcoind.rpchost=<bitcoin-ip>


### PR DESCRIPTION
Fixes: https://github.com/getumbrel/umbrel-dashboard/issues/307

Having this set when LND is backed by Bitcoin Core causes our fee estimation logic to fail which means people can't open channels or send transactions from the Umbrel UI.