### PR TITLE
Reference set-status script from status server bind mount

### DIFF
--- a/scripts/umbrel-os/external-storage/mount
+++ b/scripts/umbrel-os/external-storage/mount
@@ -21,7 +21,7 @@ EXTERNAL_DOCKER_DIR="${MOUNT_POINT}/docker"
 SWAP_DIR="/swap"
 SWAP_FILE="${SWAP_DIR}/swapfile"
 
-set_status="${UMBREL_ROOT}/scripts/umbrel-os/status-server/set-status"
+set_status="/status-server/set-status"
 
 check_root () {
   if [[ $UID != 0 ]]; then

--- a/scripts/umbrel-os/external-storage/update-from-sdcard
+++ b/scripts/umbrel-os/external-storage/update-from-sdcard
@@ -6,7 +6,7 @@ UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/../../..)"
 SD_MOUNT_POINT="/sd-root"
 SD_UMBREL_ROOT="${SD_MOUNT_POINT}${UMBREL_ROOT}"
 
-set_status="${UMBREL_ROOT}/scripts/umbrel-os/status-server/set-status"
+set_status="/status-server/set-status"
 
 check_root () {
   if [[ $UID != 0 ]]; then


### PR DESCRIPTION
We know the script will will definitely be available at this path. The script may not exist in `$UMBREL_ROOT` if we mount an SSD with an old Umbrel install.

h/t @AaronDewes 