### PR TITLE
Ensure NGINX stays alive while Bitcoin Core is shutting down

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
                 container_name: bitcoin
                 image: lncm/bitcoind:v0.21.0
                 logging: *default-logging
-                depends_on: [ tor, manager ]
+                depends_on: [ tor, manager, nginx ]
                 volumes:
                         - ${PWD}/bitcoin:/data/.bitcoin
                 restart: on-failure


### PR DESCRIPTION
This ensures the NGINX proxy doesn't shutdown until after Bitcoin Core has finished.

Otherwise if Bitcoin Core takes a long time to shutdown, which can on occasion take up to ~5 minutes, NGINX will shutdown right at the beginning of the process, the API server will be unavailable, and OTA updates will have no progress updates, and shutdown status will tell the user the device is shutdown before Bitcoin Core has finished.

We already had manager added as a dep for Bitcoin Core for this reason, but we also need NGINX too since that's what is forwarding requests on to manager.