### PR TITLE
Prefer container IPs over hostnames in btcpay-server app

### DIFF
--- a/apps/btcpay-server/docker-compose.yml
+++ b/apps/btcpay-server/docker-compose.yml
@@ -31,7 +31,7 @@ services:
         ipv4_address: $APP_BTCPAY_SERVER_NBXPLORER_IP
 
   web:
-    image: btcpayserver/btcpayserver:1.0.6.8@sha256:10c6acff736b869b731ebb1609c6bd33ecab469b5be4bb5ede8614347466abfc
+    image: btcpayserver/btcpayserver:1.0.7.0@sha256:a18d7133dc858d3596f05b8b0f570396f963ce325713e670fe2b4cb633eb50f8
     user: "1000:1000"
     logging: *default-logging
     restart: on-failure

--- a/apps/btcpay-server/docker-compose.yml
+++ b/apps/btcpay-server/docker-compose.yml
@@ -49,11 +49,11 @@ services:
         BTCPAY_DATADIR: "/data"
         BTCPAY_PLUGINDIR: "/data/plugins"
         BTCPAY_DOCKERDEPLOYMENT: "false"
-        BTCPAY_POSTGRES: "User ID=postgres;Host=postgres;Port=5432;Database=btcpayserver$BITCOIN_NETWORK"
+        BTCPAY_POSTGRES: "User ID=postgres;Host=$APP_BTCPAY_SERVER_DB_IP;Port=5432;Database=btcpayserver$BITCOIN_NETWORK"
         BTCPAY_NETWORK: "$BITCOIN_NETWORK"
         BTCPAY_BIND: 0.0.0.0:$APP_BTCPAY_SERVER_PORT
         BTCPAY_CHAINS: "btc"
-        BTCPAY_BTCEXPLORERURL: "http://nbxplorer:32838"
+        BTCPAY_BTCEXPLORERURL: "http://$APP_BTCPAY_SERVER_NBXPLORER_IP:32838"
         BTCPAY_BTCLIGHTNING: "type=lnd-rest;server=https://$LND_IP:$LND_REST_PORT/;macaroonfilepath=/lnd/data/chain/bitcoin/$BITCOIN_NETWORK/admin.macaroon;allowinsecure=true"
         BTCPAY_SOCKSENDPOINT: $TOR_PROXY_IP:$TOR_PROXY_PORT
     networks:


### PR DESCRIPTION
Using hostnames can cause issues if another container on the same network has the same hostname.