### PR TITLE
Prefer container IPs over hostnames in ride-the-lightning app

### DIFF
--- a/apps/ride-the-lightning/docker-compose.yml
+++ b/apps/ride-the-lightning/docker-compose.yml
@@ -33,7 +33,7 @@ services:
         CONFIG_PATH: "/lnd/lnd.conf"
 
         # Loop
-        SWAP_SERVER_URL: "https://loop:8081"
+        SWAP_SERVER_URL: "https://$APP_RIDE_THE_LIGHTNING_LOOP_IP:8081"
         SWAP_MACAROON_PATH: "/loop/.loop/$BITCOIN_NETWORK"
     networks:
       default:


### PR DESCRIPTION
Using hostnames can cause issues if another container on the same network has the same hostname.