### PR TITLE
Update Tor to 0.4.5.7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ x-logging: &default-logging
 services:
         tor:
                 container_name: tor
-                image: lncm/tor:0.4.4.7@sha256:48094db3afff76472b20cd7b6a41151ef5e380e5ec5e6042c36b0f861236c45f
+                image: lncm/tor:0.4.5.7@sha256:5a00971a00143b46e57fd2ce577fe54ed6a5450fa9f463f6876b3616b5dc1dbb
                 user: toruser
                 restart: on-failure
                 logging: *default-logging


### PR DESCRIPTION
https://twitter.com/torproject/status/1371872484773883904?s=21

I directly updated to 0.4.5.7, not 0.4.4.8, because 0.4.5.7 is the latest version and has no breaking changes.

These versions resolve some denial of service attack vectors.