### PR TITLE
Update the debug script

### DIFF
--- a/events/triggers/debug
+++ b/events/triggers/debug
@@ -11,7 +11,7 @@ json_encode () {
   jq --null-input --raw-input 'reduce inputs as $line (""; . += "\($line)\n")'
 }
 
-debug_json_string=$("${DEBUG_SCRIPT}" --dashboard | sed '/onion/d' | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | json_encode)
+debug_json_string=$("${DEBUG_SCRIPT}" --filter --no-colors --no-instructions | json_encode)
 dmesg_json_string=$(dmesg | json_encode)
 
 cat <<EOF > "${UMBREL_ROOT}/statuses/debug-status.json"

--- a/scripts/debug
+++ b/scripts/debug
@@ -144,7 +144,7 @@ else
     while [[ "$#" -gt 0 ]]; do
         case $1 in
             -c|--no-colors) allow_colors=false ;;
-            -i|--no-instructions instructions=false ;;
+            -i|--no-instructions) instructions=false ;;
             -f|--filter) filter_sensitive=true ;;
             -u|--upload) upload=true ;;
             -r|--run) echo "--run can't be used with other options!"; exit 1 ;;

--- a/scripts/debug
+++ b/scripts/debug
@@ -194,7 +194,7 @@ else
             echo "you can contact us on our forum (https://community.getumbrel.com/g/staff)."
             if [[ $upload = true ]]; then
                 echo "To make it possible for us to analyze your problem easier, please share the following link with us:"
-                append_dmesg $OUTPUT | sed '/onion/d' | upload
+                append_dmesg "${OUTPUT}" | sed '/onion/d' | upload
             elif [[ $instructions = true ]]; then
                 echo "Please run this script again with the --upload flag to generate a link to share."
             fi
@@ -209,7 +209,7 @@ else
     echo "The debug script did not automatically detect any issues with your Umbrel."
     if [[ $upload = true ]]; then
         echo "Please share the following link and share it with the Umbrel team at https://community.getumbrel.com/g/staff so we can help you with your problem."
-        append_dmesg $OUTPUT | sed '/onion/d' | upload
+        append_dmesg "${OUTPUT}" | sed '/onion/d' | upload
     elif [[ $instructions = true ]]; then
         echo "Please copy the entire output of this script and share it with the Umbrel team at https://community.getumbrel.com/g/staff so we can help you with your problem."
         echo "It's recommended to upload the output somewhere and share a link to it. Run this script with '--upload' to automatically generate a link to share."

--- a/scripts/debug
+++ b/scripts/debug
@@ -140,7 +140,7 @@ if [[ "${1}" == "--run" ]]; then
         no_of_block_devices=$(list_block_devices | wc -l)
     fi
 else
-    OWN_OUTPUT=$(./scripts/debug --run)
+    OWN_OUTPUT="$(./scripts/debug --run)"
     append_dmesg () {
         echo $1
         echo "dmesg"
@@ -148,7 +148,7 @@ else
         dmesg
     }
 
-    echo $OWN_OUTPUT
+    echo "${OWN_OUTPUT}"
 
     echo "================"
     echo "==== Result ===="

--- a/scripts/debug
+++ b/scripts/debug
@@ -137,6 +137,22 @@ if [[ "${1}" == "--run" ]]; then
     done
     fi
 else
+    filter_sensitive=false
+    allow_colors=true
+    upload=false
+    instructions=true
+    while [[ "$#" -gt 0 ]]; do
+        case $1 in
+            -c|--no-colors) allow_colors=false ;;
+            -i|--no-instructions instructions=false ;;
+            -f|--filter) filter_sensitive=true ;;
+            -u|--upload) upload=true ;;
+            -r|--run) echo "--run can't be used with other options!"; exit 1 ;;
+            *) echo "Unknown parameter passed: $1"; exit 1 ;;
+        esac
+        shift
+    done
+    echo "Loading data..."
     OWN_OUTPUT="$(./scripts/debug --run)"
     append_dmesg () {
         echo $1
@@ -144,6 +160,15 @@ else
         echo "-----"
         dmesg
     }
