### PR TITLE
Upload to umbrel-paste.vercel.app in debug script

### DIFF
--- a/scripts/debug
+++ b/scripts/debug
@@ -2,7 +2,7 @@
 
 # This script is based on raspinfo: https://github.com/raspberrypi/utils/blob/master/raspinfo/raspinfo
 # raspinfo is Copyright: 2018-2019, Raspberry Pi (Trading) Ltd.
-# This fork is Copyright 2020, Umbrel
+# This fork is Copyright 2020-2021, Umbrel
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -34,7 +34,7 @@
 
 # function to upload the output to our paste server
 # Based on https://github.com/seejohnrun/haste-client#lightweight-alternative
-haste() { a=$(cat); curl -X POST -s -d "$a" https://umbrel-paste.vercel.app/documents | awk -F '"' '{print "https://umbrel-paste.vercel.app/"$6}'; }
+upload() { a=$(cat); curl -X POST -s -d "$a" https://umbrel-paste.vercel.app/documents | awk -F '"' '{print "https://umbrel-paste.vercel.app/"$6}'; }
 
 echo "====================="
 echo "= Umbrel debug info ="
@@ -156,7 +156,7 @@ if [[ ! -z "${UMBREL_OS:-}" ]]; then
         echo "you can contact us on Telegram (t.me/getumbrel) and share the output of this script."
         if [[ "${1}" == "--upload" ]]; then
             echo "You can also share this link instead:"
-            ./scripts/debug | sed '/onion/d' | haste
+            ./scripts/debug | sed '/onion/d' | upload
             dmesg | haste
         else
             echo "Run this script again with the --upload flag to automatically generate a link to share."
@@ -176,7 +176,7 @@ if [[ "${1}" == "--upload" ]]; then
     # This runs the script twice, but it works
     echo "This script could not automatically detect an issue with your Umbrel."
     echo "Please share the following links and paste it in the Umbrel Telegram group (https://t.me/getumbrel) so we can help you with your problem."
-    ./scripts/debug | sed '/onion/d' | haste
+    ./scripts/debug | sed '/onion/d' | upload
     dmesg | haste
 else
     echo "This script could not automatically detect an issue with your Umbrel."

--- a/scripts/debug
+++ b/scripts/debug
@@ -32,9 +32,9 @@
 # Try to load Umbrel OS version info to detect Umbrel OS
 [[ -f "/etc/default/umbrel" ]] && source "/etc/default/umbrel"
 
-# function to upload the output to hastebin
-# Source: https://github.com/seejohnrun/haste-client#lightweight-alternative
-haste() { a=$(cat); curl -X POST -s -d "$a" https://hastebin.com/documents | awk -F '"' '{print "https://hastebin.com/"$4}'; }
+# function to upload the output to our paste server
+# Based on https://github.com/seejohnrun/haste-client#lightweight-alternative
+haste() { a=$(cat); curl -X POST -s -d "$a" https://umbrel-paste.vercel.app/documents | awk -F '"' '{print "https://umbrel-paste.vercel.app/"$6}'; }
 
 echo "====================="
 echo "= Umbrel debug info ="


### PR DESCRIPTION
Please note that on shorter, one line strings, you'll get an error "Content is too short", but not with the debug script (tested on a manual install, not Umbrel OS and not containers running for shortest possible output)