### PR TITLE
Don't overwrite existing LND config after update

### DIFF
--- a/scripts/configure
+++ b/scripts/configure
@@ -381,10 +381,17 @@ done
 
 mv -f "$NGINX_CONF_FILE" "./nginx/nginx.conf"
 mv -f "$BITCOIN_CONF_FILE" "./bitcoin/bitcoin.conf"
-mv -f "$LND_CONF_FILE" "./lnd/lnd.conf"
 mv -f "$TOR_CONF_FILE" "./tor/torrc"
 mv -f "$ELECTRS_CONF_FILE" "./electrs/electrs.toml"
 mv -f "$ENV_FILE" "./.env"
+
+# Only write LND config if one doesn't already exist to preserve any user changes.
+if [[ -f "./lnd/lnd.conf" ]]; then
+  echo "Skipping lnd.conf update to preserve user changes..."
+  rm "$LND_CONF_FILE"
+else
+  mv -f "$LND_CONF_FILE" "./lnd/lnd.conf"
+fi
 
 ##########################################################
 ######### Generate hidden services on first run ##########

--- a/scripts/update/.updateinclude
+++ b/scripts/update/.updateinclude
@@ -1,5 +1,4 @@
 .env
 bitcoin/bitcoin.conf
-lnd/lnd.conf
 tor/torrc
 electrs/electrs.toml


### PR DESCRIPTION
We currently use templates for all config files that are rebuilt during each configure script run (during each update) based on a set of input variables. This gives us easy control of all configuration files and allows us to completely rewrite them on any update or based on some sort of application state without conflicts.

This also means any user applied changes to config files get wiped after each update. Manual editing of config files isn't advised, any configuration options would ideally be exposed in the UI and handled by Umbrel's config generation system safely. However many users are becoming frustrated with their personal LND configuration changes being wiped after each update, for now it makes more sense to prevent clobbering lnd.conf changes on each update.

Note: Now changing any Umbrel variables used by lnd.conf (credentials/ports/IPs for LND/Bitcoin Core/Tor) will not be automatically applied and will require a manual migration step to keep existing installs working correctly.