+
+    if [[ $allow_colors = false ]]; then
+        OWN_OUTPUT=$(echo "${OWN_OUTPUT}" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g")
+    fi
+
+    if [[ $filter_sensitive = true ]]; then
+        # TODO: Add more filters
+        OWN_OUTPUT=$(echo "${OWN_OUTPUT}" | sed '/onion/d')
+    fi
 
     echo "${OWN_OUTPUT}"
 
@@ -167,10 +192,10 @@ else
             echo "Please shutdown your Raspberry Pi ('sudo shutdown'), then plug the SSD into the other USB3 port."
             echo "After you've finished that, boot your Raspberry Pi back up. If it still still doesn't work,"
             echo "you can contact us on our forum (https://community.getumbrel.com/g/staff)."
-            if [[ "${1}" == "--upload" ]]; then
+            if [[ $upload = true ]]; then
                 echo "To make it possible for us to analyze your problem easier, please share the following link with us:"
                 append_dmesg $OUTPUT | sed '/onion/d' | upload
-            elif [[ "${1}" != "--dashboard" ]]; then
+            elif [[ $instructions = true ]]; then
                 echo "Please run this script again with the --upload flag to generate a link to share."
             fi
             exit 0
@@ -181,14 +206,11 @@ else
         fi
     fi
 
-    if [[ "${1}" == "--dashboard" ]]; then
-        echo "The debug script did not automatically detect any issues with your Umbrel."
-    elif [[ "${1}" == "--upload" ]]; then
-        echo "This script could not automatically detect an issue with your Umbrel."
+    echo "The debug script did not automatically detect any issues with your Umbrel."
+    if [[ $upload = true ]]; then
         echo "Please share the following link and share it with the Umbrel team at https://community.getumbrel.com/g/staff so we can help you with your problem."
         append_dmesg $OUTPUT | sed '/onion/d' | upload
-    else
-        echo "This script could not automatically detect an issue with your Umbrel."
+    elif [[ $instructions = true ]]; then
         echo "Please copy the entire output of this script and share it with the Umbrel team at https://community.getumbrel.com/g/staff so we can help you with your problem."
         echo "It's recommended to upload the output somewhere and share a link to it. Run this script with '--upload' to automatically generate a link to share."
     fi

--- a/scripts/debug
+++ b/scripts/debug
@@ -139,7 +139,7 @@ if [[ "${1}" == "--run" ]]; then
         }
         no_of_block_devices=$(list_block_devices | wc -l)
     fi
-elif
+else
     OWN_OUTPUT=$(./scripts/debug --run)
     append_dmesg () {
         echo $1

--- a/scripts/debug
+++ b/scripts/debug
@@ -13,7 +13,7 @@ upload() {
     --data-binary @- \
     https://api.debug.umbrel.tech/api/upload \
     | jq '.logKey' \
-    | sed 's/"//g'
+    | sed 's/"//g' \
     | awk -F '"' '{print "https://v3.debug.umbrel.tech/"$1}'
 }
 

--- a/scripts/debug
+++ b/scripts/debug
@@ -6,22 +6,28 @@
 UMBREL_ROOT="$(dirname $(readlink -f "${BASH_SOURCE[0]}"))/.."
 cd "${UMBREL_ROOT}"
 
-if [[ "${1}" == "--run" ]]; then
-    # function to upload the output to our debug log server
-    # Based on https://github.com/seejohnrun/haste-client#lightweight-alternative
-    upload() {
+# function to upload the output to our debug log server
+# Based on https://github.com/seejohnrun/haste-client#lightweight-alternative
+upload() {
     echo "Generating link..."
     curl \
-        --header "Content-Type: text/plain" \
-        --request POST \
-        --silent \
-        --data-binary @- \
-        https://api.debug.umbrel.tech/api/upload \
-        | jq '.logKey' \
-        | sed 's/"//g' \
-        | awk -F '"' '{print "https://v3.debug.umbrel.tech/"$1}'
-    }
+    --header "Content-Type: text/plain" \
+    --request POST \
+    --silent \
+    --data-binary @- \
+    https://api.debug.umbrel.tech/api/upload \
+    | jq '.logKey' \
+    | sed 's/"//g' \
+    | awk -F '"' '{print "https://v3.debug.umbrel.tech/"$1}'
+}
 
+list_block_devices () {
+    # Documented in the mount script for Umbrel OS
+    sync
+    (ls -d /sys/block/sd* 2>/dev/null || true) | sed 's!.*/!!'
+}
+
+if [[ "${1}" == "--run" ]]; then
     echo "====================="
     echo "= Umbrel debug info ="
     echo "====================="
@@ -141,16 +147,6 @@ else
 
     echo "${OWN_OUTPUT}"
 
-
-    if [[ ! -z "${UMBREL_OS:-}" ]]; then
-        list_block_devices () {
-            # Documented in the mount script for Umbrel OS
-            sync
-            (ls -d /sys/block/sd* 2>/dev/null || true) | sed 's!.*/!!'
-        }
-        no_of_block_devices=$(list_block_devices | wc -l)
-    fi
-
     echo "================"
     echo "==== Result ===="
     echo "================"
@@ -164,6 +160,8 @@ else
             fi
             exit 0
         fi
+
+        no_of_block_devices=$(list_block_devices | wc -l)
         if [[ $no_of_block_devices -lt 1 ]]; then
             echo "You have either no external drive connected to your Raspberry Pi or the drive is not being detected."
             echo "Please shutdown your Raspberry Pi ('sudo shutdown'), then plug the SSD into the other USB3 port."
@@ -172,12 +170,11 @@ else
             if [[ "${1}" == "--upload" ]]; then
                 echo "To make it possible for us to analyze your problem easier, please share the following link with us:"
                 append_dmesg $OUTPUT | sed '/onion/d' | upload
-            elif [[ "${1}" == "--dashboard" ]]; then
+            elif [[ "${1}" != "--dashboard" ]]; then
                 echo "Please run this script again with the --upload flag to generate a link to share."
             fi
             exit 0
-        fi
-        if [[ $no_of_block_devices -gt 1 ]]; then
+        elif [[ $no_of_block_devices -gt 1 ]]; then
             echo "You have multiple external drives connected to your Raspberry Pi. Please remove the drive(s) you don't want to use for Umbrel,"
             echo "then reboot your Raspberry Pi by running 'sudo reboot'."
             exit 0

--- a/scripts/debug
+++ b/scripts/debug
@@ -130,15 +130,6 @@ if [[ "${1}" == "--run" ]]; then
         ./scripts/app compose $app logs --tail 30 | tail -n 30;
     done
     fi
-
-    if [[ ! -z "${UMBREL_OS:-}" ]]; then
-        list_block_devices () {
-            # Documented in the mount script for Umbrel OS
-            sync
-            (ls -d /sys/block/sd* 2>/dev/null || true) | sed 's!.*/!!'
-        }
-        no_of_block_devices=$(list_block_devices | wc -l)
-    fi
 else
     OWN_OUTPUT="$(./scripts/debug --run)"
     append_dmesg () {
@@ -149,6 +140,16 @@ else
     }
 
     echo "${OWN_OUTPUT}"
+
+
+    if [[ ! -z "${UMBREL_OS:-}" ]]; then
+        list_block_devices () {
+            # Documented in the mount script for Umbrel OS
+            sync
+            (ls -d /sys/block/sd* 2>/dev/null || true) | sed 's!.*/!!'
+        }
+        no_of_block_devices=$(list_block_devices | wc -l)
+    fi
 
     echo "================"
     echo "==== Result ===="

--- a/scripts/debug
+++ b/scripts/debug
@@ -6,6 +6,7 @@
 # function to upload the output to our debug log server
 # Based on https://github.com/seejohnrun/haste-client#lightweight-alternative
 upload() {
+  echo "Generating link..."
   curl \
     --header "Content-Type: text/plain" \
     --request POST \

--- a/scripts/debug
+++ b/scripts/debug
@@ -156,14 +156,14 @@ else
     upload=false
     instructions=true
     dmesg=false
-    tor=false
+    tor=true
     while [[ "$#" -gt 0 ]]; do
         case $1 in
             --no-colors) allow_colors=false ;;
             --no-instructions) instructions=false ;;
             -f|--filter) filter_sensitive=true ;;
             -u|--upload) upload=true ;;
