### PR TITLE
Add memory monitor script

### DIFF
--- a/scripts/debug
+++ b/scripts/debug
@@ -94,6 +94,10 @@ free --human --mega
 echo
 "${UMBREL_ROOT}/scripts/memory-usage"
 
+echo
+echo "Memory monitor logs"
+echo "-------------------"
+tail -n 10 "${UMBREL_ROOT}/logs/memory-monitor.log"
 
 echo
 echo "Filesystem information"

--- a/scripts/memory-monitor
+++ b/scripts/memory-monitor
@@ -22,8 +22,10 @@ log "Memory monitor running!"
 while true; do
   percent_memory_used=$(free | awk 'NR==2{print int($3*100/$2) }')
   if (( $percent_memory_used > $PERCENT_MEMORY_THRESHOLD )); then
-    touch "${UMBREL_ROOT}/statuses/memory-warning"
     log "Warning memory usage at ${percent_memory_used}%"
+    if [[ "$(jq -r '.installedApps | length > 0' ${UMBREL_ROOT}/db/user.json)" == "true" ]]; then
+      touch "${UMBREL_ROOT}/statuses/memory-warning"
+    fi
   fi
   sleep 10
 done

--- a/scripts/memory-monitor
+++ b/scripts/memory-monitor
@@ -27,5 +27,5 @@ while true; do
       touch "${UMBREL_ROOT}/statuses/memory-warning"
     fi
   fi
-  sleep 10
+  sleep 60
 done

--- a/scripts/memory-monitor
+++ b/scripts/memory-monitor
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/..)"
+
+PERCENT_MEMORY_THRESHOLD=90
+
+check_if_not_already_running() {
+  if ps ax | grep $0 | grep -v $$ | grep bash | grep -v grep
+  then
+    echo "Memory monitor is already running"
+    exit 1
+  fi
+}
+
+log () {
+  echo "$(date "+%Y-%m-%d %H:%M:%S") ${@}"
+}
+
+check_if_not_already_running
+log "Memory monitor running!"
+
+while true; do
+  percent_memory_used=$(free | awk 'NR==2{print int($3*100/$2) }')
+  if (( $percent_memory_used > $PERCENT_MEMORY_THRESHOLD )); then
+    touch "${UMBREL_ROOT}/statuses/memory-warning"
+    log "Warning memory usage at ${percent_memory_used}%"
+  fi
+  sleep 10
+done

--- a/scripts/start
+++ b/scripts/start
@@ -73,6 +73,10 @@ echo "Starting karen..."
 echo
 ./karen &>> "${UMBREL_LOGS}/karen.log" &
 
+echo "Starting memory monitor..."
+echo
+./scripts/memory-monitor &>> "${UMBREL_LOGS}/memory-monitor.log" &
+
 echo "Starting backup monitor..."
 echo
 ./scripts/backup/monitor &>> "${UMBREL_LOGS}/backup-monitor.log" &


### PR DESCRIPTION
Related:
- https://github.com/getumbrel/umbrel-manager/pull/90
- https://github.com/getumbrel/umbrel-dashboard/pull/345

Also loosely related: https://github.com/getumbrel/umbrel/pull/758

Monitors memory utilisation on the host and touches a `statuses/memory-warning` signal file if memory usage goes over 90%.