### PR TITLE
Link to Dojo Maintenance Tools from Samourai Server app

### DIFF
--- a/apps/samourai-server/nginx/connect/css/style.css
+++ b/apps/samourai-server/nginx/connect/css/style.css
@@ -18,6 +18,10 @@ body {
     opacity: 0.8;
 }
 
+.text-small {
+    font-size: 14px;
+}
+
 hr {
     width: 100%;
     height: 2px;
@@ -54,8 +58,6 @@ hr {
     margin: 10px 0 0 0;
 }
 
-
-
 .app > .app-details > .app-name {
     font-size: 52px;
     line-height: 52px;
@@ -63,22 +65,8 @@ hr {
     margin: 10px 0 0 0;
 }
 
-.maintenance-tools a {
-  display: inline-block;
-  background: #C12525;
-  padding: 0.6em 0.8em;
-  border-radius: 5px;
-  text-decoration: none;
-  box-shadow: 0 0 20px 0 rgba(0,0,0,0.8);
-  margin-bottom: 1em;
-}
-
 .heading {
     display: flex;
-}
-
-.maintenance-tools #dojo-admin-key {
-  font-size: 12px;
 }
 
 .heading > .number {
@@ -93,6 +81,7 @@ hr {
     font-weight: bold;
     box-shadow: 0 0 20px 0 rgba(0,0,0,0.8);
 }
+
 .heading > .text {
     font-size: 52px;
     line-height: 52px;
@@ -134,4 +123,21 @@ hr {
     height: 60px;
     margin: 3px 0 0 3px;
     border-radius: 15%;
+}
+
+.note {
+    margin-top: 30px;
+    background: #111010;
+    border-radius: 8px;
+    padding: 30px;
+    border: 2px dashed #3D3838;
+}
+
+.note > .note-heading {
+    margin: 0 0 20px 0;
+    font-weight: 300;
+}
+
+.note > .note-text {
+    word-wrap: break-word
 }

--- a/apps/samourai-server/nginx/connect/css/style.css
+++ b/apps/samourai-server/nginx/connect/css/style.css
@@ -63,8 +63,22 @@ hr {
     margin: 10px 0 0 0;
 }
 
+.maintenance-tools a {
+  display: inline-block;
+  background: #C12525;
+  padding: 0.6em 0.8em;
+  border-radius: 5px;
+  text-decoration: none;
+  box-shadow: 0 0 20px 0 rgba(0,0,0,0.8);
+  margin-bottom: 1em;
+}
+
 .heading {
     display: flex;
+}
+
+.maintenance-tools #dojo-admin-key {
+  font-size: 12px;
 }
 
 .heading > .number {

--- a/apps/samourai-server/nginx/connect/index.html
+++ b/apps/samourai-server/nginx/connect/index.html
@@ -25,12 +25,6 @@
         <p class="text-muted">Follow the instructions below to pair Dojo and Whirlpool running on your Umbrel to your
             Samourai Wallet.
         </p>
-        <div class="maintenance-tools">
-          <a href="/admin/">Dojo Maintenance Tool</a>
-          <div class="text-muted">
-            Admin key: <code id="dojo-admin-key"></code>
-          </div>
-        </div>
     </section>
     <hr />
     <section class="container">
@@ -62,6 +56,15 @@
                 Network Options by tapping the WiFi-like icon on the top to verify if “Dojo Full Node” is successfully
                 enabled (it should display a green dot).</li>
         </ol>
+        <div class="note">
+            <h5 class="note-heading text-muted text-small">Advanced</h5>
+            <p class="note-text">
+                If you need to access the Dojo Maintenance Tool, <a href="/admin/" target="_blank">click here</a>.
+            </p>
+            <p class="note-text text-small">
+                Admin key: <code id="dojo-admin-key"></code>
+            </p>
+        </div>
     </section>
     <hr />
     <section class="container">

--- a/apps/samourai-server/nginx/connect/index.html
+++ b/apps/samourai-server/nginx/connect/index.html
@@ -25,6 +25,12 @@
         <p class="text-muted">Follow the instructions below to pair Dojo and Whirlpool running on your Umbrel to your
             Samourai Wallet.
         </p>
+        <div class="maintenance-tools">
+          <a href="/admin/">Dojo Maintenance Tool</a>
+          <div class="text-muted">
+            Admin key: <code id="dojo-admin-key"></code>
+          </div>
+        </div>
     </section>
     <hr />
     <section class="container">

--- a/apps/samourai-server/nginx/connect/js/conf.template.js
+++ b/apps/samourai-server/nginx/connect/js/conf.template.js
@@ -1,5 +1,5 @@
 var dojoHiddenService = "$DOJO_HIDDEN_SERVICE";
 var whirlpoolHiddenService = "http://$WHIRLPOOL_HIDDEN_SERVICE";
 var bitcoinNetwork = "$COMMON_BTC_NETWORK";
-var apiKey = "$NODE_ADMIN_KEY";
+var dojoAdminKey = "$NODE_ADMIN_KEY";
 var supportPrefix = "$NODE_PREFIX_SUPPORT";

--- a/apps/samourai-server/nginx/connect/js/script.js
+++ b/apps/samourai-server/nginx/connect/js/script.js
@@ -1,3 +1,5 @@
+document.getElementById('dojo-admin-key').innerText = dojoAdminKey;
+
 var baseRoute = bitcoinNetwork == "testnet" ? "test/v2" : "v2";
 
 fetch(`http://${window.location.host}/${baseRoute}/auth/login`, {
@@ -5,7 +7,7 @@ fetch(`http://${window.location.host}/${baseRoute}/auth/login`, {
     headers: new Headers({
       'Content-Type': 'application/x-www-form-urlencoded'
     }),
-    body: `apikey=${apiKey}`
+    body: `apikey=${dojoAdminKey}`
  })
  .then(response => response.json())
  .then(data => {


### PR DESCRIPTION
Adds a link to the Dojo Maintenance Tools from the Samourai Server app. Also gives the user easy access to the randomly generated admin key.

@mayankchhabra if you think it can be made to look better, please go ahead.

<img width="1189" alt="Screenshot 2021-02-17 at 20 00 06" src="https://user-images.githubusercontent.com/2123375/108208355-8444dc00-715b-11eb-951c-b8e59ba9082e.png">

If you wanna run this in a dev environment you'll need to apply the follwing patch to get the Samourai Server app started in regtest mode.

```diff
diff --git a/apps/samourai-server/docker-compose.yml b/apps/samourai-server/docker-compose.yml
index cfb92fb..8dc7938 100644
--- a/apps/samourai-server/docker-compose.yml
+++ b/apps/samourai-server/docker-compose.yml
@@ -116,11 +116,11 @@ services:
     init: true
     logging: *default-logging
     restart: on-failure
-    command: /bin/sh -c "envsubst < /var/www/connect/js/conf.template.js > /var/www/connect/js/conf.js && /wait-for node:8080 --timeout=720 -- nginx"
+    command: /bin/sh -c "envsubst < /var/www/connect/js/conf.template.js > /var/www/connect/js/conf.js && nginx"
     volumes:
       - ${APP_DATA_DIR}/nginx/wait-for:/wait-for
       - ${APP_DATA_DIR}/nginx/nginx.conf:/etc/nginx/nginx.conf
-      - ${APP_DATA_DIR}/nginx/${BITCOIN_NETWORK}.conf:/etc/nginx/sites-enabled/dojo.conf
+      - ${APP_DATA_DIR}/nginx/mainnet.conf:/etc/nginx/sites-enabled/dojo.conf
       - ${APP_DATA_DIR}/nginx/connect:/var/www/connect
     environment:
         COMMON_BTC_NETWORK: $BITCOIN_NETWORK
@@ -130,8 +130,8 @@ services:
         NODE_ADMIN_KEY: $SAMOURAI_SERVER_NODE_ADMIN_KEY
     ports:
       - "$APP_SAMOURAI_SERVER_PORT:80"
-    depends_on:
-      - node
+    # depends_on:
+    #   - node
     networks:
        default:
          ipv4_address: $APP_SAMOURAI_SERVER_IP
```