### PR TITLE
Rename mempool db container to mariadb

### DIFF
--- a/apps/mempool/docker-compose.yml
+++ b/apps/mempool/docker-compose.yml
@@ -48,7 +48,7 @@ services:
     networks:
        default:
          ipv4_address: $APP_MEMPOOL_API_IP
-  db:
+  mariadb:
     image: mariadb:10.5.8
     user: "1000:1000"
     logging: *default-logging


### PR DESCRIPTION
Resolves #572 

This prevents a hostname collision between the samourai-server_db and mempool_db container.

The samourai-server_node container connects to the DB via the `db` hostname. It was expected that this would always resolve to the IP of the `db` service local to the Docker Compose configuration it was called from. However in some cases it appears that when `db` is requested from samourai-server_node it resolves to the IP of mempool_db instead of samourai-server_db.

Renaming from mempool_db to mempool_mariadb is a quick fix to ensure this won't ever happen. However ideally we would be able to pass in an explicit DB IP to the samourai-server_node container instead of relying on Docker's hostname resolver.