### PR TITLE
Allow running without root permissions

### DIFF
--- a/karen
+++ b/karen
@@ -3,9 +3,9 @@
 # karen watches for signals and executes triggers in the events dir
 # karen gets triggered a lot
 
-check_root () {
-  if [[ $UID != 0 ]]; then
-    echo "Error: This script must be run as root."
+check_permissions () {
+  if ! id --name --groups --zero "$USER" | grep --quiet --null-data --line-regexp --fixed-strings "docker" && [[ $UID != 0 ]]; then
+    echo "Error: This script must be run as root or with docker permissions."
     echo "Can I speak to a manager please?"
     exit 1
   fi
@@ -28,7 +28,7 @@ check_dependencies () {
   done
 }
 
-check_root
+check_permissions
 
 check_if_not_already_running
 

--- a/scripts/start
+++ b/scripts/start
@@ -3,8 +3,8 @@ set -euo pipefail
 
 # Start Umbrel
 
-if [[ $UID != 0 ]]; then
-    echo "Umbrel must be started as root"
+if ! id --name --groups --zero "$USER" | grep --quiet --null-data --line-regexp --fixed-strings "docker" && [[ $UID != 0 ]]; then
+    echo "Umbrel must be started as root or with docker permissions"
     echo "Please re-run this script as"
     echo "  sudo ./scripts/start"
     exit 1


### PR DESCRIPTION
This still needs more testing, but now the start script can be run without root, so only docker permissions are required.

---

I forgot that some scripts like the backup monitor require root.