### PR TITLE
Add app logs to debug script

### DIFF
--- a/scripts/debug
+++ b/scripts/debug
@@ -148,6 +148,19 @@ echo "--------"
 echo
 docker-compose logs --tail=30 tor
 
+installed_apps=$(./scripts/app ls-installed)
+if [[ ! -z "${installed_apps:-}" ]]; then
+  echo
+  echo "App logs"
+  echo "--------"
+  for app in $installed_apps; do
+    echo
+    echo "${app}"
+    echo
+    ./scripts/app compose $app logs --tail 10 | tail -n 10;
+  done
+fi
+
 if [[ ! -z "${UMBREL_OS:-}" ]]; then
     list_block_devices () {
         # Documented in the mount script for Umbrel OS

--- a/scripts/debug
+++ b/scripts/debug
@@ -157,6 +157,7 @@ if [[ ! -z "${installed_apps:-}" ]]; then
     echo
     echo "${app}"
     echo
+    # Double tail because we want 30 lines total not per container
     ./scripts/app compose $app logs --tail 30 | tail -n 30;
   done
 fi

--- a/scripts/debug
+++ b/scripts/debug
@@ -157,7 +157,7 @@ if [[ ! -z "${installed_apps:-}" ]]; then
     echo
     echo "${app}"
     echo
-    ./scripts/app compose $app logs --tail 10 | tail -n 10;
+    ./scripts/app compose $app logs --tail 30 | tail -n 30;
   done
 fi
 


### PR DESCRIPTION
Loops over installed apps and dumps last 10 lines of the logs.

Output from my Umbrel:

```
App logs
--------

bluewallet

redis_1   | 6:M 02 May 2021 11:36:43.084 * 1 changes in 3600 seconds. Saving...
redis_1   | 6:M 02 May 2021 11:36:43.100 * Background saving started by pid 16
redis_1   | 16:C 02 May 2021 11:36:43.116 * DB saved on disk
redis_1   | 16:C 02 May 2021 11:36:43.117 * RDB: 0 MB of memory used by copy-on-write
redis_1   | 6:M 02 May 2021 11:36:43.200 * Background saving terminated with success
redis_1   | 6:M 02 May 2021 12:36:44.066 * 1 changes in 3600 seconds. Saving...
redis_1   | 6:M 02 May 2021 12:36:44.074 * Background saving started by pid 17
redis_1   | 17:C 02 May 2021 12:36:44.090 * DB saved on disk
redis_1   | 17:C 02 May 2021 12:36:44.091 * RDB: 0 MB of memory used by copy-on-write
redis_1   | 6:M 02 May 2021 12:36:44.174 * Background saving terminated with success

btc-rpc-explorer

web_1  | 2021-05-02T15:55:13.221Z btcexp:app Skipping performance-intensive task: fetch UTXO set summary. This is skipped due to the flag 'slowDeviceMode' which defaults to 'true' to protect slow nodes. Set this flag to 'false' to enjoy UTXO set summary details.
web_1  | 2021-05-02T15:55:13.221Z btcexp:app Skipping performance-intensive task: fetch last 24 hrs of blockstats to calculate transaction volume. This is skipped due to the flag 'slowDeviceMode' which defaults to 'true' to protect slow nodes. Set this flag to 'false' to enjoy UTXO set summary details.
web_1  | 2021-05-02T16:25:13.225Z btcexp:app Skipping performance-intensive task: fetch UTXO set summary. This is skipped due to the flag 'slowDeviceMode' which defaults to 'true' to protect slow nodes. Set this flag to 'false' to enjoy UTXO set summary details.
web_1  | 2021-05-02T16:25:13.226Z btcexp:app Skipping performance-intensive task: fetch last 24 hrs of blockstats to calculate transaction volume. This is skipped due to the flag 'slowDeviceMode' which defaults to 'true' to protect slow nodes. Set this flag to 'false' to enjoy UTXO set summary details.
web_1  | 2021-05-02T16:55:13.228Z btcexp:app Skipping performance-intensive task: fetch UTXO set summary. This is skipped due to the flag 'slowDeviceMode' which defaults to 'true' to protect slow nodes. Set this flag to 'false' to enjoy UTXO set summary details.
web_1  | 2021-05-02T16:55:13.228Z btcexp:app Skipping performance-intensive task: fetch last 24 hrs of blockstats to calculate transaction volume. This is skipped due to the flag 'slowDeviceMode' which defaults to 'true' to protect slow nodes. Set this flag to 'false' to enjoy UTXO set summary details.
web_1  | 2021-05-02T17:25:13.229Z btcexp:app Skipping performance-intensive task: fetch UTXO set summary. This is skipped due to the flag 'slowDeviceMode' which defaults to 'true' to protect slow nodes. Set this flag to 'false' to enjoy UTXO set summary details.
web_1  | 2021-05-02T17:25:13.231Z btcexp:app Skipping performance-intensive task: fetch last 24 hrs of blockstats to calculate transaction volume. This is skipped due to the flag 'slowDeviceMode' which defaults to 'true' to protect slow nodes. Set this flag to 'false' to enjoy UTXO set summary details.
web_1  | 2021-05-02T17:55:13.231Z btcexp:app Skipping performance-intensive task: fetch UTXO set summary. This is skipped due to the flag 'slowDeviceMode' which defaults to 'true' to protect slow nodes. Set this flag to 'false' to enjoy UTXO set summary details.
web_1  | 2021-05-02T17:55:13.231Z btcexp:app Skipping performance-intensive task: fetch last 24 hrs of blockstats to calculate transaction volume. This is skipped due to the flag 'slowDeviceMode' which defaults to 'true' to protect slow nodes. Set this flag to 'false' to enjoy UTXO set summary details.

btcpay-server

web_1        | info: Events:         NBXplorer BTC: Ready => Synching
web_1        | info: Events:         BTC: New block
web_1        | info: Events:         BTC: New block
web_1        | info: Events:         BTC: New block
web_1        | info: Events:         BTC: New block
web_1        | info: Events:         NBXplorer BTC: Synching => Ready
web_1        | info: Events:         BTC: New block
web_1        | info: Events:         BTC: New block
web_1        | info: Events:         BTC: New block
web_1        | info: Events:         BTC: New block

lightning-terminal

web_1  | 2021-05-02 17:49:29.693 [INF] RPCS: Received new block notification: height=681568
web_1  | 2021-05-02 17:49:30.978 [INF] RPCS: Received new block notification: height=681568
web_1  | 2021-05-02 17:52:48.021 [INF] RPCS: Received new block notification: height=681569
web_1  | 2021-05-02 17:52:49.385 [INF] RPCS: Received new block notification: height=681569
web_1  | 2021-05-02 17:54:57.138 [INF] RPCS: Received new block notification: height=681570
web_1  | 2021-05-02 17:54:58.129 [INF] RPCS: Received new block notification: height=681570
web_1  | 2021-05-02 17:58:13.882 [INF] RPCS: Received new block notification: height=681571
web_1  | 2021-05-02 17:58:15.740 [INF] RPCS: Received new block notification: height=681571
web_1  | 2021-05-02 18:06:32.338 [INF] RPCS: Received new block notification: height=681572
web_1  | 2021-05-02 18:06:33.133 [INF] RPCS: Received new block notification: height=681572

lnbits

Attaching to lnbits_web_1
web_1  | /app/lnbits/app.py:63: RuntimeWarning:   × The backend for LndWallet isn't working properly: '<_InactiveRpcError of RPC that terminated with:
web_1  | 	status = StatusCode.UNAVAILABLE
web_1  | 	details = "failed to connect to all addresses"
web_1  | 	debug_error_string = "{"created":"@1619711734.213800009","description":"Failed to pick subchannel","file":"src/core/ext/filters/client_channel/client_channel.cc","file_line":5420,"referenced_errors":[{"created":"@1619711734.213787786","description":"failed to connect to all addresses","file":"src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc","file_line":398,"grpc_status":14}]}"
web_1  | >'
web_1  |   RuntimeWarning,
web_1  | [2021-04-29 15:55:34 +0000] [17] [INFO] Running on http://0.0.0.0:3007 (CTRL + C to quit)
web_1  | [2021-04-29 15:56:25 +0000] [16] [INFO] Running on http://0.0.0.0:3007 (CTRL + C to quit)

mempool

mariadb_1  | 2021-04-29 15:54:25 0 [Note] Plugin 'FEEDBACK' is disabled.
mariadb_1  | 2021-04-29 15:54:25 0 [Note] Server socket created on IP: '::'.
mariadb_1  | 2021-04-29 15:54:25 0 [Warning] 'proxies_priv' entry '@% root@b3ba2ad23c23' ignored in --skip-name-resolve mode.
mariadb_1  | 2021-04-29 15:54:25 0 [Note] Reading of all Master_info entries succeeded
mariadb_1  | 2021-04-29 15:54:25 0 [Note] Added new Master_info '' to hash table
mariadb_1  | 2021-04-29 15:54:25 0 [Note] mysqld: ready for connections.
mariadb_1  | Version: '10.5.8-MariaDB-1:10.5.8+maria~focal'  socket: '/run/mysqld/mysqld.sock'  port: 3306  mariadb.org binary distribution
mariadb_1  | 2021-04-29 15:54:25 3 [Warning] Aborted connection 3 to db: 'unconnected' user: 'unauthenticated' host: '10.21.21.27' (This connection closed normally without authentication)
mariadb_1  | 2021-04-29 15:54:25 0 [Note] InnoDB: Buffer pool(s) load completed at 210429 15:54:25
mariadb_1  | 2021-04-29 15:54:26 4 [Warning] Aborted connection 4 to db: 'unconnected' user: 'unauthenticated' host: '10.21.21.26' (This connection closed normally without authentication)

ride-the-lightning

loop_1  | 2021-04-29 15:56:04.084 [INF] LOOPD: Starting liquidity manager
loop_1  | 2021-04-29 15:56:04.084 [INF] LOOPD: Starting swap client
loop_1  | 2021-04-29 15:56:04.090 [INF] LOOP: Connected to lnd node '03416a2754f4cf3b90f1' with pubkey 03416a2754f4cf3b90f1cad3ecd1b77d2a79320f990afc823957adedcbc7d7f5f8 (version v0.12.1-beta, build tags 'autopilotrpc,signrpc,walletrpc,chainrpc,invoicesrpc,watchtowerrpc')
loop_1  | 2021-04-29 15:56:04.084 [INF] LOOPD: Starting gRPC listener
loop_1  | 2021-04-29 15:56:04.105 [INF] LOOP: Wait for first block ntfn
loop_1  | 2021-04-29 15:56:04.125 [INF] LOOP: Starting event loop at height 681104
loop_1  | 2021-04-29 15:56:04.968 [INF] LOOPD: Starting REST proxy listener
loop_1  | 2021-04-29 15:56:04.968 [INF] LOOPD: RPC server listening on 127.0.0.1:11010
loop_1  | 2021-04-29 15:56:04.968 [INF] LOOPD: REST proxy listening on [::]:8081
web_1   | Server is up and running, please open the UI at http://localhost:3001

samourai-server

whirlpool_1  | 2021-05-02 16:52:13.243  INFO 10 --- [t-1619974333228] s.w.c.w.l.LoggingWhirlpoolClientListener :  - [MIX] 0.001btc ?????????? (10%) CONNECTING : connecting...
whirlpool_1  | 2021-05-02 16:52:13.244  WARN 10 --- [whirlpoolClient] c.s.w.client.wallet.WhirlpoolWallet      : onMixFail(CANCEL): won't retry
whirlpool_1  | 2021-05-02 16:52:18.824  INFO 10 --- [ent@5f642dfa-97] s.w.c.w.l.LoggingWhirlpoolClientListener :  - [MIX] 0.001btc ?????????? (20%) CONNECTED : connected
whirlpool_1  | 2021-05-02 16:52:20.387  INFO 10 --- [ent@5f642dfa-94] s.w.c.w.l.LoggingWhirlpoolClientListener :  - [MIX] 0.001btc ?????????? (30%) REGISTERED_INPUT : registered input
whirlpool_1  | 2021-05-02 17:52:28.295  INFO 10 --- [rchestratorImpl] c.s.w.client.wallet.MixOrchestratorImpl  :  ? Connecting client to pool: 0.001btc
whirlpool_1  | 2021-05-02 17:52:28.301  INFO 10 --- [t-1619977948300] s.w.c.w.l.LoggingWhirlpoolClientListener :  - [MIX] 0.001btc ?????????? (10%) CONNECTING : connecting...
whirlpool_1  | 2021-05-02 17:52:28.303  INFO 10 --- [whirlpoolClient] s.w.c.w.l.LoggingWhirlpoolClientListener :  - [MIX] 0.001btc Cancelled
whirlpool_1  | 2021-05-02 17:52:28.304  WARN 10 --- [whirlpoolClient] c.s.w.client.wallet.WhirlpoolWallet      : onMixFail(CANCEL): won't retry
whirlpool_1  | 2021-05-02 17:52:32.719  INFO 10 --- [ent@5f642dfa-96] s.w.c.w.l.LoggingWhirlpoolClientListener :  - [MIX] 0.001btc ?????????? (20%) CONNECTED : connected
whirlpool_1  | 2021-05-02 17:52:34.173  INFO 10 --- [ent@5f642dfa-95] s.w.c.w.l.LoggingWhirlpoolClientListener :  - [MIX] 0.001btc ?????????? (30%) REGISTERED_INPUT : registered input

specter-desktop

web_1  | [2021-05-02 08:55:40,361] INFO in version: version checked. upgrade: False
web_1  | [2021-05-02 09:55:40,686] INFO in version: version checked. upgrade: False
web_1  | [2021-05-02 10:55:41,008] INFO in version: version checked. upgrade: False
web_1  | [2021-05-02 11:55:41,311] INFO in version: version checked. upgrade: False
web_1  | [2021-05-02 12:55:41,644] INFO in version: version checked. upgrade: False
web_1  | [2021-05-02 13:55:41,917] INFO in version: version checked. upgrade: False
web_1  | [2021-05-02 14:55:42,265] INFO in version: version checked. upgrade: False
web_1  | [2021-05-02 15:55:42,910] INFO in version: version checked. upgrade: False
web_1  | [2021-05-02 16:55:43,240] INFO in version: version checked. upgrade: False
web_1  | [2021-05-02 17:55:43,501] INFO in version: version checked. upgrade: False

sphinx-relay

sphinx-relay    | [lightning] [ 'verifyMessage' ]
sphinx-relay    | => received delete message
sphinx-relay    | [lightning] [ 'verifyMessage' ]
sphinx-relay    | => received delete message
sphinx-relay    | [lightning] [ 'verifyMessage' ]
sphinx-relay    | [send notification] {
sphinx-relay    |   chat_id: 1,
sphinx-relay    |   sound: 'default',
sphinx-relay    |   message: 'You have 1 new messages in Planet Sphinx'
sphinx-relay    | }

thunderhub

Attaching to thunderhub_web_1
web_1  | 
web_1  | > thunderhub@0.12.14 start /app
web_1  | > next start
web_1  | 
web_1  | ready - started server on 0.0.0.0:3000, url: http://localhost:3000
```

The double tail is required because `docker-compose logs --tail 10` logs the last 10 lines from EACH container in the app and sorts them all chronologically. So if the app has 3 containers, you'll get 30 lines.