### PR TITLE
Refactor Tor container volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,9 @@ services:
                 image: lncm/tor:0.4.5.7@sha256:a83e0d9fd1a35adf025f2f34237ec1810e2a59765988dce1dfb222ca8ef6583c
                 user: toruser
                 restart: on-failure
+                command: "-f /data/torrc"
                 volumes:
-                    - ${PWD}/tor/torrc:/etc/tor/torrc
-                    - ${PWD}/tor/data:/var/lib/tor/
-                    - ${PWD}/tor/run:/var/run/tor/
+                    - ${PWD}/tor:/data
                 ports:
                   - "127.0.0.1:$TOR_PROXY_PORT:$TOR_PROXY_PORT"
                 networks:

--- a/templates/torrc-sample
+++ b/templates/torrc-sample
@@ -8,75 +8,75 @@ DataDirectory /data/data
 # Umbrel
 
 # Dashboard Hidden Service
-HiddenServiceDir /var/lib/tor/web
+HiddenServiceDir /data/data/web
 HiddenServicePort 80 <nginx-ip>:80
 
 # Bitcoin Core P2P Hidden Service
-HiddenServiceDir /var/lib/tor/bitcoin-p2p
+HiddenServiceDir /data/data/bitcoin-p2p
 HiddenServicePort <bitcoin-p2p-port> <bitcoin-ip>:<bitcoin-p2p-port>
 
 # Bitcoin Core RPC Hidden Service
-HiddenServiceDir /var/lib/tor/bitcoin-rpc
+HiddenServiceDir /data/data/bitcoin-rpc
 HiddenServicePort <bitcoin-rpc-port> <bitcoin-ip>:<bitcoin-rpc-port>
 
 # Electrum Hidden Service
-HiddenServiceDir /var/lib/tor/electrum
+HiddenServiceDir /data/data/electrum
 HiddenServicePort <electrum-port> <electrum-ip>:<electrum-port>
 
 # LND REST Hidden Service
-HiddenServiceDir /var/lib/tor/lnd-rest
+HiddenServiceDir /data/data/lnd-rest
 HiddenServicePort <lnd-rest-port> <lnd-ip>:<lnd-rest-port>
 
 # LND gRPC Hidden Service
-HiddenServiceDir /var/lib/tor/lnd-grpc
+HiddenServiceDir /data/data/lnd-grpc
 HiddenServicePort <lnd-grpc-port> <lnd-ip>:<lnd-grpc-port>
 
 # Apps
 
 # btc-rpc-explorer Hidden Service
-HiddenServiceDir /var/lib/tor/app-btc-rpc-explorer
+HiddenServiceDir /data/data/app-btc-rpc-explorer
 HiddenServicePort 80 <app-btc-rpc-explorer-ip>:<app-btc-rpc-explorer-port>
 
 # thunderhub Hidden Service
-HiddenServiceDir /var/lib/tor/app-thunderhub
+HiddenServiceDir /data/data/app-thunderhub
 HiddenServicePort 80 <app-thunderhub-ip>:<app-thunderhub-port>
 
 # sphinx-relay Hidden Service
 # We expose 80 for the connection string UI and <app-sphinx-relay-port> for the
 # actual server connection
-HiddenServiceDir /var/lib/tor/app-sphinx-relay
+HiddenServiceDir /data/data/app-sphinx-relay
 HiddenServicePort 80 <app-sphinx-relay-ip>:<app-sphinx-relay-port>
 HiddenServicePort <app-sphinx-relay-port> <app-sphinx-relay-ip>:<app-sphinx-relay-port>
 
 # ride-the-lightning Hidden Service
-HiddenServiceDir /var/lib/tor/app-ride-the-lightning
+HiddenServiceDir /data/data/app-ride-the-lightning
 HiddenServicePort 80 <app-ride-the-lightning-ip>:<app-ride-the-lightning-port>
 
 # lightning-terminal Hidden Service
-HiddenServiceDir /var/lib/tor/app-lightning-terminal
+HiddenServiceDir /data/data/app-lightning-terminal
 HiddenServicePort 80 <app-lightning-terminal-ip>:<app-lightning-terminal-port>
 
 # specter-desktop Hidden Service
-HiddenServiceDir /var/lib/tor/app-specter-desktop
+HiddenServiceDir /data/data/app-specter-desktop
 HiddenServicePort 80 <app-specter-desktop-ip>:<app-specter-desktop-port>
 
 # btcpay-server Hidden Service
-HiddenServiceDir /var/lib/tor/app-btcpay-server
+HiddenServiceDir /data/data/app-btcpay-server
 HiddenServicePort 80 <app-btcpay-server-ip>:<app-btcpay-server-port>
 
 # lnbits Hidden Service
-HiddenServiceDir /var/lib/tor/app-lnbits
+HiddenServiceDir /data/data/app-lnbits
 HiddenServicePort 80 <app-lnbits-ip>:<app-lnbits-port>
 # mempool Hidden Service
-HiddenServiceDir /var/lib/tor/app-mempool
+HiddenServiceDir /data/data/app-mempool
 HiddenServicePort 80 <app-mempool-ip>:<app-mempool-port>
 
 # samourai-server Hidden Service
-HiddenServiceDir /var/lib/tor/app-samourai-server
+HiddenServiceDir /data/data/app-samourai-server
 HiddenServicePort 80 <app-samourai-server-ip>:80
 
 # samourai-server whirlpool Hidden Service
-HiddenServiceDir /var/lib/tor/app-samourai-server-whirlpool
+HiddenServiceDir /data/data/app-samourai-server-whirlpool
 HiddenServicePort 80 <app-samourai-server-whirlpool-ip>:<app-samourai-server-whirlpool-port>
 
 HashedControlPassword <password>

--- a/templates/torrc-sample
+++ b/templates/torrc-sample
@@ -2,6 +2,9 @@
 SocksPort   <tor-proxy-ip>:<tor-proxy-port>
 ControlPort <tor-proxy-ip>:29051
 
+# Store working data in the mounted Umbrel directory
+DataDirectory /data/data
+
 # Umbrel
 
 # Dashboard Hidden Service


### PR DESCRIPTION
This PR modifies volumes management for the Tor container: the whole `tor` directory is now mounted into the container (instead of sub dirs and files one by one), and the data directory (containing hidden services data) is set accordingly to the new path.

w/ @lukechilds 