### PR TITLE
Increase NGINX proxy timeout to 10 minutes

### DIFF
--- a/templates/nginx-sample.conf
+++ b/templates/nginx-sample.conf
@@ -10,6 +10,8 @@ events {
 http {
 	access_log /dev/stdout;
 
+	proxy_read_timeout 600;
+
 	default_type application/octet-stream;
 
 	server {


### PR DESCRIPTION
Sometimes services that we proxy to can take a long time to respond, typically LND or Bitcoin Core.

Many users have reported being stuck on the login screen with `Loading LND...` indefinitely. The issue appears to be that the default NGINX timeout of 30 seconds is too small. If LND is busy and taking 35 seconds to respond to our requests, each request will timeout after 30 seconds and the dashboard will never load.

We always want to let users hang on page until an action completes instead of just returning an error and not let them see if the action was successful or not. So increasing the timeout from 30 seconds to 10 minutes seems like a reasonable solution for our use case.