### PR TITLE
Don't depend on bitcoin for electrs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
                         ipv4_address: $NGINX_IP
         bitcoin:
                 container_name: bitcoin
-                image: lncm/bitcoind:v0.21.0@sha256:f9348bff310e1c2bfeca9ca44318ed81a7e74172658881245d0922f77e6c4ca5
+                image: lncm/bitcoind:v0.21.1@sha256:5bedb46d698de16c59e9e43d31485d0d82239bd437d62ac7cf47ebb633214f37
                 depends_on: [ tor, manager, nginx ]
                 volumes:
                         - ${PWD}/bitcoin:/data/.bitcoin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,7 +163,6 @@ services:
         electrs:
               container_name: electrs
               image: getumbrel/electrs:v0.8.9@sha256:592fb50cdf16fa2b2e20f7c0a28d4a132c2ee636d89d4b9c24f14886763b5478
-              depends_on: [ bitcoin ]
               volumes:
                 - ${PWD}/bitcoin:/data/.bitcoin:ro
                 - ${PWD}/electrs:/data


### PR DESCRIPTION
We don't need to add this dependency at the service level since electrs will just poll for Bitcoin Core and wait until it's ready.

However it slows down shutdown time significantly since both electrs and Bitcoin Core take a long time to shutdown and with the dependency shutdown of the two services happens serially instead of in parallel.