### PR TITLE
Show build version for development installs

### DIFF
--- a/scripts/update/update
+++ b/scripts/update/update
@@ -43,6 +43,15 @@ if [[ "${update_type}" == "repo" ]]; then
   mkdir -p "${repo_path}"
   git clone --single-branch --branch "${branch}" "https://github.com/${repo}.git" "${repo_path}"
 
+  # Patch version to show development build
+  commit=$(git --git-dir "${repo_path}/.git" rev-parse --short HEAD)
+  mv "${repo_path}/info.json" "${repo_path}/info.json.orig"
+  jq \
+    --arg commit "${commit}" \
+    '.version = .version + "-build-" + $commit' \
+    "${repo_path}/info.json.orig" \
+    > "${repo_path}/info.json"
+
   # Now hand over to the path updater
   update_type="path"
   update_path="${repo_path}"


### PR DESCRIPTION
Some testers updating to development builds were confused because they still saw the old stable build number. This PR patches the version file to include the git commit during the update process.

<img width="401" alt="Screenshot 2021-04-21 at 22 56 08" src="https://user-images.githubusercontent.com/2123375/115584874-56178000-a2f5-11eb-9525-5803c544ba63.png">
