### PR TITLE
Umbrel v0.3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Make sure your User ID is `1000` (verify it by running `id -u`) and ensure that 
 > Run this in an empty directory where you want to install Umbrel. If using an external storage such as an SSD or HDD, run this inside an empty directory on that drive.
 
 ```bash
-curl -L https://github.com/getumbrel/umbrel/archive/v0.3.12.tar.gz | tar -xz --strip-components=1
+curl -L https://github.com/getumbrel/umbrel/archive/v0.3.13.tar.gz | tar -xz --strip-components=1
 ```
 
 ### Step 2. Run Umbrel

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
-    "version": "0.3.12",
-    "name": "Umbrel v0.3.12",
+    "version": "0.3.13",
+    "name": "Umbrel v0.3.13",
     "requires": ">=0.2.1",
-    "notes": "Umbrel v0.3.12 fixes a bug that made Umbrel inaccessible over Tor.\n\nIf you face any difficulties while updating, please message us on Telegram: https://t.me/getumbrel"
+    "notes": "Umbrel v0.3.13 brings the latest versions of Ride The Lightning, Specter Desktop, ThunderHub and LNbits in the Umbrel App Store. The new Ride The Lightning version includes an important security fix and updating quickly is strongly recommended.\n\nIf you face any difficulties while updating, please message us on Telegram: https://t.me/getumbrel"
 }


### PR DESCRIPTION
Umbrel v0.3.13 brings the latest versions of Ride The Lightning, Specter Desktop, ThunderHub and LNbits in the Umbrel App Store. The new Ride The Lightning version includes an important security fix and updating quickly is strongly recommended.

If you face any difficulties while updating, please message us on Telegram: https://t.me/getumbrel

Diff: https://github.com/getumbrel/umbrel/compare/v0.3.12...v0.3.13