### PR TITLE
Add port to device hosts (for CORS)

### DIFF
--- a/scripts/start
+++ b/scripts/start
@@ -55,6 +55,7 @@ echo
 DEVICE_IP="$(ip -o route get to 8.8.8.8 | sed -n 's/.*src \([0-9.]\+\).*/\1/p')"
 DEVICE_HOSTNAME="$(hostname)"
 DEVICE_HOSTS="http://${DEVICE_IP},http://${DEVICE_HOSTNAME}.local,https://${DEVICE_HOSTNAME}.local,http://${DEVICE_HOSTNAME},https://${DEVICE_HOSTNAME}"
+DEVICE_HOSTS="${DEVICE_HOSTS},$(echo $DEVICE_HOSTS | sed -e "s/,/:${NGINX_PORT},/g"):${NGINX_PORT}"
 if [[ -f "${UMBREL_ROOT}/tor/data/web/hostname" ]]; then
     hidden_service_url=$(cat "${UMBREL_ROOT}/tor/data/web/hostname")
     DEVICE_HOSTS="${DEVICE_HOSTS},http://${hidden_service_url}"


### PR DESCRIPTION
This PR adds device hosts with nginx port to the device hosts list, for CORS. Without this, setting a custom `NGINX_PORT` will lead to a "Not allowed by CORS" on dashboard login.

Fixes https://github.com/getumbrel/umbrel/issues/584, https://github.com/getumbrel/umbrel/issues/398#issuecomment-759069511.