### PR TITLE
Update sphinx-relay app to v2.0.3

### DIFF
--- a/apps/registry.json
+++ b/apps/registry.json
@@ -97,7 +97,7 @@
         "id": "sphinx-relay",
         "category": "Messaging",
         "name": "Sphinx Relay",
-        "version": "1.3.8",
+        "version": "2.0.3",
         "tagline": "Chat and pay over the Lightning Network",
         "description": "Sphinx Relay turns your Lightning node into a personal communication server. Messages are end-to-end encrypted and transmitted over the Bitcoin Lightning Network. Download Sphinx on your phone from https://sphinx.chat and pair it with Sphinx Relay on Umbrel.\n\nCommunication between Sphinx Relay nodes takes place entirely on the Lightning Network, so it is decentralized, untraceable, and encrypted. Messages are encrypted using client public keys on the Sphinx app.\n\nYou can join tribes at https://tribes.sphinx.chat. If you join a podcast tribe, you can listen to the podcast in Sphinx and stream donations to the host.",
         "developer": "Stakwork",

--- a/apps/sphinx-relay/docker-compose.yml
+++ b/apps/sphinx-relay/docker-compose.yml
@@ -8,7 +8,7 @@ x-logging: &default-logging
 services:
   sphinx-relay:
     container_name: sphinx-relay
-    image: sphinxlightning/sphinx-relay:v1.3.8@sha256:cfffa6a821356838a0079d2ea8720d4f7f4415275535812da815b6db0ca67149
+    image: sphinxlightning/sphinx-relay:v2.0.3@sha256:9864925add480da27f04b82226d4dc0144c99941fae8c8e6e748c9705ec3bd36
     init: true
     restart: on-failure
     stop_grace_period: 1m


### PR DESCRIPTION
This version is needed for compatibility between Umbrel nodes and newer Sphinx Relay nodes.