### PR TITLE
Disable AMilk extension in lnbits app

### DIFF
--- a/apps/lnbits/docker-compose.yml
+++ b/apps/lnbits/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       # App
       LNBITS_SITE_TITLE: "LNbits - Umbrel"
       LNBITS_DEFAULT_WALLET_NAME: "LNbits wallet"
+      LNBITS_DISABLED_EXTENSIONS: "amilk"
     networks:
         default:
           ipv4_address: $APP_LNBITS_IP


### PR DESCRIPTION
>Keep amilk disabled, its too buggy/resource intensive to have easy access to
@arcbtc - https://github.com/getumbrel/umbrel/pull/372#issuecomment-778761656