### PR TITLE
Auto unlock LND on boot

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
                         ipv4_address: $LND_IP
         dashboard:
                 container_name: dashboard
-                image: getumbrel/dashboard:v0.3.18@sha256:56a964bb624551345480cc442ddfd065c561d42192877dfcf49a925bcfb3b2a7
+                image: lukechilds/dashboard:lnd-unlocker
                 logging: *default-logging
                 restart: on-failure
                 stop_grace_period: 1m30s
@@ -75,7 +75,7 @@ services:
                         ipv4_address: $DASHBOARD_IP
         manager:
                 container_name: manager
-                image: getumbrel/manager:v0.2.10@sha256:aaeddfd7bd861dc9c418b34a4a4aa83a873e8b0304e28999d1d594eabf0e1b70
+                image: lukechilds/manager:lnd-unlocker
                 logging: *default-logging
                 depends_on: [ tor ]
                 restart: on-failure
@@ -131,7 +131,7 @@ services:
                         ipv4_address: $MANAGER_IP
         middleware:
                 container_name: middleware
-                image: getumbrel/middleware:v0.1.9@sha256:8001338c3e6804afc9078eb08e8ee820e9d2c908a44303a3e4968ab57c8ad90b
+                image: lukechilds/middleware:lnd-unlocker
                 logging: *default-logging
                 depends_on: [ manager, bitcoin, lnd ]
                 command: ["./wait-for-node-manager.sh", $MANAGER_IP, "npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
                         ipv4_address: $LND_IP
         dashboard:
                 container_name: dashboard
-                image: lukechilds/dashboard:lnd-unlocker
+                image: lukechilds/dashboard:decouple-bitcoin
                 logging: *default-logging
                 restart: on-failure
                 stop_grace_period: 1m30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
                         ipv4_address: $DASHBOARD_IP
         manager:
                 container_name: manager
-                image: lukechilds/manager:lnd-unlocker
+                image: lukechilds/manager:remove-builder-image
                 logging: *default-logging
                 depends_on: [ tor ]
                 restart: on-failure


### PR DESCRIPTION
Related:

- https://github.com/getumbrel/umbrel-middleware/pull/82
- https://github.com/getumbrel/umbrel-manager/pull/85
- https://github.com/getumbrel/umbrel-dashboard/pull/326

This PR is just to aid in the testing of the LND auto unlock functionality implemented in the above PRs, it won't be merged into this repo.

Before testing this PR you should change your Umbrel password to something that is **not** `moneyprintergobrrr`.

Once that's done, you can update to this branch with:
```
sudo scripts/update/update --repo lukechilds/umbrel#lnd-unlocker
```

If you successfully log in with your password, manager should automatically use that password to change your LND wallet to use the new hardcoded `moneyprintergobrrr` password.

If you reboot your Umbrel, LND should be automatically unlocked on the next boot before you login.

If you reset your Umbrel, the LND wallet should use the hardcoded `moneyprintergobrrr` password, not the users dashboard password.

This is handy to keep track of the LND lock state:

```
docker-compose logs -f middleware | grep LndUnlocker
```

**Note:** On mainnet it can take ~1.5 minutes to do the initial login since it's blocked by the LND wallet password change. That's just a one time occurrence, all future logins are much quicker because the wallet is already unlocked.
