### PR TITLE
Wait for USB devices to be ready after rebinding drivers

### DIFF
--- a/scripts/umbrel-os/external-storage/mount
+++ b/scripts/umbrel-os/external-storage/mount
@@ -184,6 +184,20 @@ main () {
   echo "Blacklisting USB device IDs against UAS driver..."
   blacklist_uas
 
+  echo "Checking USB devices are back..."
+  retry_for_usb_devices=1
+  while [[ ! -e "${partition_path}" ]]; do
+    retry_for_usb_devices=$(( $retry_for_usb_devices + 1 ))
+    if [[ $retry_for_usb_devices -gt 10 ]]; then
+      echo "USB devices weren't registered after 10 tries..."
+      echo "Exiting mount script without doing anything"
+      exit 1
+    fi
+
+    echo "Waiting for USB devices..."
+    sleep 1
+  done
+
   echo "Checking if the device is ext4..."
 
   if is_partition_ext4 "${partition_path}" ; then


### PR DESCRIPTION
Sometimes it can take a few seconds for the block device to show up again at `/dev/sd*` after rebinding the USB drivers (related https://github.com/getumbrel/umbrel/pull/722). If we don't wait for the expected files to exist again some future commands can fail. 

With really bad timing this could potentially result in an Umbrel drive being detected as a non-Umbrel drive and being mistakenly wiped.