### PR TITLE
Add initial PhotoPrism app config

### DIFF
--- a/apps/photoprism/database/.gitignore
+++ b/apps/photoprism/database/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/apps/photoprism/docker-compose.yml
+++ b/apps/photoprism/docker-compose.yml
@@ -1,0 +1,86 @@
+version: "3.7"
+
+# Umbrel Docker Compose config file for PhotoPrism (Linux / AMD64)
+#
+# Documentation : https://docs.photoprism.org/getting-started/docker-compose/
+# Docker Hub URL: https://hub.docker.com/r/photoprism/photoprism/
+#
+# Please run behind a reverse proxy like Caddy, Traefik or Nginx if you need HTTPS / SSL support
+# e.g. when running PhotoPrism on a public server outside your home network.
+#
+# ------------------------------------------------------------------
+# DOCKER COMPOSE COMMAND REFERENCE
+# ------------------------------------------------------------------
+# Start    | docker-compose up -d
+# Stop     | docker-compose stop
+# Update   | docker-compose pull
+# Logs     | docker-compose logs --tail=25 -f
+# Terminal | docker-compose exec photoprism bash
+# Help     | docker-compose exec photoprism photoprism help
+# Config   | docker-compose exec photoprism photoprism config
+# Reset    | docker-compose exec photoprism photoprism reset
+# Backup   | docker-compose exec photoprism photoprism backup -a -i
+# Restore  | docker-compose exec photoprism photoprism restore -a -i
+# Index    | docker-compose exec photoprism photoprism index
+# Reindex  | docker-compose exec photoprism photoprism index -a
+# Import   | docker-compose exec photoprism photoprism import
+# -------------------------------------------------------------------
+# Note: All commands may have to be prefixed with "sudo" when not running as root.
+#       This will change the home directory "~" to "/root" in your configuration.
+
+services:
+  photoprism:
+    # Use photoprism/photoprism:preview instead for testing preview builds:
+    user: "1000:1000"
+    stop_grace_period: "1m"
+    restart: on-failure
+    image: photoprism/photoprism:latest
+    ports:
+      - 2342:2342 # [local port]:[container port]
+    environment:
+      PHOTOPRISM_ADMIN_PASSWORD: "moneyprintergobrrr"  # PLEASE CHANGE: Your initial admin password (min 4 characters)
+      PHOTOPRISM_ORIGINALS_LIMIT: 5000                 # File size limit for originals in MB (increase for high-res video)
+      PHOTOPRISM_HTTP_COMPRESSION: "gzip"              # Improves transfer speed and bandwidth utilization (none or gzip)
+      PHOTOPRISM_DEBUG: "false"                        # Run in debug mode (shows additional log messages)
+      PHOTOPRISM_PUBLIC: "false"                       # No authentication required (disables password protection)
+      PHOTOPRISM_READONLY: "false"                     # Don't modify originals directory (reduced functionality)
+      PHOTOPRISM_EXPERIMENTAL: "false"                 # Enables experimental features
+      PHOTOPRISM_DISABLE_WEBDAV: "false"               # Disables built-in WebDAV server
+      PHOTOPRISM_DISABLE_SETTINGS: "false"             # Disables Settings in Web UI
+      PHOTOPRISM_DISABLE_TENSORFLOW: "false"           # Disables using TensorFlow for image classification
+      PHOTOPRISM_DARKTABLE_PRESETS: "false"            # Enables Darktable presets and disables concurrent RAW conversion
+      PHOTOPRISM_DETECT_NSFW: "false"                  # Flag photos as private that MAY be offensive (requires TensorFlow)
+      PHOTOPRISM_UPLOAD_NSFW: "true"                   # Allow uploads that MAY be offensive
+      # PHOTOPRISM_DATABASE_DRIVER: "sqlite"           # SQLite is an embedded database that doesn't require a server
+      PHOTOPRISM_DATABASE_DRIVER: "mysql"              # Use MariaDB (or MySQL) instead of SQLite for improved performance
+      PHOTOPRISM_DATABASE_SERVER: "mariadb:3306" # MariaDB database server (hostname:port)
+      PHOTOPRISM_DATABASE_NAME: "photoprism"           # MariaDB database schema name
+      PHOTOPRISM_DATABASE_USER: "photoprism"           # MariaDB database user name
+      PHOTOPRISM_DATABASE_PASSWORD: "hre6aErg"         # MariaDB database user password
+      PHOTOPRISM_SITE_URL: "http://localhost:2342/"    # Public PhotoPrism URL
+      PHOTOPRISM_SITE_TITLE: "PhotoPrism"
+      PHOTOPRISM_SITE_CAPTION: "Digital Asset Management"
+      PHOTOPRISM_SITE_DESCRIPTION: ""
+      PHOTOPRISM_SITE_AUTHOR: ""
+    volumes:
+      - "${APP_DATA_DIR}/originals:/photoprism/originals"
+      - "${APP_DATA_DIR}/storage:/photoprism/storage"
+    networks:
+      default:
+        ipv4_address: $APP_LIGHTNING_TERMINAL_IP
+
+  mariadb:
+    stop_grace_period: "1m"
+    restart: on-failure
+    image: mariadb:10.5
+    command: mysqld --transaction-isolation=READ-COMMITTED --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --max-connections=512 --innodb-rollback-on-timeout=OFF --innodb-lock-wait-timeout=50
+    volumes: # Don't remove permanent storage for index database files!
+      - "${APP_DATA_DIR}/database:/var/lib/mysql"
+    environment:
+      MYSQL_ROOT_PASSWORD: bwt4u90by
+      MYSQL_DATABASE: photoprism
+      MYSQL_USER: photoprism
+      MYSQL_PASSWORD: hre6aErg
+    networks:
+      default:
+        ipv4_address: $APP_LIGHTNING_TERMINAL_IP

--- a/apps/photoprism/originals/.gitignore
+++ b/apps/photoprism/originals/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/apps/photoprism/storage/.gitignore
+++ b/apps/photoprism/storage/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Note:
- HTTP port 2342 will be exposed directly. Production
  environments should use an HTTPS proxy like Traefik in front of
  PhotoPrism. Since it makes sense to set up a single reverse proxy
  for all apps (instead of each app running its own proxy), this
  was left open.
- A random initial admin password should be used instead of a
  static one.
- If PhotoPrism doesn't start it's typically due to wrong storage
  folder permissions, like when it was automatically created by
  Docker as root but the container is running as UID 1000.
- SQLite may be used if MariaDB is too heavy, however it doesn't
  scale well for many pictures and/or cpu cores.