### PR TITLE
WIP: Add teslamate

### DIFF
--- a/apps/registry.json
+++ b/apps/registry.json
@@ -1,25 +1,25 @@
 [
     {
-      "id": "nextcloud",
-      "category": "Files",
-      "name": "Nextcloud",
-      "version": "21.0.2",
-      "tagline": "Productivity platform that keeps you in control",
-      "description": "Nextcloud puts your data at your fingertips, under your control. Store your documents, calendar, contacts and photos on your Umbrel instead of some company's data center. Features:\n\n- Mobile and desktop sync \n- Versioning and undelete \n- Galleries and activity feed \n- File editing and preview support for PDF, images, text files, Open Document, Word files and more. \n- Smooth performance and easy user interface. \n- Fine-grained control over access to data and sharing capabilities by user and by group.\n\nNote: After creating your admin account when you open Nextcloud for the first time, you'll be taken to a white (blank) screen. Please close the app and open it again to continue.",
-      "developer": "Nextcloud GmbH",
-      "website": "https://nextcloud.com",
-      "dependencies": [],
-      "repo": "https://github.com/nextcloud/server",
-      "support": "https://help.nextcloud.com/categories",
-      "port": 8081,
-      "gallery": [
-          "1.jpg",
-          "2.jpg",
-          "3.jpg"
-      ],
-      "path": "",
-      "defaultPassword": "",
-      "torOnly": false
+        "id": "nextcloud",
+        "category": "Files",
+        "name": "Nextcloud",
+        "version": "21.0.2",
+        "tagline": "Productivity platform that keeps you in control",
+        "description": "Nextcloud puts your data at your fingertips, under your control. Store your documents, calendar, contacts and photos on your Umbrel instead of some company's data center. Features:\n\n- Mobile and desktop sync \n- Versioning and undelete \n- Galleries and activity feed \n- File editing and preview support for PDF, images, text files, Open Document, Word files and more. \n- Smooth performance and easy user interface. \n- Fine-grained control over access to data and sharing capabilities by user and by group.\n\nNote: After creating your admin account when you open Nextcloud for the first time, you'll be taken to a white (blank) screen. Please close the app and open it again to continue.",
+        "developer": "Nextcloud GmbH",
+        "website": "https://nextcloud.com",
+        "dependencies": [],
+        "repo": "https://github.com/nextcloud/server",
+        "support": "https://help.nextcloud.com/categories",
+        "port": 8081,
+        "gallery": [
+            "1.jpg",
+            "2.jpg",
+            "3.jpg"
+        ],
+        "path": "",
+        "defaultPassword": "",
+        "torOnly": false
     },
     {
         "id": "photoprism",
@@ -86,6 +86,28 @@
         "path": "",
         "defaultPassword": "",
         "torOnly": false
+    },
+    {
+        "id": "teslamate",
+        "category": "Analytics",
+        "name": "TeslaMate",
+        "version": "1.23.7",
+        "tagline": "Track your tesla without a third party",
+        "description": "",
+        "developer": "Adrian Kumpf",
+        "website": "https://github.com/adriankumpf",
+        "dependencies": [],
+        "repo": "https://github.com/adriankumpf/teslamate",
+        "support": "https://github.com/adriankumpf/teslamate/issues",
+        "port": 4000,
+        "gallery": [
+            "1.jpg",
+            "2.jpg",
+            "3.jpg"
+        ],
+        "path": "",
+        "defaultPassword": "",
+        "torOnly": true
     },
     {
         "id": "code-server",

--- a/apps/teslamate/docker-compose.yml
+++ b/apps/teslamate/docker-compose.yml
@@ -1,0 +1,50 @@
+version: "3.7"
+
+services:
+  home:
+    image: teslamate/teslamate:1.23.7@sha256:389ab5d9b166e908be2db7936064710adad8829f08e70f89c4a4aaf139f71a55
+    restart: on-failure
+    stop_grace_period: 1m
+    expose:
+      - "4000"
+    environment:
+      - DATABASE_USER=teslamate
+      - DATABASE_PASS=BitcoinRunsOnRenewables
+      - DATABASE_NAME=teslamate
+      - DATABASE_HOST=database
+      - DATABASE_PORT=5432
+      - DISABLE_MQTT=true
+      - TZ=Etc/UTC
+    cap_drop:
+      - all
+    networks:
+      default:
+        ipv4_address: $APP_TESLAMATE_IP
+
+  grafana:
+    image: teslamate/grafana:1.23.7@sha256:cdc8b41245c71d62d34b979232fc6738b8f85c2089aa96beac082d3fde8ec9d7
+    restart: on-failure
+    stop_grace_period: 1m
+    expose:
+      - "3000"
+    environment:
+      - DATABASE_USER=teslamate
+      - DATABASE_PASS=BitcoinRunsOnRenewables
+      - DATABASE_NAME=teslamate
+      - DATABASE_HOST=database
+    volumes:
+      - ${APP_DATA_DIR}/data/grafana:/var/lib/grafana
+    networks:
+      default:
+        ipv4_address: $APP_TESLAMATE_GRAFANA_IP
+
+  database:
+    image: postgres:13.3-alpine@sha256:cd1b837c86e9c2df778b3b4ece70dcd5a74f3ea68f82d00714aec91f34ba328d
+    restart: on-failure
+    stop_grace_period: 1m
+    environment:
+      - POSTGRES_USER=teslamate
+      - POSTGRES_PASSWORD=BitcoinRunsOnRenewables
+      - POSTGRES_DB=teslamate
+    volumes:
+      - ${APP_DATA_DIR}/data/db:/var/lib/postgresql/data

--- a/apps/teslamate/post_install.sh
+++ b/apps/teslamate/post_install.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+app="$1"
+app_data_dir="$2"
+
+# Fix file permissions to match that which would exist when
+# The grafana user creates the folder in a volume
+chmod 777 "${app_data_dir}/data/grafana"
+chown 472:0 "${app_data_dir}/data/grafana"

--- a/scripts/app
+++ b/scripts/app
@@ -153,6 +153,20 @@ update_installed_apps() {
   rm -f "${USER_FILE}.lock"
 }
 
+run_post_install_hook() {
+  local app="${1}"
+  local app_data_dir="${2}"
+
+  if [[ ! -f "${app_data_dir}/post_install.sh" ]]; then
+    # Ignore if it doesn't exist
+    exit
+  fi
+
+  echo "Running post install hook for app ${app}..."
+  "${app_data_dir}/post_install.sh" "${app}" "${app_data_dir}"
+  exit
+}
+
 # Pulls down images for an app and starts it
 if [[ "$command" = "install" ]]; then
 
@@ -168,6 +182,9 @@ if [[ "$command" = "install" ]]; then
 
   echo "Saving app ${app} in DB..."
   update_installed_apps add "${app}"
+
+  # Only echoes if a hook script is found
+  run_post_install_hook "${app}" "${app_data_dir}"
 
   echo "Successfully installed app ${app}"
   exit

--- a/scripts/configure
+++ b/scripts/configure
@@ -184,6 +184,8 @@ APP_VAULTWARDEN_IP="10.21.21.46"
 APP_VAULTWARDEN_PORT="8089"
 APP_CODE_SERVER_IP="10.21.21.53"
 APP_CODE_SERVER_PORT="8091"
+APP_TESLAMATE_IP="10.21.21.47"
+APP_TESLAMATE_GRAFANA_IP="10.21.21.48"
 
 # Generate RPC credentials
 if [[ -z ${BITCOIN_RPC_USER+x} ]] || [[ -z ${BITCOIN_RPC_PASS+x} ]] || [[ -z ${BITCOIN_RPC_AUTH+x} ]]; then
@@ -373,6 +375,8 @@ for template in "${NGINX_CONF_FILE}" "${BITCOIN_CONF_FILE}" "${LND_CONF_FILE}" "
   sed -i "s/<app-vaultwarden-port>/${APP_VAULTWARDEN_PORT}/g" "${template}"
   sed -i "s/<app-code-server-ip>/${APP_CODE_SERVER_IP}/g" "${template}"
   sed -i "s/<app-code-server-port>/${APP_CODE_SERVER_PORT}/g" "${template}"
+  sed -i "s/<app-teslamate-ip>/${APP_TESLAMATE_IP}/g" "${template}"
+  sed -i "s/<app-teslamate-grafana-ip>/${APP_TESLAMATE_GRAFANA_IP}/g" "${template}"
 done
 
 ##########################################################

--- a/templates/.env-sample
+++ b/templates/.env-sample
@@ -87,3 +87,5 @@ APP_VAULTWARDEN_IP=<app-vaultwarden-ip>
 APP_VAULTWARDEN_PORT=<app-vaultwarden-port>
 APP_CODE_SERVER_IP=<app-code-server-ip>
 APP_CODE_SERVER_PORT=<app-code-server-port>
+APP_TESLAMATE_IP=<app-teslamate-ip>
+APP_TESLAMATE_GRAFANA_IP=<app-teslamate-grafana-ip>

--- a/templates/torrc-sample
+++ b/templates/torrc-sample
@@ -127,4 +127,9 @@ HiddenServicePort 80 <app-vaultwarden-ip>:<app-vaultwarden-port>
 HiddenServiceDir /var/lib/tor/app-code-server
 HiddenServicePort 80 <app-code-server-ip>:8080
 
+# teslamate Hidden Service
+HiddenServiceDir /var/lib/tor/app-teslamate
+HiddenServicePort 80 <app-teslamate-ip>:4000
+HiddenServicePort 3000 <app-teslamate-grafana-ip>:3000
+
 HashedControlPassword <password>


### PR DESCRIPTION
Major problems:

1. (**RETRACTED as it's not really that bad. Only bad when compared to https etc.**) Grafana is slow on tor. Extremely slow... 
2. (**SOLVED by removing ports section for home and grafana**) I set tor only as true, but not sure what that does... I can still access via http locally via ip and local hostname. Since this will be a dashboard for personal data and tracking your GPS location for every drive, having that accessible to anyone on your local network seems scary and I'd like to only allow the tor container to have request access to it if possible... in my personal instance I use NGINX Basic Auth password to keep out others... I think "knowledge of the tor onion address" should be enough of a deterrent.
3. (**SOLVED by adding a post install hook**) I need to use a volume for grafana because of an issue in the way they manage sqlite. When I use the normal method, docker creates the folder under 755 root:root permissions. grafana user is 472:0 (it's in the root group(GID) but UID is 472 (name=grafana)) so it chokes on a permission denied error and dies constantly. With volumes, the folder is created (by grafana user) with 777 472:0 permissions... Looking online I see no way around this without grafana container using root user...

TODO:

- Write description
- Take some screenshots (I have a lot of data... so I can take some with my instance.)
- Deal with above problems

When accessing locally, it works great. I can log in with my tesla credentials and it starts pinging my car immediately.