### PR TITLE
Improve iptables logic

### DIFF
--- a/scripts/start
+++ b/scripts/start
@@ -96,6 +96,9 @@ echo
 docker-compose up --detach --build --remove-orphans
 echo
 
+echo "Removing status server iptables entry..."
+"${UMBREL_ROOT}/scripts/umbrel-os/status-server/setup-iptables" --delete
+
 echo
 echo "Starting installed apps..."
 echo

--- a/scripts/umbrel-os/external-storage/monitor
+++ b/scripts/umbrel-os/external-storage/monitor
@@ -45,7 +45,7 @@ main () {
   echo "Stopping Umbrel due to failed storage device check..."
   docker kill $(docker ps -aq)
   $set_status mount errored monitor-check
-  $setup_iptables
+  $setup_iptables --force
 }
 
 main

--- a/scripts/umbrel-os/external-storage/monitor
+++ b/scripts/umbrel-os/external-storage/monitor
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
-
 UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/../../..)"
 block_device="${1}"
 mount_point="${2}"

--- a/scripts/umbrel-os/external-storage/monitor
+++ b/scripts/umbrel-os/external-storage/monitor
@@ -6,7 +6,8 @@ UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/../../..)"
 block_device="${1}"
 mount_point="${2}"
 
-set_status="/sd-root/${UMBREL_ROOT}/scripts/umbrel-os/status-server/set-status"
+set_status="/status-server/set-status"
+setup_iptables="/status-server/setup-iptables"
 
 check_if_not_already_running() {
   if ps ax | grep $0 | grep -v $$ | grep bash | grep -v grep
@@ -44,8 +45,9 @@ main () {
   done
 
   echo "Stopping Umbrel due to failed storage device check..."
-  $set_status mount errored monitor-check
   docker kill $(docker ps -aq)
+  $set_status mount errored monitor-check
+  $setup_iptables
 }
 
 main

--- a/scripts/umbrel-os/status-server/setup-iptables
+++ b/scripts/umbrel-os/status-server/setup-iptables
@@ -15,6 +15,11 @@ if [[ "${@}" == *"--delete"* ]]; then
   delete="true"
 fi
 
+force="false"
+if [[ "${@}" == *"--force"* ]]; then
+  force="true"
+fi
+
 check_root () {
   if [[ $UID != 0 ]]; then
     echo "This script must be run as root"
@@ -38,7 +43,11 @@ main () {
     echo "No existing iptables entry found."
   fi
   if [[ "${delete}" == "false" ]]; then
-    iptables --append ${rule[@]}
+    position="--append"
+    if [[ "${force}" == "true" ]]; then
+      position="--insert"
+    fi
+    iptables "${position}" ${rule[@]}
     echo "Appended new iptables entry."
   fi
 }

--- a/scripts/umbrel-os/status-server/setup-iptables
+++ b/scripts/umbrel-os/status-server/setup-iptables
@@ -4,6 +4,17 @@ set -euo pipefail
 
 UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/../../..)"
 
+source /etc/default/umbrel 2> /dev/null || true
+if [[ -z "${UMBREL_OS:-}" ]]; then
+  echo "Exiting iptables setup when not on Umbrel OS"
+  exit
+fi
+
+delete="false"
+if [[ "${@}" == *"--delete"* ]]; then
+  delete="true"
+fi
+
 check_root () {
   if [[ $UID != 0 ]]; then
     echo "This script must be run as root"
@@ -26,8 +37,10 @@ main () {
   else
     echo "No existing iptables entry found."
   fi
-  iptables --append ${rule[@]}
-  echo "Appended new iptables entry."
+  if [[ "${delete}" == "false" ]]; then
+    iptables --append ${rule[@]}
+    echo "Appended new iptables entry."
+  fi
 }
 
 main


### PR DESCRIPTION
The iptables rules were breaking the Tor container. We now remove them after Umbrel has started and re-apply them if the storage monitor script detects a problem.

We also prepend the rules to iptables in the event of disk issues since if the externally mounted Docker data dir is inaccessible we can't guarantee the NGINX container will be shutdown and remove its iptables entry.