### PR TITLE
Watch for block device not partition when waiting for storage devices

### DIFF
--- a/scripts/umbrel-os/external-storage/mount
+++ b/scripts/umbrel-os/external-storage/mount
@@ -177,7 +177,8 @@ main () {
 
   # At this point we know there is only one block device attached
   block_device=$(list_block_devices)
-  partition_path="/dev/${block_device}1"
+  block_device_path="/dev/${block_device}"
+  partition_path="${block_device_path}1"
   block_device_model=$(get_block_device_model $block_device)
   echo "Found device \"${block_device_model}\""
 
@@ -186,7 +187,7 @@ main () {
 
   echo "Checking USB devices are back..."
   retry_for_usb_devices=1
-  while [[ ! -e "${partition_path}" ]]; do
+  while [[ ! -e "${block_device_path}" ]]; do
     retry_for_usb_devices=$(( $retry_for_usb_devices + 1 ))
     if [[ $retry_for_usb_devices -gt 10 ]]; then
       echo "USB devices weren't registered after 10 tries..."


### PR DESCRIPTION
When checking for storage devices to be ready after driver rebinding (https://github.com/getumbrel/umbrel/pull/724) we were watching the partition path not the block device path. The partition path only exists on formatted drives, so drives that aren't formatted yet will never be detected.