-            -t|--tor) tor=true ;;
+            --no-tor) tor=false ;;
             -d|--dmesg) dmesg=true ;;
             -r|--run) echo "--run can't be used with other options!"; exit 1 ;;
             *) echo "Unknown parameter passed: $1"; exit 1 ;;
@@ -189,15 +189,16 @@ else
     fi
 
     if [[ $dmesg = true ]]; then
-        OWN_OUTPUT=$(echo "${OWN_OUTPUT}" | sed '/onion/d')
         OWN_OUTPUT=$(append_dmesg "${OWN_OUTPUT}")
     fi
 
     echo "${OWN_OUTPUT}"
     
-    if [[ $dmesg = false ]] && [[ $upload = true ]]; then
+    if [[ $upload = true ]]; then
+        if [[ $dmesg = false ]]; then
+            OWN_OUTPUT=$(append_dmesg "${OWN_OUTPUT}")
+        fi
         OWN_OUTPUT=$(echo "${OWN_OUTPUT}" | sed '/onion/d')
-        OWN_OUTPUT=$(append_dmesg "${OWN_OUTPUT}")
     fi
 
     echo "================"

--- a/scripts/debug
+++ b/scripts/debug
@@ -155,7 +155,7 @@ else
     echo "Loading data..."
     OWN_OUTPUT="$(./scripts/debug --run)"
     append_dmesg () {
-        echo $1
+        echo "${1}"
         echo "dmesg"
         echo "-----"
         dmesg

--- a/scripts/debug
+++ b/scripts/debug
@@ -172,6 +172,11 @@ else
 
     echo "${OWN_OUTPUT}"
 
+    if [[ $upload = true ]]; then
+        OWN_OUTPUT=$(echo "${OWN_OUTPUT}" | sed '/onion/d')
+        OWN_OUTPUT=$(append_dmesg "${OWN_OUTPUT}")
+    fi
+
     echo "================"
     echo "==== Result ===="
     echo "================"
@@ -194,7 +199,7 @@ else
             echo "you can contact us on our forum (https://community.getumbrel.com/g/staff)."
             if [[ $upload = true ]]; then
                 echo "To make it possible for us to analyze your problem easier, please share the following link with us:"
-                append_dmesg "${OUTPUT}" | sed '/onion/d' | upload
+                echo "${OWN_OUTPUT}" | upload
             elif [[ $instructions = true ]]; then
                 echo "Please run this script again with the --upload flag to generate a link to share."
             fi
@@ -209,7 +214,7 @@ else
     echo "The debug script did not automatically detect any issues with your Umbrel."
     if [[ $upload = true ]]; then
         echo "Please share the following link and share it with the Umbrel team at https://community.getumbrel.com/g/staff so we can help you with your problem."
-        append_dmesg "${OUTPUT}" | sed '/onion/d' | upload
+        echo "${OWN_OUTPUT}" | upload
     elif [[ $instructions = true ]]; then
         echo "Please copy the entire output of this script and share it with the Umbrel team at https://community.getumbrel.com/g/staff so we can help you with your problem."
         echo "It's recommended to upload the output somewhere and share a link to it. Run this script with '--upload' to automatically generate a link to share."

--- a/scripts/debug
+++ b/scripts/debug
@@ -1,38 +1,9 @@
-#!/bin/bash
-
-# This script is based on raspinfo: https://github.com/raspberrypi/utils/blob/master/raspinfo/raspinfo
-# raspinfo is Copyright: 2018-2019, Raspberry Pi (Trading) Ltd.
-# This fork is Copyright 2020-2021, Umbrel
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions
-# are met:
-# 1. Redistributions of source code must retain the above copyright
-#    notice, this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright
-#    notice, this list of conditions and the following disclaimer in the
-#    documentation and/or other materials provided with the distribution.
-# 3. Neither the name of the University nor the names of its contributors
-#    may be used to endorse or promote products derived from this software
-#    without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-# ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-# A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE HOLDERS OR
-# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
+#!/usr/bin/env bash
 
 # Try to load Umbrel OS version info to detect Umbrel OS
 [[ -f "/etc/default/umbrel" ]] && source "/etc/default/umbrel"
 
-# function to upload the output to our paste server
+# function to upload the output to our debug log server
 # Based on https://github.com/seejohnrun/haste-client#lightweight-alternative
 upload() {
   curl \
@@ -40,8 +11,10 @@ upload() {
     --request POST \
     --silent \
     --data-binary @- \
-    https://umbrel-paste.vercel.app/documents \
-    | awk -F '"' '{print "https://umbrel-paste.vercel.app/"$6}'
+    https://api.debug.umbrel.tech/api/upload \
+    | jq '.logKey' \
+    | sed 's/"//g'
+    | awk -F '"' '{print "https://v3.debug.umbrel.tech/"$1}'
 }
 
 echo "====================="
@@ -66,13 +39,7 @@ if [[ ! -z "${UMBREL_OS:-}" ]]; then
     echo "Raspberry Pi Model"
     echo "------------------"
 
-    cat /proc/cpuinfo | tail -3
-
-    echo
-    echo "Firmware"
-    echo "--------"
-
-    vcgencmd version
+    cat /proc/cpuinfo | tail -1
 
     echo
     echo "Temperature"
@@ -123,13 +90,11 @@ echo
 echo "Karen logs"
 echo "----------"
 echo
-
 tail -n 50 logs/karen.log | sed '/onion/d'
 
 echo
 echo "Docker containers"
 echo "-----------------"
-
 docker ps --format="table {{.Names}}\t{{.Status}}"
 
 echo
@@ -176,10 +141,11 @@ fi
 echo "================"
 echo "==== Result ===="
 echo "================"
+echo
 if [[ ! -z "${UMBREL_OS:-}" ]]; then
     if [[ $(vcgencmd get_throttled) != "throttled=0x0" ]]; then
         if [[ $(vcgencmd get_throttled) = "throttled=0x5"* ]]; then
-            echo "There is probably issue with your power supply. We recommend using the official power supply to avoid this issue"
+            echo "There is probably issue with your power supply. We recommend using the official power supply to avoid this issue."
         else
             echo "The temperature of your Raspberry Pi is too high. We recommend either using a case that lowers the temperature of your Pi or a case with a builtin fan."
         fi
@@ -189,33 +155,35 @@ if [[ ! -z "${UMBREL_OS:-}" ]]; then
         echo "You have either no external drive connected to your Raspberry Pi or the drive is not being detected."
         echo "Please shutdown your Raspberry Pi ('sudo shutdown'), then plug the SSD into the other USB3 port."
         echo "After you've finished that, boot your Raspberry Pi back up. If it still still doesn't work,"
-        echo "you can contact us on Telegram (t.me/getumbrel) and share the output of this script."
+        echo "you can contact us on our forum (https://community.getumbrel.com/g/staff)."
         if [[ "${1}" == "--upload" ]]; then
-            echo "You can also share these links instead:"
-            echo "$(./scripts/debug | sed '/onion/d') === Umbrel-Paste split === $(dmesg)" | upload
+            echo "To make it possible for us to analyze your problem easier, please share the following link with us:"
+            echo "$(./scripts/debug --with-dmesg | sed '/onion/d')" | upload
         else
-            echo "Run this script again with the --upload flag to automatically generate a link to share."
+            echo "Please run this script again with the --upload flag to generate a link to share."
         fi
         exit 0
     fi
     if [[ $no_of_block_devices -gt 1 ]]; then
-        echo "================"
-        echo "==== Result ===="
-        echo "================"
-        echo "You have multiple external drives connected to your Raspberry Pi. Please remove the drive(s) you don't want to use for Umbrel."
+        echo "You have multiple external drives connected to your Raspberry Pi. Please remove the drive(s) you don't want to use for Umbrel,"
+        echo "then reboot your Raspberry Pi by running 'sudo reboot'."
         exit 0
     fi
 fi
 
 if [[ "${1}" == "--dashboard" ]]; then
     echo "The debug script did not automatically detect any issues with your Umbrel."
+elif [[ "${1}" == "--with-dmesg" ]]; then
+    echo "dmesg"
+    echo "-----"
+    dmesg
 elif [[ "${1}" == "--upload" ]]; then
     # This runs the script twice, but it works
     echo "This script could not automatically detect an issue with your Umbrel."
-    echo "Please share the following links and paste it in the Umbrel Telegram group (https://t.me/getumbrel) so we can help you with your problem."
-    echo "$(./scripts/debug | sed '/onion/d') === Umbrel-Paste split === $(dmesg)" | upload
+    echo "Please share the following link and share it with the Umbrel team at https://community.getumbrel.com/g/staff so we can help you with your problem."
+    echo "$(./scripts/debug --with-dmesg | sed '/onion/d')" | upload
 else
     echo "This script could not automatically detect an issue with your Umbrel."
-    echo "Please copy the entire output of this script and paste it in the Umbrel Telegram group (https://t.me/getumbrel) so we can help you with your problem."
+    echo "Please copy the entire output of this script and share it with the Umbrel team at https://community.getumbrel.com/g/staff so we can help you with your problem."
     echo "It's recommended to upload the output somewhere and share a link to it. Run this script with '--upload' to automatically generate a link to share."
 fi

--- a/scripts/debug
+++ b/scripts/debug
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 
-# Try to load Umbrel OS version info to detect Umbrel OS
-[[ -f "/etc/default/umbrel" ]] && source "/etc/default/umbrel"
-
 UMBREL_ROOT="$(dirname $(readlink -f "${BASH_SOURCE[0]}"))/.."
 cd "${UMBREL_ROOT}"
+
+# Try to load Umbrel OS version info to detect Umbrel OS
+[[ -f "/etc/default/umbrel" ]] && source "/etc/default/umbrel"
+[[ -f "./.env" ]] && source "./.env"
 
 # function to upload the output to our debug log server
 # Based on https://github.com/seejohnrun/haste-client#lightweight-alternative
@@ -13,6 +14,19 @@ upload() {
     curl \
     --header "Content-Type: text/plain" \
     --request POST \
+    --silent \
+    --data-binary @- \
+    https://api.debug.umbrel.tech/api/upload \
+    | jq '.logKey' \
+    | sed 's/"//g' \
+    | awk -F '"' '{print "https://v3.debug.umbrel.tech/"$1}'
+}
+
+torupload() {
+  curl \
+    --header "Content-Type: text/plain" \
+    --request POST \
+    --socks5 "localhost:${TOR_PROXY_PORT}" \
     --silent \
     --data-binary @- \
     https://api.debug.umbrel.tech/api/upload \
@@ -141,12 +155,16 @@ else
     allow_colors=true
     upload=false
     instructions=true
+    dmesg=false
+    tor=false
     while [[ "$#" -gt 0 ]]; do
         case $1 in
-            -c|--no-colors) allow_colors=false ;;
-            -i|--no-instructions) instructions=false ;;
+            --no-colors) allow_colors=false ;;
+            --no-instructions) instructions=false ;;
             -f|--filter) filter_sensitive=true ;;
             -u|--upload) upload=true ;;
