### PR TITLE
Remove colours for debug output upload

### DIFF
--- a/scripts/debug
+++ b/scripts/debug
@@ -164,7 +164,7 @@ if [[ ! -z "${UMBREL_OS:-}" ]]; then
         echo "you can contact us on Telegram (t.me/getumbrel) and share the output of this script."
         if [[ "${1}" == "--upload" ]]; then
             echo "You can also share these links instead:"
-            echo "$(./scripts/debug | sed '/onion/d') === Umbrel-Paste split === $(dmesg)" | upload
+            echo "$(./scripts/debug | sed '/onion/d' | sed -r 's/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g') === Umbrel-Paste split === $(dmesg)" | upload
         else
             echo "Run this script again with the --upload flag to automatically generate a link to share."
         fi

--- a/scripts/debug
+++ b/scripts/debug
@@ -183,7 +183,7 @@ if [[ "${1}" == "--upload" ]]; then
     # This runs the script twice, but it works
     echo "This script could not automatically detect an issue with your Umbrel."
     echo "Please share the following links and paste it in the Umbrel Telegram group (https://t.me/getumbrel) so we can help you with your problem."
-    echo "$(./scripts/debug | sed '/onion/d') === Umbrel-Paste split === $(dmesg)" | upload
+    echo "$(./scripts/debug | sed '/onion/d' | sed -r 's/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g') === Umbrel-Paste split === $(dmesg)" | upload
 else
     echo "This script could not automatically detect an issue with your Umbrel."
     echo "Please copy the entire output of this script and paste it in the Umbrel Telegram group (https://t.me/getumbrel) so we can help you with your problem."


### PR DESCRIPTION
Remove the terminal colours characters from the debug script output, to make the uploaded paste more readable. 

Currently:
```
[36mtor                  |[0m Apr 16 15:01:04.000 [notice] Bootstrapped 10% (conn_done): Connected to a relay
[36mtor                  |[0m Apr 16 15:01:04.000 [notice] Bootstrapped 14% (handshake): Handshaking with a relay
[36mtor                  |[0m Apr 16 15:01:05.000 [notice] Bootstrapped 15% (handshake_done): Handshake with a relay done
[36mtor                  |[0m Apr 16 15:01:05.000 [notice] Bootstrapped 20% (onehop_create): Establishing an encrypted directory connection
[36mtor                  |[0m Apr 16 15:01:05.000 [notice] Bootstrapped 25% (requesting_status): Asking for networkstatus consensus
[36mtor                  |[0m Apr 16 15:01:05.000 [notice] Bootstrapped 30% (loading_status): Loading networkstatus consensus
```

With this fix:
```
tor                  | Apr 18 09:30:58.000 [notice] Bootstrapped 14% (handshake): Handshaking with a relay
tor                  | Apr 18 09:30:58.000 [notice] Bootstrapped 15% (handshake_done): Handshake with a relay done
tor                  | Apr 18 09:30:58.000 [notice] Bootstrapped 20% (onehop_create): Establishing an encrypted directory connection
tor                  | Apr 18 09:30:58.000 [notice] Bootstrapped 25% (requesting_status): Asking for networkstatus consensus
tor                  | Apr 18 09:30:58.000 [notice] Bootstrapped 30% (loading_status): Loading networkstatus consensus
```