### PR TITLE
Make sure configure script never overwrites app permissions

### DIFF
--- a/scripts/configure
+++ b/scripts/configure
@@ -424,7 +424,7 @@ fi
 
 echo "Configuring permissions..."
 echo
-chown -R 1000:1000 "$UMBREL_ROOT"
+find "$UMBREL_ROOT" -path "$UMBREL_ROOT/app-data" -prune -o -exec chown 1000:1000 {} +
 
 # Create configured status
 touch "${STATUS_DIR}/configured"


### PR DESCRIPTION
If the configure script is run from the root dir it will clobber the entire app-data dir permissions breaking any apps that require certain permissions they've already setup like Nextcloud.

We should really look into why this `chown -R 1000:1000 "$UMBREL_ROOT"` was added and either remove it if it's no longer needed or lock it down to the specific files/directories it's supposed to target if it is needed.