### PR TITLE
docker:revert docker-compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '2.2'
 x-logging: &default-logging
     driver: journald
     options:


### PR DESCRIPTION
This is necessary to build/deploy Umbrel on raspi os from the git repository.