+            -t|--tor) tor=true ;;
+            -d|--dmesg) dmesg=true ;;
             -r|--run) echo "--run can't be used with other options!"; exit 1 ;;
             *) echo "Unknown parameter passed: $1"; exit 1 ;;
         esac
@@ -170,9 +188,14 @@ else
         OWN_OUTPUT=$(echo "${OWN_OUTPUT}" | sed '/onion/d')
     fi
 
-    echo "${OWN_OUTPUT}"
+    if [[ $dmesg = true ]]; then
+        OWN_OUTPUT=$(echo "${OWN_OUTPUT}" | sed '/onion/d')
+        OWN_OUTPUT=$(append_dmesg "${OWN_OUTPUT}")
+    fi
 
-    if [[ $upload = true ]]; then
+    echo "${OWN_OUTPUT}"
+    
+    if [[ $dmesg = false ]] && [[ $upload = true ]]; then
         OWN_OUTPUT=$(echo "${OWN_OUTPUT}" | sed '/onion/d')
         OWN_OUTPUT=$(append_dmesg "${OWN_OUTPUT}")
     fi
@@ -214,7 +237,11 @@ else
     echo "The debug script did not automatically detect any issues with your Umbrel."
     if [[ $upload = true ]]; then
         echo "Please share the following link and share it with the Umbrel team at https://community.getumbrel.com/g/staff so we can help you with your problem."
