### PR TITLE
Make sure code-server restarts on failure

### DIFF
--- a/apps/code-server/docker-compose.yml
+++ b/apps/code-server/docker-compose.yml
@@ -3,6 +3,7 @@ version: "3.7"
 services:
   server:
     image: codercom/code-server:3.11.0@sha256:d712341c622b0ae896d8f5b8c02368e44e1f5a03b93cd0489f937352dfc7bab8
+    restart: on-failure
     user: "1000:1000"
     ports:
       - "${APP_CODE_SERVER_PORT}:8080"


### PR DESCRIPTION
code-server sometimes fails to start with `error timed out`. It seems to happen often on initial start or after a update, but not if manaully restarted. It appears it could be due to many apps starting at the same time (during initial start or after an update) which slows everything down and means some low timeout expires which doesn't happen when more resources are free (manual app restart).

Anyway, just adding `restart: on-failure` (which was mistakenly left out of the initial PR) ensures that when this edge case is hit the Docker will attempt to start the app again until it succeeds.