### PR TITLE
Disable journald logging

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -96,16 +96,9 @@ Let's copy-paste the following template `docker-compose.yml` file in a text edit
 ```yml
 version: "3.7"
 
-x-logging:
-  &default-logging
-  driver: journald
-  options:
-    tag: "umbrel-app {{.Name}}"
-
 services:
   web:
     image: <docker-image>:<tag>
-    logging: *default-logging
     restart: on-failure
     stop_grace_period: 1m
     ports:

--- a/apps/btc-rpc-explorer/docker-compose.yml
+++ b/apps/btc-rpc-explorer/docker-compose.yml
@@ -1,15 +1,8 @@
 version: "3.7"
 
-x-logging:
-  &default-logging
-  driver: journald
-  options:
-    tag: "umbrel-app {{.Name}}"
-
 services:
   web:
     image: getumbrel/btc-rpc-explorer:v2.2.0@sha256:0caa2adf7d480c366942f565543c97b589bcbf8298180d7a143e73f484c04c9f
-    logging: *default-logging
     restart: on-failure
     stop_grace_period: 1m
     ports:

--- a/apps/btcpay-server/docker-compose.yml
+++ b/apps/btcpay-server/docker-compose.yml
@@ -1,16 +1,9 @@
 version: "3.7"
 
-x-logging:
-  &default-logging
-  driver: journald
-  options:
-    tag: "umbrel-app {{.Name}}"
-
 services:
   nbxplorer:
     image: "nicolasdorier/nbxplorer:2.1.49@sha256:b247343d3127c737ed2ce250e780e52a958241fff1d897a5b6e8cd20fb5f142a"
     user: "1000:1000"
-    logging: *default-logging
     restart: on-failure
     stop_grace_period: 1m
     volumes:
@@ -33,7 +26,6 @@ services:
   web:
     image: btcpayserver/btcpayserver:1.0.7.0@sha256:a18d7133dc858d3596f05b8b0f570396f963ce325713e670fe2b4cb633eb50f8
     user: "1000:1000"
-    logging: *default-logging
     restart: on-failure
     stop_grace_period: 1m
     depends_on: [ nbxplorer, postgres ]

--- a/apps/lightning-terminal/docker-compose.yml
+++ b/apps/lightning-terminal/docker-compose.yml
@@ -1,16 +1,9 @@
 version: "3.7"
 
-x-logging:
-  &default-logging
-  driver: journald
-  options:
-    tag: "umbrel-app {{.Name}}"
-
 services:
   web:
     image: lightninglabs/lightning-terminal:v0.4.1-alpha@sha256:624376ebaf286cf7118ca271ed43fb852be4aad814c1f4f6a56634f673671a4a
     user: "1000:1000"
-    logging: *default-logging
     restart: on-failure
     stop_grace_period: 1m
     ports:

--- a/apps/lnbits/docker-compose.yml
+++ b/apps/lnbits/docker-compose.yml
@@ -1,17 +1,10 @@
 version: "3.7"
 
-x-logging:
-  &default-logging
-  driver: journald
-  options:
-    tag: "umbrel-app {{.Name}}"
-
 services:
   web:
     image: louneskmt/lnbits:8188ae0@sha256:191b1696e8a532dfd94f982cd8249e7896dfd69c25fbe0a8437b0d08795670ef
     user: 1000:1000
     init: true
-    logging: *default-logging
     restart: on-failure
     stop_grace_period: 1m
     ports:

--- a/apps/mempool/docker-compose.yml
+++ b/apps/mempool/docker-compose.yml
@@ -1,17 +1,10 @@
 version: "3.7"
 
-x-logging:
-  &default-logging
-  driver: journald
-  options:
-    tag: "umbrel-app {{.Name}}"
-
 services:
   web:
     image: mempool/frontend:v2.1.2@sha256:69fefe55dc1eb4c8373c32d57362df7eeb672fc591d55033d68ae79355274dcc
     user: "1000:1000"
     init: true
-    logging: *default-logging
     restart: on-failure
     stop_grace_period: 1m
     command: "./wait-for mariadb:3306 --timeout=720 -- nginx -g 'daemon off;'"
@@ -27,7 +20,6 @@ services:
     image: mempool/backend:v2.1.2@sha256:58394cb35aad82b95ab2496fd4a6d3c983a712a1003454d94b0a53197d306f6d
     user: "1000:1000"
     init: true
-    logging: *default-logging
     restart: on-failure
     stop_grace_period: 1m
     command: "./wait-for-it.sh mariadb:3306 --timeout=720 --strict -- ./start.sh"
@@ -51,7 +43,6 @@ services:
   mariadb:
     image: mariadb:10.5.8@sha256:8040983db146f729749081c6b216a19d52e0973134e2e34c0b4fd87f48bc15b0
     user: "1000:1000"
-    logging: *default-logging
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/apps/ride-the-lightning/docker-compose.yml
+++ b/apps/ride-the-lightning/docker-compose.yml
@@ -1,16 +1,9 @@
 version: "3.7"
 
-x-logging:
-  &default-logging
-  driver: journald
-  options:
-    tag: "umbrel-app {{.Name}}"
-
 services:
   web:
     image: shahanafarooqui/rtl:0.10.1@sha256:d076f91c4b994d3059d3c0db80dc560ca05f675924d5625bae724df473877882
     user: "1000:1000"
-    logging: *default-logging
     restart: on-failure
     stop_grace_period: 1m
     ports:
@@ -42,7 +35,6 @@ services:
   loop:
     image: louneskmt/loop:v0.11.4-beta@sha256:5e9d882921ca74abdbf613428406e32ffb48a635235cd2c9710fe2a28a225271
     user: "1000:1000"
-    logging: *default-logging
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/apps/samourai-server/docker-compose.yml
+++ b/apps/samourai-server/docker-compose.yml
@@ -1,16 +1,9 @@
 version: "3.7"
 
-x-logging:
-  &default-logging
-  driver: journald
-  options:
-    tag: "umbrel-app {{.Name}}"
-
 services:
   db:
     image: mariadb:10.5.8@sha256:8040983db146f729749081c6b216a19d52e0973134e2e34c0b4fd87f48bc15b0
     init: true
-    logging: *default-logging
     restart: on-failure
     stop_grace_period: 5m
     user: "1000:1000"
@@ -31,7 +24,6 @@ services:
   node:
     image: louneskmt/dojo-nodejs:1.9.0@sha256:fbef514d55dd848e038f9852e5b5146f18675c7c207e6370fb9f54d0fd6eb6ce
     init: true
-    logging: *default-logging
     restart: on-failure
     command: "/home/node/app/wait-for-it.sh db:3306 --timeout=720 --strict -- /home/node/app/restart.sh"
     user: "1000:1000"
@@ -95,7 +87,6 @@ services:
   whirlpool:
     image: louneskmt/whirlpool:0.10.10@sha256:0914a0784a59819d55605e45b595b2715e5d1ed9b5aa5cd58db0fb068d8f6367
     init: true
-    logging: *default-logging
     restart: on-failure
     user: "1000:1000"
     command:
@@ -123,7 +114,6 @@ services:
   nginx:
     image: nginx:1.19-alpine@sha256:c2ce58e024275728b00a554ac25628af25c54782865b3487b11c21cafb7fabda
     init: true
-    logging: *default-logging
     restart: on-failure
     command: /bin/sh -c "envsubst < /var/www/connect/js/conf.template.js > /var/www/connect/js/conf.js && /wait-for node:8080 --timeout=720 -- nginx"
     volumes:

--- a/apps/specter-desktop/docker-compose.yml
+++ b/apps/specter-desktop/docker-compose.yml
@@ -1,16 +1,9 @@
 version: "3.7"
 
-x-logging:
-  &default-logging
-  driver: journald
-  options:
-    tag: "umbrel-app {{.Name}}"
-
 services:
   web:
     image: lncm/specter-desktop:v1.2.2@sha256:22d6abe4ba97dcb9d3f5f1695524c5262be176d873f5f57c9d9c3a95840cb3da
     stop_signal: SIGINT
-    logging: *default-logging
     restart: on-failure
     stop_grace_period: 1m
     ports:

--- a/apps/sphinx-relay/docker-compose.yml
+++ b/apps/sphinx-relay/docker-compose.yml
@@ -1,10 +1,5 @@
 version: "3.7"
 
-x-logging: &default-logging
-  driver: journald
-  options:
-    tag: "umbrel-app {{.Name}}"
-
 services:
   sphinx-relay:
     container_name: sphinx-relay
@@ -12,7 +7,6 @@ services:
     init: true
     restart: on-failure
     stop_grace_period: 1m
-    logging: *default-logging
     volumes:
       - ${LND_DATA_DIR}:/lnd:ro
       - ${APP_DATA_DIR}/data:/relay/.lnd/

--- a/apps/thunderhub/docker-compose.yml
+++ b/apps/thunderhub/docker-compose.yml
@@ -1,16 +1,9 @@
 version: "3.7"
 
-x-logging:
-  &default-logging
-  driver: journald
-  options:
-    tag: "umbrel-app {{.Name}}"
-
 services:
   web:
     image: apotdevin/thunderhub:v0.12.12
     user: "1000:1000"
-    logging: *default-logging
     restart: on-failure
     stop_grace_period: 1m
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,4 @@
 version: '3.7'
-x-logging: &default-logging
-    driver: journald
-    options:
-        tag: "{{.Name}}"
 
 services:
         tor:
@@ -10,7 +6,6 @@ services:
                 image: lncm/tor:0.4.5.7@sha256:a83e0d9fd1a35adf025f2f34237ec1810e2a59765988dce1dfb222ca8ef6583c
                 user: toruser
                 restart: on-failure
-                logging: *default-logging
                 volumes:
                     - ${PWD}/tor/torrc:/etc/tor/torrc
                     - ${PWD}/tor/data:/var/lib/tor/
@@ -23,7 +18,6 @@ services:
         nginx:
                 container_name: nginx
                 image: nginx:1.17.8@sha256:380eb808e2a3b0dd954f92c1cae2f845e6558a15037efefcabc5b4e03d666d03
-                logging: *default-logging
                 depends_on: [ dashboard, manager ]
                 volumes:
                         - ${PWD}/nginx:/etc/nginx
@@ -37,7 +31,6 @@ services:
         bitcoin:
                 container_name: bitcoin
                 image: lncm/bitcoind:v0.21.0@sha256:f9348bff310e1c2bfeca9ca44318ed81a7e74172658881245d0922f77e6c4ca5
-                logging: *default-logging
                 depends_on: [ tor, manager, nginx ]
                 volumes:
                         - ${PWD}/bitcoin:/data/.bitcoin
@@ -51,7 +44,6 @@ services:
         lnd:
                 container_name: lnd
                 image: lncm/lnd:v0.12.1@sha256:bdc442c00bc4dd4d5bfa42efd7d977bfe4d21a08d466c933b9cff7cfc83e0c0e
-                logging: *default-logging
                 depends_on: [ tor, manager ]
                 volumes:
                         - ${PWD}/lnd:/data/.lnd
@@ -67,7 +59,6 @@ services:
         dashboard:
                 container_name: dashboard
                 image: getumbrel/dashboard:v0.3.18@sha256:56a964bb624551345480cc442ddfd065c561d42192877dfcf49a925bcfb3b2a7
-                logging: *default-logging
                 restart: on-failure
                 stop_grace_period: 1m30s
                 networks:
@@ -76,7 +67,6 @@ services:
         manager:
                 container_name: manager
                 image: getumbrel/manager:v0.2.10@sha256:aaeddfd7bd861dc9c418b34a4a4aa83a873e8b0304e28999d1d594eabf0e1b70
-                logging: *default-logging
                 depends_on: [ tor ]
                 restart: on-failure
                 stop_grace_period: 5m30s
@@ -132,7 +122,6 @@ services:
         middleware:
                 container_name: middleware
                 image: getumbrel/middleware:v0.1.9@sha256:8001338c3e6804afc9078eb08e8ee820e9d2c908a44303a3e4968ab57c8ad90b
-                logging: *default-logging
                 depends_on: [ manager, bitcoin, lnd ]
                 command: ["./wait-for-node-manager.sh", $MANAGER_IP, "npm", "start"]
                 restart: on-failure
@@ -155,7 +144,6 @@ services:
         neutrino-switcher:
                 container_name: neutrino-switcher
                 image: getumbrel/neutrino-switcher:v1.2.0@sha256:4d9636aabd9d06ed3693173870d6ab57d4e08716c618a0457512d542c4cf9b01
-                logging: *default-logging
                 depends_on: [ bitcoin, lnd ]
                 restart: on-failure
                 volumes:
@@ -176,7 +164,6 @@ services:
         frontail:
             container_name: frontail
             image: getumbrel/frontail:v4.9.1@sha256:9fa345b7a947361e2732909db8bd316b8157749d7dd9949abd8150eb023906db
-            logging: *default-logging
             restart: on-failure
             command: "/var/log/syslog --url-path /logs --number 100 --disable-usage-stats"
             volumes:
@@ -187,7 +174,6 @@ services:
         electrs:
               container_name: electrs
               image: getumbrel/electrs:v0.8.9@sha256:592fb50cdf16fa2b2e20f7c0a28d4a132c2ee636d89d4b9c24f14886763b5478
-              logging: *default-logging
               depends_on: [ bitcoin ]
               volumes:
                 - ${PWD}/bitcoin:/data/.bitcoin:ro


### PR DESCRIPTION
Resolves #629 

We were writing all container logs to journald which in turn writes to syslog which means all logs ultimately get written to the SD card on Umbrel OS. Some contianers make pretty heavy use of logging. This is bad for performance and also reduces the life and reliability of the SD card.

By disabling journald we fall back to the default json-file based Docker logging driver which stores logs in JSON files in the Docker data directory. Since https://github.com/getumbrel/umbrel/pull/589 the Docker data directory now lives on the external storage device on Umbrel OS which means perf will be much better and won't degrade SD card lifetime.