### PR TITLE
Umbrel OS

### DIFF
--- a/.github/workflows/build_umbrel_os.yml
+++ b/.github/workflows/build_umbrel_os.yml
@@ -18,4 +18,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           path: ./os/umbrel-os.img
-          name: ./os/umbrel-os.img
+          name: umbrel-os.img

--- a/.github/workflows/build_umbrel_os.yml
+++ b/.github/workflows/build_umbrel_os.yml
@@ -1,0 +1,21 @@
+name: Build Umbrel OS image
+
+on: push
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v2
+
+      - name: Build image
+        run: ./os/build.sh
+
+      - name: Uploading image
+        uses: actions/upload-artifact@v2
+        with:
+          path: ./os/umbrel-os.img
+          name: ./os/umbrel-os.img

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ logs/*
 statuses/*
 tor/*
 app-data/*
+os/packer_cache
+os/*.img
 
 # Commit these files
 

--- a/os/build.sh
+++ b/os/build.sh
@@ -1,6 +1,8 @@
+# SCRIPT_DIR="$(readlink $(dirname "${BASH_SOURCE[0]}"))"
+SCRIPT_DIR=$(realpath $(dirname "${BASH_SOURCE[0]}"))
 docker run \
   --rm \
   --privileged \
   -v /dev:/dev \
-  -v ${PWD}:/build \
+  -v ${SCRIPT_DIR}:/build \
   mkaczanowski/packer-builder-arm build raspberrypi.json

--- a/os/build.sh
+++ b/os/build.sh
@@ -1,0 +1,6 @@
+docker run \
+  --rm \
+  --privileged \
+  -v /dev:/dev \
+  -v ${PWD}:/build \
+  mkaczanowski/packer-builder-arm build raspberrypi.json

--- a/os/provision.sh
+++ b/os/provision.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+UMBREL_VERSION="v0.3.13"
+UMBREL_ROOT="/home/umbrel/umbrel"
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Setup Umbrel OS
+# -----------------------
+
+# Update package lists
+apt-get update
+
+# Set UMBREL_OS environment variable
+# TODO: Find the correct place to set this
+echo "UMBREL_OS=${UMBREL_VERSION}" >> /etc/environment
+echo "export UMBREL_OS=${UMBREL_VERSION}" >> /etc/default/umbrel
+
+# Change hostname to Umbrel
+echo umbrel > /etc/hostname
+
+# Install Avahi
+apt-get install -y avahi-daemon avahi-discover libnss-mdns
+
+# Create umbrel user
+password_hash=$(perl -e 'print crypt("moneyprintergobrrr", "salt")')
+useradd --create-home --groups sudo --password $password_hash umbrel
+
+# Pi OS specific tweaks
+# -----------------------
+
+# Enable SSH
+touch /boot/ssh
+
+# Delete Pi user
+pkill --euid pi || true
+deluser --remove-home pi
+
+# Umbrel installation
+# -------------------
+
+# Install Docker
+apt-get install -y curl
+curl -fsSL https://get.docker.com | sh
+usermod --append --groups docker umbrel
+
+# Install docker-compose
+apt-get install -y python3-pip libffi-dev
+pip3 install docker-compose
+
+# Install Umbrel
+apt-get install -y python3-qrcode fswatch rsync jq
+mkdir "${UMBREL_ROOT}"
+(
+  cd "${UMBREL_ROOT}" &&
+  curl -L "https://github.com/getumbrel/umbrel/archive/${UMBREL_VERSION}.tar.gz" | tar -xz --strip-components=1 &&
+  UMBREL_SYSTEMD_SERVICES="${UMBREL_ROOT}/scripts/umbrel-os/services/*.service"
+  for service_path in $UMBREL_SYSTEMD_SERVICES; do
+    service_name=$(basename "${service_path}")
+    install -m 644 "${service_path}" "/etc/systemd/system/${service_name}"
+    systemctl enable "${service_name}"
+  done
+)

--- a/os/raspberrypi.json
+++ b/os/raspberrypi.json
@@ -1,0 +1,41 @@
+{
+  "variables": {},
+  "builders": [{
+    "type": "arm",
+    "file_urls" : ["https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2021-05-28/2021-05-07-raspios-buster-arm64-lite.zip"],
+    "file_checksum": "868cca691a75e4280c878eb6944d95e9789fa5f4bbce2c84060d4c39d057a042",
+    "file_checksum_type": "sha256",
+    "file_target_extension": "zip",
+    "image_build_method": "resize",
+    "image_path": "umbrel-os.img",
+    "image_size": "4G",
+    "image_type": "dos",
+    "image_partitions": [
+      {
+        "name": "boot",
+        "type": "c",
+        "start_sector": "8192",
+        "filesystem": "vfat",
+        "size": "256M",
+        "mountpoint": "/boot"
+      },
+      {
+        "name": "root",
+        "type": "83",
+        "start_sector": "532480",
+        "filesystem": "ext4",
+        "size": "0",
+        "mountpoint": "/"
+      }
+    ],
+    "image_chroot_env": ["PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"],
+    "qemu_binary_source_path": "/usr/bin/qemu-aarch64-static",
+    "qemu_binary_destination_path": "/usr/bin/qemu-aarch64-static"
+  }],
+  "provisioners": [
+    {
+      "type": "shell",
+      "script": "provision.sh"
+    }
+  ]
+}


### PR DESCRIPTION
Just a quickly thrown together example of how Umbrel OS builds could be done.

In a mergeable version:

- The local Umbrel installation would be installed in the image, not a hardcoded version pulled down via git.
- Vanilla Debian would be used as a base image so we don't have to clean up all the Pi OS stuff.
- The provision script would be idempotent so we have a single place to keep track of all dependencies and configurations and we re-run the script after each ota update.
- We would add multiple build targets: Raspberry Pi, x86, etc.

This was just quickly thrown together as I needed the resulting image to test some things. I'll be focusing on other higher priority issues and won't be continuing on this. If anyone else wants to take this on, feel free.

@AaronDewes I know you've been playing around with vmdb2. If you think swapping out Packer for vmdb2 can simplify this process even more then even better.