### PR TITLE
Draft: Add screen driver

### DIFF
--- a/events/triggers/install-screen
+++ b/events/triggers/install-screen
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/../..)"
+
+check_root () {
+  if [[ $UID != 0 ]]; then
+    echo "This script must be run as root"
+    exit 1
+  fi
+}
+
+check_umbrel_os () {
+  [[ -f "/etc/default/umbrel" ]] && source "/etc/default/umbrel"
+  if [[ -z "${UMBREL_OS:-}" ]]; then
+    echo "This script must only be run on Umbrel OS"
+    exit 1
+  fi
+}
+
+check_root
+check_umbrel_os
+
+# This script installs a screen driver, then reboots Umbrel
+echo "dtoverlay=piscreen,speed=16000000,rotate=270" >> /boot/config.txt
+echo "dtparam=spi=on" >> /boot/config.txt
+modprobe spi-bcm2835
+touch "${UMBREL_ROOT}/statuses/screen-configured"


### PR DESCRIPTION
This is a proposal for a screen driver feature for Umbrel. This is the host part. If you think this is a good way to do this, corresponding manager logic will be added.

My proposal would be that apps can request an additional dependency "framebuffer", which gives them access to /dev/fb* and installation causes the manager to execute this trigger, and the dashboard to prompt for a reboot.

This would allow getting apps like https://github.com/lorenzoPrimi/umbrel-crypto-display to work inside docker.

@lukechilds @mayankchhabra What are your thoughts on this?

I'll follow up with PRs to other components if you think this is an acceptable way of adding screen apps.

TODO: set executable permission, this was a quick draft from the GitHub web editor
TODO: Allow changing screen rotation via separate trigger. (Screen rotation should be a setting on the dashboard)