### PR TITLE
Show memory usage in logs

### DIFF
--- a/scripts/debug
+++ b/scripts/debug
@@ -96,6 +96,15 @@ if [[ ! -z "${UMBREL_OS:-}" ]]; then
     echo "-----------------------------"
     journalctl --unit=umbrel-external-storage.service | tail -n 30
 fi
+
+echo
+echo "Memory usage"
+echo "------------"
+free --human --mega
+echo
+"${UMBREL_ROOT}/scripts/memory-usage"
+
+
 echo
 echo "Filesystem information"
 echo "----------------------"

--- a/scripts/memory-usage
+++ b/scripts/memory-usage
@@ -9,7 +9,7 @@ get_container_memory_use () {
   local container_memory=0
 
   local container_pids=$(docker top "${container}" | tail -n +2 | awk '{print $2}')
-  for pid in "${container_pids}"; do
+  for pid in $container_pids; do
     local pid_memory=$(ps u "${pid}" | awk '{print $4}' | grep -v 'MEM')
     if [[ ! -z "${pid_memory}" ]]; then
       container_memory=$(awk "BEGIN {print ${container_memory}+${pid_memory}}")
@@ -25,7 +25,7 @@ get_app_memory_use () {
   local app_memory=0
 
   local app_containers=$("${UMBREL_ROOT}/scripts/app" compose "${app}" ps | awk '{print $1}' | grep -v 'Name\|-----')
-  for container in "${app_containers}"; do
+  for container in $app_containers; do
     local container_memory=$(get_container_memory_use "${container}")
     app_memory=$(awk "BEGIN {print ${app_memory}+${container_memory}}")
   done

--- a/scripts/memory-usage
+++ b/scripts/memory-usage
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/..)"
+
+get_container_memory_use () {
+  local container="${1}"
+
+  local container_memory=0
+
+  local container_pids=$(docker top "${container}" | tail -n +2 | awk '{print $2}')
+  for pid in "${container_pids}"; do
+    local pid_memory=$(ps u "${pid}" | awk '{print $4}' | grep -v 'MEM')
+    if [[ ! -z "${pid_memory}" ]]; then
+      container_memory=$(awk "BEGIN {print ${container_memory}+${pid_memory}}")
+    fi
+  done
+
+  echo "${container_memory}"
+}
+
+get_app_memory_use () {
+  local app="${1}"
+
+  local app_memory=0
+
+  local app_containers=$("${UMBREL_ROOT}/scripts/app" compose "${app}" ps | awk '{print $1}' | grep -v 'Name\|-----')
+  for container in "${app_containers}"; do
+    local container_memory=$(get_container_memory_use "${container}")
+    app_memory=$(awk "BEGIN {print ${app_memory}+${container_memory}}")
+  done
+
+  echo "${app_memory}"
+}
+
+main() {
+  local total_system_memory_usage=$(free | awk 'NR==2{print sprintf("%.1f", $3*100/$2) }')
+  echo "total: ${total_system_memory_usage}%"
+
+  local total_container_memory=0
+
+  # Core services memory use
+  for service in bitcoin lnd electrs tor; do
+    local service_memory=$(get_container_memory_use "${service}")
+    total_container_memory=$(awk "BEGIN {print ${total_container_memory}+${service_memory}}")
+    echo "${service}: ${service_memory}%"
+  done
+
+  # Installed app memory use
+  for app in $("${UMBREL_ROOT}/scripts/app" ls-installed); do
+    local app_memory=$(get_app_memory_use "${app}")
+    total_container_memory=$(awk "BEGIN {print ${total_container_memory}+${app_memory}}")
+    echo "${app}: ${app_memory}%"
+  done
+
+  # Misc system memory use
+  local system_memory=$(awk "function pos(x){return(x<0?0:x)} BEGIN {print pos(${total_system_memory_usage}-${total_container_memory})}")
+  echo "system: ${system_memory}%"
+}
+
+main 2> /dev/null | sort --key 2 --numeric-sort --reverse


### PR DESCRIPTION
Adds the following output to the debug script:

```
Memory usage
------------
              total        used        free      shared  buff/cache   available
Mem:           7.8G        4.7G        392M         10M        2.7G        3.0G
Swap:          4.1G        970M        3.1G

total: 63.0%
mempool: 17.8%
bitcoin: 12.7%
samourai-server: 12.5%
electrs: 8.2%
btcpay-server: 4.1%
lnd: 2.9%
system: 1.7%
sphinx-relay: 1.2%
thunderhub: 0.5%
tor: 0.4%
specter-desktop: 0.4%
btc-rpc-explorer: 0.3%
lnbits: 0.2%
lightning-terminal: 0.1%
ride-the-lightning: 0%
```

Useful to help more technical users troubleshoot if they encounter a high memory warning from https://github.com/getumbrel/umbrel/pull/757