### PR TITLE
Switch to debug.umbrel.tech

### DIFF
--- a/scripts/debug
+++ b/scripts/debug
@@ -40,8 +40,8 @@ upload() {
     --request POST \
     --silent \
     --data-binary @- \
-    https://umbrel-paste.vercel.app/documents \
-    | awk -F '"' '{print "https://umbrel-paste.vercel.app/"$6}'
+    https://debug.umbrel.tech/documents \
+    | awk -F '"' '{print "https://debug.umbrel.tech/"$6}'
 }
 
 echo "====================="


### PR DESCRIPTION
I'm moving all of the Umbrel services I provide to that place now, so it's in a more centralized place and not over a lot of different services/domains. The old domain still works.