### PR TITLE
Simplify filesystem section in debug script

### DIFF
--- a/scripts/debug
+++ b/scripts/debug
@@ -109,7 +109,7 @@ echo
 echo "Filesystem information"
 echo "----------------------"
 
-df -h "${UMBREL_ROOT}"
+df -h / "${UMBREL_ROOT}"
 
 
 echo

--- a/scripts/debug
+++ b/scripts/debug
@@ -109,7 +109,7 @@ echo
 echo "Filesystem information"
 echo "----------------------"
 
-df -h / "${UMBREL_ROOT}"
+df --human-readable / "${UMBREL_ROOT}"
 
 
 echo

--- a/scripts/debug
+++ b/scripts/debug
@@ -109,9 +109,7 @@ echo
 echo "Filesystem information"
 echo "----------------------"
 
-df -h
-echo
-cat /proc/swaps
+df -h "${UMBREL_ROOT}"
 
 
 echo


### PR DESCRIPTION
No need for `cat /proc/swaps` since we now show swap info as part of the memory section.

Also limiting `df` to just `UMBREL_ROOT` and `/` reduces a lot of noise in the output:

```
umbrel@umbrel:~/umbrel $ df -h / "${UMBREL_ROOT}"
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        30G   12G   17G  40% /
/dev/sda1       1.9T  494G  1.3T  28% /home/umbrel/umbrel

umbrel@umbrel:~/umbrel $ df -h
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        30G   12G   17G  40% /
devtmpfs        3.7G     0  3.7G   0% /dev
tmpfs           3.9G     0  3.9G   0% /dev/shm
tmpfs           3.9G   27M  3.8G   1% /run
tmpfs           5.0M  4.0K  5.0M   1% /run/lock
tmpfs           3.9G     0  3.9G   0% /sys/fs/cgroup
/dev/mmcblk0p1  253M   55M  198M  22% /boot
/dev/sda1       1.9T  494G  1.3T  28% /mnt/data
tmpfs           782M     0  782M   0% /run/user/1000
```