### PR TITLE
Use same tor for hashed password as we use later

### DIFF
--- a/scripts/configure
+++ b/scripts/configure
@@ -171,7 +171,7 @@ if [[ -z ${TOR_PASSWORD+x} ]] || [[ -z ${TOR_HASHED_PASSWORD+x} ]]; then
   echo "Generating Tor password"
   echo
   TOR_PASSWORD=$("./scripts/rpcauth.py" "itdoesntmatter" | tail -1)
-  TOR_HASHED_PASSWORD=$(docker run --rm getumbrel/tor:v0.4.1.9 --quiet --hash-password "$TOR_PASSWORD")
+  TOR_HASHED_PASSWORD=$(docker run --rm  lncm/tor:0.4.5.7 --quiet --hash-password "$TOR_PASSWORD")
 fi
 
 


### PR DESCRIPTION
This avoids nodes having to download Tor when we it's bundled with Umbrel OS