### PR TITLE
Update specter desktop to 1.5.1

### DIFF
--- a/apps/registry.json
+++ b/apps/registry.json
@@ -294,7 +294,7 @@
         "id": "specter-desktop",
         "category": "Wallets",
         "name": "Specter Desktop",
-        "version": "1.5.0",
+        "version": "1.5.1",
         "tagline": "Multisig with hardware wallets made easy",
         "description": "Specter Desktop connects to the Bitcoin Core running on your Umbrel and functions as a watch-only coordinator for multi-signature and single-key Bitcoin wallets. At the moment Specter Desktop is working with all major hardware wallets including:\n\n- Trezor\n- Ledger\n- KeepKey\n- BitBox02\n- ColdCard (optionally airgapped, using an SD card)\n- Electrum (optionally airgapped, if running Electrum on an airgapped computer/phone)\n- Specter DIY (optionally airgapped, using QR codes)\n- Cobo (airgapped, using QR codes)\n\nSpecter Desktop also supports using the Bitcoin Core on your Umbrel as a hot wallet, by importing or generating a random BIP39 mnemonic, but this feature is experimental and we do not recommend using it at this stage. We plan to add support for other hardware wallets as they come up.",
         "developer": "Crypto Advance",

--- a/apps/specter-desktop/docker-compose.yml
+++ b/apps/specter-desktop/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: lncm/specter-desktop:v1.5.0@sha256:c3e99bcb0dde4f2dcf26f089e73a7a50835e35a7839b0e70416ef6f21d0dd868
+    image: lncm/specter-desktop:v1.5.1@sha256:fcfd2d5b5808c48717af7830b6da92606fbd7f5edcdd62b5766a0cb2f08f2ffe
     stop_signal: SIGINT
     restart: on-failure
     stop_grace_period: 1m


### PR DESCRIPTION
Release notes [here](https://github.com/cryptoadvance/specter-desktop/releases/tag/v1.5.1)