### PR TITLE
Show build version without changing main version

### DIFF
--- a/scripts/update/update
+++ b/scripts/update/update
@@ -48,7 +48,7 @@ if [[ "${update_type}" == "repo" ]]; then
   mv "${repo_path}/info.json" "${repo_path}/info.json.orig"
   jq \
     --arg commit "${commit}" \
-    '.version = .version + "-build-" + $commit' \
+    '.build = $commit' \
     "${repo_path}/info.json.orig" \
     > "${repo_path}/info.json"
 


### PR DESCRIPTION
Related: https://github.com/getumbrel/umbrel-dashboard/pull/342

The previous way we did this was by injecting the build version into the version string during dev updates. This broke OTA updates and left testers on dev builds unable to do OTA updates. This new method injects the build version into a separate property which is detected and shown in the UI on build versions without interfering with OTA functionality.