### PR TITLE
Update mempool app to v2.1.2

### DIFF
--- a/apps/mempool/docker-compose.yml
+++ b/apps/mempool/docker-compose.yml
@@ -8,7 +8,7 @@ x-logging:
 
 services:
   web:
-    image: mempool/frontend:v2.1.1@sha256:17e7fedcd27b6f99de2f159f0f6372b76dd5825f1a98c1b0114ea9564cab1c0e
+    image: mempool/frontend:v2.1.2@sha256:69fefe55dc1eb4c8373c32d57362df7eeb672fc591d55033d68ae79355274dcc
     user: "1000:1000"
     init: true
     logging: *default-logging
@@ -24,7 +24,7 @@ services:
       default:
         ipv4_address: $APP_MEMPOOL_IP
   api:
-    image: mempool/backend:v2.1.1@sha256:c15c3d1af0f9df4672f3760b0ff9b79d1dd60235cde7316a7860b1d650b31360
+    image: mempool/backend:v2.1.2@sha256:58394cb35aad82b95ab2496fd4a6d3c983a712a1003454d94b0a53197d306f6d
     user: "1000:1000"
     init: true
     logging: *default-logging
@@ -44,7 +44,7 @@ services:
       MYSQL_DATABASE: "mempool"
       MYSQL_USER: "mempool"
       MYSQL_PASS: "mempool"
-      CACHE_DIR: "/backend/cache/"
+      CACHE_DIR: "/backend/cache"
     networks:
        default:
          ipv4_address: $APP_MEMPOOL_API_IP

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -3,7 +3,7 @@
         "id": "mempool",
         "category": "Explorers",
         "name": "Mempool",
-        "version": "2.1.1",
+        "version": "2.1.2",
         "tagline": "A mempool visualizer, explorer and fee estimator",
         "description": "Mempool is the official self-hosted version of the fully featured explorer, visualizer, fee estimator, and API service running on mempool.space, an open source project developed and operated for the benefit of the Bitcoin community, with a focus on the emerging transaction fee market to help our transition into a multi-layer ecosystem.\n\nFeatures:\n\n- Live dashboard visualizing the mempool and blockchain\n- Live transaction tracking\n- Search any transaction, block or address\n- Fee estimations\n- Mempool historical data\n- TV View for larger displays as a TV in a cafe or bar\n- View transaction scripts and op_return messages\n- Audio notifications on transaction confirmed and address balance change\n- Multiple languages support\n- JSON APIs",
         "developer": "mempool.space",


### PR DESCRIPTION
```
This is a patch release that optimizes memory usage for embedded devices like Raspberry Pi

Notes:

The disk cache now has its own folder, so mv cache*.json ./cache/ before restart to migrate
Changes:

Optimize memory usage when writing disk cache (#342)
Reduce backend maximum heap size setting to 2G (#345)
Enable mempool clear protection on all backends (#335)
Make mempool clear protection timeout configurable (#343)
Minor tweaks to About page text, links (#350)
Logo design update (#349) by @pedromvpg
Fix style on block hover (#347) by @Czino and @Eric-Machinas
```