-        echo "${OWN_OUTPUT}" | upload
+        if [[ $tor = true ]]; then
+            echo "${OWN_OUTPUT}" | torupload
+        else
+            echo "${OWN_OUTPUT}" | upload
+        fi
     elif [[ $instructions = true ]]; then
         echo "Please copy the entire output of this script and share it with the Umbrel team at https://community.getumbrel.com/g/staff so we can help you with your problem."
         echo "It's recommended to upload the output somewhere and share a link to it. Run this script with '--upload' to automatically generate a link to share."

--- a/scripts/debug
+++ b/scripts/debug
@@ -3,188 +3,195 @@
 # Try to load Umbrel OS version info to detect Umbrel OS
 [[ -f "/etc/default/umbrel" ]] && source "/etc/default/umbrel"
 
-# function to upload the output to our debug log server
-# Based on https://github.com/seejohnrun/haste-client#lightweight-alternative
-upload() {
-  echo "Generating link..."
-  curl \
-    --header "Content-Type: text/plain" \
-    --request POST \
-    --silent \
-    --data-binary @- \
-    https://api.debug.umbrel.tech/api/upload \
-    | jq '.logKey' \
-    | sed 's/"//g' \
-    | awk -F '"' '{print "https://v3.debug.umbrel.tech/"$1}'
-}
-
-echo "====================="
-echo "= Umbrel debug info ="
-echo "====================="
-
 UMBREL_ROOT="$(dirname $(readlink -f "${BASH_SOURCE[0]}"))/.."
 cd "${UMBREL_ROOT}"
 
