### PR TITLE
Fix dbcache to 200MB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,12 +144,11 @@ services:
                         ipv4_address: $MIDDLEWARE_IP
         neutrino-switcher:
                 container_name: neutrino-switcher
-                image: getumbrel/neutrino-switcher:v1.2.0@sha256:4d9636aabd9d06ed3693173870d6ab57d4e08716c618a0457512d542c4cf9b01
+                image: getumbrel/neutrino-switcher:v1.3.0@sha256:399ccea7f39129ff16c9c408f9e68a01dd4671f428273f3c3f401a8a0d2f7ddc
                 depends_on: [ bitcoin, lnd ]
                 restart: on-failure
                 volumes:
                     - ${PWD}/lnd:/lnd
-                    - ${PWD}/bitcoin:/bitcoin
                     - ${PWD}/statuses:/statuses
                     - /var/run/docker.sock:/var/run/docker.sock
                 environment:
@@ -157,7 +156,6 @@ services:
                     RPCUSER: $BITCOIN_RPC_USER
                     RPCPASS: $BITCOIN_RPC_PASS
                     LND_CONTAINER_NAME: lnd
-                    BITCOIN_CONTAINER_NAME: bitcoin
                     SLEEPTIME: 3600
                 networks:
                     default:

--- a/scripts/configure
+++ b/scripts/configure
@@ -323,28 +323,6 @@ for template in "${NGINX_CONF_FILE}" "${BITCOIN_CONF_FILE}" "${LND_CONF_FILE}" "
   sed -i "s/<app-bluewallet-redis-ip>/${APP_BLUEWALLET_REDIS_IP}/g" "${template}"
 done
 
-
-##########################################################
-############### Performance optimizations ################
-##########################################################
-
-echo
-echo "Making performance optimizations"
-echo
-
-echo "Setting dbcache size"
-echo
-if [[ -f "${STATUS_DIR}/node-status-bitcoind-ready" ]]; then
-  # Limit dbcache to 200 after IBD
-  DBCACHE_SIZE="200"
-else
-  # Allocate (50% of RAM) - 300MB to dbcache for IDB
-  DBCACHE_SIZE=$(awk '/MemTotal/{printf "%d\n", ($2/2^10 * 0.5) - 300}' /proc/meminfo)
-fi
-sed -i -e "s/dbcache=<size>/dbcache=$DBCACHE_SIZE/g" "$BITCOIN_CONF_FILE"
-
-# TODO: Adjust prune size based on available disk space
-
 ##########################################################
 ############## Override main config files ################
 ##########################################################

--- a/templates/bitcoin-sample.conf
+++ b/templates/bitcoin-sample.conf
@@ -13,7 +13,7 @@ rpcallowip=127.0.0.1
 rpcauth=<rpcauth>
 
 # Memory
-dbcache=<size>
+dbcache=200
 maxmempool=300
 
 # zmq


### PR DESCRIPTION
We previously (https://github.com/getumbrel/umbrel/pull/345) set a very high dbcache (50% of RAM) to speed up IBD and then after IBD completed we set dbcache back down to 200MB and restarted Bitcoin Core.

This made sense when Bitcoin Core was one of the only services running on the system. Now we have many apps on the app store it doesn't really make sense to allocate so many resources to a single process.

Some users are also reporting Bitcoin Core corruption right after reaching 100% sync. It seems like the Bitcoin Core restart right after IBD when the db cache is full takes a very long time and can in some occasions expire the 15m shutdown timeout and cause Bitcoin Core to be killed.

Also, in my testing, it seems the dbcache only has a very small effect on sync speed. The RAM/speed tradeoff is not really worth it on such a constrained system.

Leaving Bitcoin Core to sync for 3 hours with varying dbcache set on a Pi resulted in negligible differences:

#### dbcache=2000
- Height 353509
- Progress 0.104588541289604

#### dbcache=200
- Height 350600
- Progress 0.100994502901211

#### dbcache=100
- Height 354351
- Progress 0.1053484172272391

#### dbcache=4
- Height 343766
- Progress 0.09396825465750046

So from these quick tests it looks like reducing dbcache from 2000MB to 4MB only results in around a 10% performance reduction but uses significantly less memory.

0.09396825465750046/0.104588541289604=0.898456499

We can hardcode to 200MB for now. If we don't spot an increase in users complaining about slow syncs I'd suggest decreasing right down to 4MB for the next update.