### PR TITLE
Ensure SD card updater runs after networking and Docker

### DIFF
--- a/scripts/umbrel-os/services/umbrel-external-storage-sdcard-update.service
+++ b/scripts/umbrel-os/services/umbrel-external-storage-sdcard-update.service
@@ -1,8 +1,8 @@
-# Umbrel External Storage Updater
-# Installed at /etc/systemd/system/umbrel-external-storage-update.service
+# Umbrel External Storage SDcard Updater
+# Installed at /etc/systemd/system/umbrel-external-storage-sdcard-update.service
 
 [Unit]
-Description=External Storage Updater
+Description=External Storage SDcard Updater
 Requires=umbrel-external-storage.service
 After=umbrel-external-storage.service
 Wants=network-online.target

--- a/scripts/umbrel-os/services/umbrel-external-storage-update.service
+++ b/scripts/umbrel-os/services/umbrel-external-storage-update.service
@@ -1,0 +1,26 @@
+# Umbrel External Storage Updater
+# Installed at /etc/systemd/system/umbrel-external-storage-update.service
+
+[Unit]
+Description=External Storage Updater
+Requires=umbrel-external-storage.service
+After=umbrel-external-storage.service
+Wants=network-online.target
+After=network-online.target
+Wants=docker.service
+After=docker.service
+
+[Service]
+Type=oneshot
+Restart=no
+ExecStart=/home/umbrel/umbrel/scripts/umbrel-os/external-storage/update-from-sdcard
+TimeoutStartSec=45min
+User=root
+Group=root
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=external storage updater
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/umbrel-os/services/umbrel-external-storage.service
+++ b/scripts/umbrel-os/services/umbrel-external-storage.service
@@ -9,7 +9,6 @@ Before=docker.service
 Type=oneshot
 Restart=no
 ExecStart=/home/umbrel/umbrel/scripts/umbrel-os/external-storage/mount
-ExecStartPost=/home/umbrel/umbrel/scripts/umbrel-os/external-storage/update-from-sdcard
 TimeoutStartSec=45min
 User=root
 Group=root

--- a/scripts/umbrel-os/services/umbrel-startup.service
+++ b/scripts/umbrel-os/services/umbrel-startup.service
@@ -3,8 +3,8 @@
 
 [Unit]
 Description=Umbrel Startup Service
-Requires=umbrel-external-storage.service
-After=umbrel-external-storage.service
+Requires=umbrel-external-storage-update.service
+After=umbrel-external-storage-update.service
 Wants=network-online.target
 After=network-online.target
 Wants=docker.service

--- a/scripts/umbrel-os/services/umbrel-startup.service
+++ b/scripts/umbrel-os/services/umbrel-startup.service
@@ -3,6 +3,8 @@
 
 [Unit]
 Description=Umbrel Startup Service
+Requires=umbrel-external-storage.service
+After=umbrel-external-storage.service
 Requires=umbrel-external-storage-update.service
 After=umbrel-external-storage-update.service
 Wants=network-online.target

--- a/scripts/umbrel-os/services/umbrel-startup.service
+++ b/scripts/umbrel-os/services/umbrel-startup.service
@@ -5,8 +5,8 @@
 Description=Umbrel Startup Service
 Requires=umbrel-external-storage.service
 After=umbrel-external-storage.service
-Requires=umbrel-external-storage-update.service
-After=umbrel-external-storage-update.service
+Requires=umbrel-external-storage-sdcard-update.service
+After=umbrel-external-storage-sdcard-update.service
 Wants=network-online.target
 After=network-online.target
 Wants=docker.service


### PR DESCRIPTION
The external storage update requires entwork & docker to be running, if it runs before they are ready it will fail to update the SSD installation if the SD card installation is newer.