### PR TITLE
Support running bin scripts with argument which contains quotes

### DIFF
--- a/bin/bitcoin-cli
+++ b/bin/bitcoin-cli
@@ -7,7 +7,7 @@ UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/..)"
 result=$(docker-compose \
   --file "${UMBREL_ROOT}/docker-compose.yml" \
   --env-file "${UMBREL_ROOT}/.env" \
-  exec bitcoin bitcoin-cli $@)
+  exec bitcoin bitcoin-cli "$@")
 
 # We need to echo with quotes to preserve output formatting
 echo "$result"

--- a/bin/lncli
+++ b/bin/lncli
@@ -7,7 +7,7 @@ UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/..)"
 result=$(docker-compose \
   --file "${UMBREL_ROOT}/docker-compose.yml" \
   --env-file "${UMBREL_ROOT}/.env" \
-  exec lnd lncli $@)
+  exec lnd lncli "$@")
 
 # We need to echo with quotes to preserve output formatting
 echo "$result"


### PR DESCRIPTION
Fix #863
e.g:
```
./bin/lncli addinvoice --amt=6969 --memo="A coffee for Roger"
```