-echo
-echo "Umbrel version"
-echo "--------------"
-cat info.json | jq .version | sed 's/"//g'
-
-if [[ ! -z "${UMBREL_OS:-}" ]]; then
-    echo
-    echo "Umbrel OS version"
-    echo "-----------------"
-    echo $UMBREL_OS
-
-    echo
-    echo "Raspberry Pi Model"
-    echo "------------------"
-
-    cat /proc/cpuinfo | tail -1
-
-    echo
-    echo "Temperature"
-    echo "-----------"
-
-    vcgencmd measure_temp
-
-    echo
-    echo "Throttling"
-    echo "----------"
-
-    vcgencmd get_throttled
-fi
-
-echo
-echo "Memory usage"
-echo "------------"
-free --human --mega
-echo
-"${UMBREL_ROOT}/scripts/memory-usage"
-
-
-echo
-echo "Filesystem information"
-echo "----------------------"
-
-df --human-readable / "${UMBREL_ROOT}"
-
-if [[ ! -z "${UMBREL_OS:-}" ]]; then
-    echo
-    echo "Startup service logs"
-    echo "--------------------"
-    journalctl --unit=umbrel-startup.service | tail -n 30  | sed '/onion/d'
-
-    echo
-    echo "External storage service logs"
-    echo "-----------------------------"
-    journalctl --unit=umbrel-external-storage.service | tail -n 30
-
-    echo
-    echo "External storage SD card update service logs"
-    echo "--------------------------------------------"
-    journalctl --unit=umbrel-external-storage-sdcard-update.service | tail -n 30
-fi
-
-
-echo
-echo "Karen logs"
-echo "----------"
-echo
-tail -n 50 logs/karen.log | sed '/onion/d'
-
-echo
-echo "Docker containers"
-echo "-----------------"
-docker ps --format="table {{.Names}}\t{{.Status}}"
-
-echo
-echo "Bitcoin Core logs"
-echo "-----------------"
-echo
-docker-compose logs --tail=30 bitcoin
-
-echo
-echo "LND logs"
-echo "--------"
-echo
-docker-compose logs --tail=30 lnd
-
-echo
-echo "Tor logs"
-echo "--------"
-echo
-docker-compose logs --tail=30 tor
-
-installed_apps=$(./scripts/app ls-installed)
-if [[ ! -z "${installed_apps:-}" ]]; then
-  echo
-  echo "App logs"
-  echo "--------"
-  for app in $installed_apps; do
-    echo
-    echo "${app}"
-    echo
-    # Double tail because we want 30 lines total not per container
-    ./scripts/app compose $app logs --tail 30 | tail -n 30;
-  done
-fi
-
-if [[ ! -z "${UMBREL_OS:-}" ]]; then
-    list_block_devices () {
-        # Documented in the mount script for Umbrel OS
-        sync
-        (ls -d /sys/block/sd* 2>/dev/null || true) | sed 's!.*/!!'
+if [[ "${1}" == "--run" ]]; then
+    # function to upload the output to our debug log server
+    # Based on https://github.com/seejohnrun/haste-client#lightweight-alternative
+    upload() {
+    echo "Generating link..."
+    curl \
+        --header "Content-Type: text/plain" \
+        --request POST \
+        --silent \
+        --data-binary @- \
+        https://api.debug.umbrel.tech/api/upload \
+        | jq '.logKey' \
+        | sed 's/"//g' \
+        | awk -F '"' '{print "https://v3.debug.umbrel.tech/"$1}'
     }
-    no_of_block_devices=$(list_block_devices | wc -l)
-fi
 
-echo "================"
-echo "==== Result ===="
-echo "================"
-echo
-if [[ ! -z "${UMBREL_OS:-}" ]]; then
-    if [[ $(vcgencmd get_throttled) != "throttled=0x0" ]]; then
-        if [[ $(vcgencmd get_throttled) = "throttled=0x5"* ]]; then
-            echo "There is probably issue with your power supply. We recommend using the official power supply to avoid this issue."
-        else
-            echo "The temperature of your Raspberry Pi is too high. We recommend either using a case that lowers the temperature of your Pi or a case with a builtin fan."
-        fi
-        exit 0
-    fi
-    if [[ $no_of_block_devices -lt 1 ]]; then
-        echo "You have either no external drive connected to your Raspberry Pi or the drive is not being detected."
-        echo "Please shutdown your Raspberry Pi ('sudo shutdown'), then plug the SSD into the other USB3 port."
-        echo "After you've finished that, boot your Raspberry Pi back up. If it still still doesn't work,"
-        echo "you can contact us on our forum (https://community.getumbrel.com/g/staff)."
-        if [[ "${1}" == "--upload" ]]; then
-            echo "To make it possible for us to analyze your problem easier, please share the following link with us:"
-            echo "$(./scripts/debug --with-dmesg | sed '/onion/d')" | upload
-        else
-            echo "Please run this script again with the --upload flag to generate a link to share."
-        fi
-        exit 0
-    fi
-    if [[ $no_of_block_devices -gt 1 ]]; then
-        echo "You have multiple external drives connected to your Raspberry Pi. Please remove the drive(s) you don't want to use for Umbrel,"
-        echo "then reboot your Raspberry Pi by running 'sudo reboot'."
-        exit 0
-    fi
-fi
+    echo "====================="
+    echo "= Umbrel debug info ="
+    echo "====================="
 
-if [[ "${1}" == "--dashboard" ]]; then
-    echo "The debug script did not automatically detect any issues with your Umbrel."
-elif [[ "${1}" == "--with-dmesg" ]]; then
-    echo "dmesg"
-    echo "-----"
-    dmesg
-elif [[ "${1}" == "--upload" ]]; then
-    # This runs the script twice, but it works
-    echo "This script could not automatically detect an issue with your Umbrel."
-    echo "Please share the following link and share it with the Umbrel team at https://community.getumbrel.com/g/staff so we can help you with your problem."
-    echo "$(./scripts/debug --with-dmesg | sed '/onion/d')" | upload
-else
-    echo "This script could not automatically detect an issue with your Umbrel."
-    echo "Please copy the entire output of this script and share it with the Umbrel team at https://community.getumbrel.com/g/staff so we can help you with your problem."
-    echo "It's recommended to upload the output somewhere and share a link to it. Run this script with '--upload' to automatically generate a link to share."
+    echo
+    echo "Umbrel version"
+    echo "--------------"
+    cat info.json | jq .version | sed 's/"//g'
+
+    if [[ ! -z "${UMBREL_OS:-}" ]]; then
+        echo
+        echo "Umbrel OS version"
+        echo "-----------------"
+        echo $UMBREL_OS
+
+        echo
+        echo "Raspberry Pi Model"
+        echo "------------------"
+
+        cat /proc/cpuinfo | tail -1
+
+        echo
+        echo "Temperature"
+        echo "-----------"
+
+        vcgencmd measure_temp
+
+        echo
+        echo "Throttling"
+        echo "----------"
+
+        vcgencmd get_throttled
+    fi
+
+    echo
+    echo "Memory usage"
+    echo "------------"
+    free --human --mega
+    echo
+    "${UMBREL_ROOT}/scripts/memory-usage"
+
+
+    echo
+    echo "Filesystem information"
+    echo "----------------------"
+
+    df --human-readable / "${UMBREL_ROOT}"
+
+    if [[ ! -z "${UMBREL_OS:-}" ]]; then
+        echo
+        echo "Startup service logs"
+        echo "--------------------"
+        journalctl --unit=umbrel-startup.service | tail -n 30  | sed '/onion/d'
+
+        echo
+        echo "External storage service logs"
+        echo "-----------------------------"
+        journalctl --unit=umbrel-external-storage.service | tail -n 30
+
+        echo
+        echo "External storage SD card update service logs"
+        echo "--------------------------------------------"
+        journalctl --unit=umbrel-external-storage-sdcard-update.service | tail -n 30
+    fi
+
+
+    echo
+    echo "Karen logs"
+    echo "----------"
+    echo
+    tail -n 50 logs/karen.log | sed '/onion/d'
+
+    echo
+    echo "Docker containers"
+    echo "-----------------"
+    docker ps --format="table {{.Names}}\t{{.Status}}"
+
+    echo
+    echo "Bitcoin Core logs"
+    echo "-----------------"
+    echo
+    docker-compose logs --tail=30 bitcoin
+
+    echo
+    echo "LND logs"
+    echo "--------"
+    echo
+    docker-compose logs --tail=30 lnd
+
+    echo
+    echo "Tor logs"
+    echo "--------"
+    echo
+    docker-compose logs --tail=30 tor
+
+    installed_apps=$(./scripts/app ls-installed)
+    if [[ ! -z "${installed_apps:-}" ]]; then
+    echo
+    echo "App logs"
+    echo "--------"
+    for app in $installed_apps; do
+        echo
+        echo "${app}"
+        echo
+        # Double tail because we want 30 lines total not per container
+        ./scripts/app compose $app logs --tail 30 | tail -n 30;
+    done
+    fi
+
+    if [[ ! -z "${UMBREL_OS:-}" ]]; then
+        list_block_devices () {
+            # Documented in the mount script for Umbrel OS
+            sync
+            (ls -d /sys/block/sd* 2>/dev/null || true) | sed 's!.*/!!'
+        }
+        no_of_block_devices=$(list_block_devices | wc -l)
+    fi
+elif
+    OWN_OUTPUT=$(./scripts/debug --run)
+    append_dmesg () {
+        echo $1
+        echo "dmesg"
+        echo "-----"
+        dmesg
+    }
+
+    echo $OWN_OUTPUT
+
+    echo "================"
+    echo "==== Result ===="
+    echo "================"
+    echo
+    if [[ ! -z "${UMBREL_OS:-}" ]]; then
+        if [[ $(vcgencmd get_throttled) != "throttled=0x0" ]]; then
+            if [[ $(vcgencmd get_throttled) = "throttled=0x5"* ]]; then
+                echo "There is probably issue with your power supply. We recommend using the official power supply to avoid this issue."
+            else
+                echo "The temperature of your Raspberry Pi is too high. We recommend either using a case that lowers the temperature of your Pi or a case with a builtin fan."
+            fi
+            exit 0
+        fi
+        if [[ $no_of_block_devices -lt 1 ]]; then
+            echo "You have either no external drive connected to your Raspberry Pi or the drive is not being detected."
+            echo "Please shutdown your Raspberry Pi ('sudo shutdown'), then plug the SSD into the other USB3 port."
+            echo "After you've finished that, boot your Raspberry Pi back up. If it still still doesn't work,"
+            echo "you can contact us on our forum (https://community.getumbrel.com/g/staff)."
+            if [[ "${1}" == "--upload" ]]; then
+                echo "To make it possible for us to analyze your problem easier, please share the following link with us:"
+                append_dmesg $OUTPUT | sed '/onion/d' | upload
+            elif [[ "${1}" == "--dashboard" ]]; then
+                echo "Please run this script again with the --upload flag to generate a link to share."
+            fi
+            exit 0
+        fi
+        if [[ $no_of_block_devices -gt 1 ]]; then
+            echo "You have multiple external drives connected to your Raspberry Pi. Please remove the drive(s) you don't want to use for Umbrel,"
+            echo "then reboot your Raspberry Pi by running 'sudo reboot'."
+            exit 0
+        fi
+    fi
+
+    if [[ "${1}" == "--dashboard" ]]; then
+        echo "The debug script did not automatically detect any issues with your Umbrel."
+    elif [[ "${1}" == "--upload" ]]; then
+        echo "This script could not automatically detect an issue with your Umbrel."
+        echo "Please share the following link and share it with the Umbrel team at https://community.getumbrel.com/g/staff so we can help you with your problem."
+        append_dmesg $OUTPUT | sed '/onion/d' | upload
+    else
+        echo "This script could not automatically detect an issue with your Umbrel."
+        echo "Please copy the entire output of this script and share it with the Umbrel team at https://community.getumbrel.com/g/staff so we can help you with your problem."
+        echo "It's recommended to upload the output somewhere and share a link to it. Run this script with '--upload' to automatically generate a link to share."
+    fi
 fi


### PR DESCRIPTION
I still don't like what I did in the original debug script, so here's version 3.

### Update for debug server v3
The new server is in development. It seperates the frontend from the backend.
Both parts of the server have been completely rewritten to look better. MongoDB Atlas is used as the backend for the server v3 instead of Firebase.
The legacy debug.umbrel.tech will be deleted a week after 0.3.11 is released (The domain will be removed in a few minutes, but umbrel-paste.vercel.app is the only server we use anyway)

### Remove raspinfo copyright
While the script was based on Raspinfo in the beginning, none of the raspinfo code is left inside our codebase anymore
### Remove duplicated result if multiple SSDs were connected

```
================
==== Result ====
================
```

This was shown twice before.

### Remove firmware version from the output

This may be useful to RPi Foundation staff (which is why it was in raspinfo) but probably nothing we'll need.