### PR TITLE
Fix frontail not following rotated syslog file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -180,7 +180,7 @@ services:
             restart: on-failure
             command: "/var/log/syslog --url-path /logs --number 100 --disable-usage-stats"
             volumes:
-                - /var/log/syslog:/var/log/syslog:ro
+                - /var/log:/var/log:ro
             networks:
                 default:
                     ipv4_address: $FRONTAIL_IP


### PR DESCRIPTION
When logrotate executes, it moves `/var/log/syslog` to `/var/log/syslog.1`
and syslog continues writing to the new file. Frontail uses `tail` (good!)
which on Linux implements two follow modes:

* `--follow=name`, which will read whatever is at the filename, even if
  the underlying file is moved, and
* `--follow=descriptor`, which will follow the inode around.

Frontail uses `tail -F` which is an alias for `--follow=name`. The familiar
`tail -f` is an alias for `--follow=descriptor`.

So frontail is doing the right thing here. What's the problem?

The issue is that docker is volume-mounting the descriptor, not the file
path. When logrotate rotates the file, it stops being written to, and
the file inside the container remains the (now rotated and idle) file.

To solve this, we can simply volume-mount the whole folder, and then
`tail -F` can work its usual magic.

Fixes #361
Fixes #575