### PR TITLE
Hardcode initial Nextcloud credentials

### DIFF
--- a/apps/nextcloud/docker-compose.yml
+++ b/apps/nextcloud/docker-compose.yml
@@ -43,6 +43,8 @@ services:
       - MYSQL_PASSWORD=moneyprintergobrrr
       - MYSQL_DATABASE=nextcloud
       - MYSQL_USER=nextcloud
+      - NEXTCLOUD_ADMIN_USER=umbrel
+      - NEXTCLOUD_ADMIN_PASSWORD=moneyprintergobrrr
       - NEXTCLOUD_TRUSTED_DOMAINS=${APP_DOMAIN}:${APP_NEXTCLOUD_PORT} ${APP_HIDDEN_SERVICE}
     depends_on:
       - db

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -17,8 +17,8 @@
           "2.jpg",
           "3.jpg"
       ],
-      "path": "",
-      "defaultPassword": "",
+      "path": "/login?user=umbrel",
+      "defaultPassword": "moneyprintergobrrr",
       "torOnly": false
     },
     {

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -5,7 +5,7 @@
       "name": "Nextcloud",
       "version": "21.0.2",
       "tagline": "Productivity platform that keeps you in control",
-      "description": "Nextcloud puts your data at your fingertips, under your control. Store your documents, calendar, contacts and photos on your Umbrel instead of some company's data center. Features:\n\n- Mobile and desktop sync \n- Versioning and undelete \n- Galleries and activity feed \n- File editing and preview support for PDF, images, text files, Open Document, Word files and more. \n- Smooth performance and easy user interface. \n- Fine-grained control over access to data and sharing capabilities by user and by group.\n\nNote: After creating your admin account when you open Nextcloud for the first time, you'll be taken to a white (blank) screen. Please close the app and open it again to continue.",
+      "description": "Nextcloud puts your data at your fingertips, under your control. Store your documents, calendar, contacts and photos on your Umbrel instead of some company's data center. Features:\n\n- Mobile and desktop sync \n- Versioning and undelete \n- Galleries and activity feed \n- File editing and preview support for PDF, images, text files, Open Document, Word files and more. \n- Smooth performance and easy user interface. \n- Fine-grained control over access to data and sharing capabilities by user and by group.\n\nNote: After logging in to Nextcloud please change the password to something secure before sharing the address with anyone.",
       "developer": "Nextcloud GmbH",
       "website": "https://nextcloud.com",
       "dependencies": [],

--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -132,9 +132,10 @@ cd "$UMBREL_ROOT"
 
 # Fix broken Nextcloud installs from Umbrel v0.4.0 to be accessible from both
 # umbrel.local and Tor
+current_umbrel_version=$(cat "${UMBREL_ROOT}/info.json" | jq -r .version)
 nextcloud_config_file="${UMBREL_ROOT}/app-data/nextcloud/data/nextcloud/config/config.php"
 nextcloud_tor_file="${UMBREL_ROOT}/tor/data/app-nextcloud/hostname"
-if [[ -f "${nextcloud_config_file}" ]] && [[ -f "${nextcloud_tor_file}" ]]; then
+if [[ "${current_umbrel_version}" = "0.4.0" ]] && [[ -f "${nextcloud_config_file}" ]] && [[ -f "${nextcloud_tor_file}" ]]; then
   echo
   echo "Fixing broken Umbrel v0.4.0 Nextcloud install..."
   nextcloud_hs=$(cat "${nextcloud_tor_file}")

--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -144,6 +144,7 @@ if [[ "${current_umbrel_version}" = "0.4.0" ]] && [[ -f "${nextcloud_config_file
     -e '/)/!d;a\  \x27trusted_domains\x27 => array ( 0 => \x27localhost\x27, 1 => \x27umbrel.local:8081\x27, 2 => \x27'$nextcloud_hs'\x27),' \
     -e 'd' \
     -i "${nextcloud_config_file}"
+  echo
 fi
 
 # Move Docker data dir to external storage now if this is an old install.

--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -130,6 +130,21 @@ EOF
 cd "$UMBREL_ROOT"
 ./scripts/stop
 
+# Fix broken Nextcloud installs from Umbrel v0.4.0 to be accessible from both
+# umbrel.local and Tor
+nextcloud_config_file="${UMBREL_ROOT}/app-data/nextcloud/data/nextcloud/config/config.php"
+nextcloud_tor_file="${UMBREL_ROOT}/tor/data/app-nextcloud/hostname"
+if [[ -f "${nextcloud_config_file}" ]] && [[ -f "${nextcloud_tor_file}" ]]; then
+  echo
+  echo "Fixing broken Umbrel v0.4.0 Nextcloud install..."
+  nextcloud_hs=$(cat "${nextcloud_tor_file}")
+  sed \
+    -e '/trusted_domains\x27 => $/,/)/!b' \
+    -e '/)/!d;a\  \x27trusted_domains\x27 => array ( 0 => \x27localhost\x27, 1 => \x27umbrel.local:8081\x27, 2 => \x27'$nextcloud_hs'\x27),' \
+    -e 'd' \
+    -i "${nextcloud_config_file}"
+fi
+
 # Move Docker data dir to external storage now if this is an old install.
 # This is only needed temporarily until all users have transitioned Docker to SSD.
 DOCKER_DIR="/var/lib/docker"


### PR DESCRIPTION
The Nextcloud container only respects the some of the configuration environment variables when you hardcode auth parameters. If you let the user manually go through the setup process, configurations settings are set to defaults and the environment variables we set are ignored. Notably whitelisting both the local hostname and the Tor hidden service does not happen when a user manually registers, instead Nextcloud is only accessible over the hostname they accessed the registration form over.

This change hardcodes a default Nextcloud username/password of `umbrel`/`moneyprintergobrrr` which triggers the Docker image to run through the automated setup process and respect our environment variables. Added a note explaining users who wish to share files via Nextcloud should update the password before sharing links.

We also add a migration step to the update step to fix any existing installs that