### PR TITLE
Remove hardcoded SSH password from SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,10 +32,6 @@ We plan to resolve this by implementing SSO authentication across all apps. We c
 
 This means all Umbrel apps exposing a web interface will be protected by your Umbrel dashboard password.
 
-**SSH password of Umbrel OS.**
-
-Umbrel OS's current SSH password is same for all Umbrel OS users. In the future we'll have it automatically change to the user's dashboard password, but for now if a malicious actor is on the same network as your Umbrel node (running Umbrel OS), they could SSH into your node using the publicly available password. For that reason, we recommend advanced users to manually update their SSH password.
-
 **Relaxed Permissions**
 
 Currently we are being quite liberal with filesystem permissions and root usage. Some background jobs on the host are currently being run as root that don't strictly need to. Also some scripts executed by root are writable by non-root users. The `umbrel` user itself is also currently added to the `docker` group which makes it essentially root.


### PR DESCRIPTION
Since https://github.com/getumbrel/umbrel/pull/429 and https://github.com/getumbrel/umbrel-manager/pull/77 the SSH password is now set as the user's dashboard password.