### PR TITLE
Configure dhcpd to ignore virtual network interfaces

### DIFF
--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -61,6 +61,14 @@ if [[ ! -z "${UMBREL_OS:-}" ]]; then
         DEBIAN_FRONTEND=noninteractive apt-get install unattended-upgrades -y
     fi
 
+    # Make sure dhcpd ignores virtual network interfaces
+    dhcpd_conf="/etc/dhcpcd.conf"
+    dhcpd_rule="denyinterfaces veth*"
+    if [[ -f "${dhcpd_conf}" ]] && ! cat "${dhcpd_conf}" | grep --quiet "${dhcpd_rule}"; then
+      echo "${dhcpd_rule}" >> "${dhcpd_conf}"
+      systemctl restart dhcpcd
+    fi
+
     # This makes sure systemd services are always updated (and new ones are enabled).
     UMBREL_SYSTEMD_SERVICES="${UMBREL_ROOT}/.umbrel-${RELEASE}/scripts/umbrel-os/services/*.service"
     for service_path in $UMBREL_SYSTEMD_SERVICES; do

--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -65,7 +65,7 @@ if [[ ! -z "${UMBREL_OS:-}" ]]; then
     dhcpd_conf="/etc/dhcpcd.conf"
     dhcpd_rule="denyinterfaces veth*"
     if [[ -f "${dhcpd_conf}" ]] && ! cat "${dhcpd_conf}" | grep --quiet "${dhcpd_rule}"; then
-      echo "${dhcpd_rule}" >> "${dhcpd_conf}"
+      echo "${dhcpd_rule}" | tee -a "${dhcpd_conf}"
       systemctl restart dhcpcd
     fi
 


### PR DESCRIPTION
Each running Docker container has a virtual network interface that `dhcpd` tries to keep track of. `dhcpd` can crash when dealing with a large number of interfaces and the device will then become unresponsive over the network.

This change just configures `dhcpd` to ignore all virtual network interfaces which resolves the issue.

Related: https://github.com/raspberrypi/linux/issues/4092

h/t to @AaronDewes for his awesome debugging skills.