### PR TITLE
Improve samourai-server app stability

### DIFF
--- a/apps/samourai-server/docker-compose.yml
+++ b/apps/samourai-server/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     image: louneskmt/dojo-nodejs:1.10.1@sha256:d1460df18df091837718fcd0a6d3850e2f1a4a49da5914a697648c40d5477184
     init: true
     restart: on-failure
-    command: "/home/node/app/wait-for-it.sh db:3306 --timeout=720 --strict -- /home/node/app/restart.sh"
+    command: "/home/node/app/wait-for-it.sh ${APP_SAMOURAI_SERVER_DB_IP}:3306 --timeout=720 --strict -- /home/node/app/restart.sh"
     user: "1000:1000"
     environment:
       # GLOBAL

--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -203,6 +203,14 @@ if [[ -d "${samourai_app_dir}" ]] && [[ -d "${samourai_data_dir}" ]]; then
   rsync --archive --verbose "${samourai_app_dir}/" "${samourai_data_dir}"
 fi
 
+# Handle updating mysql conf for samourai-server app
+samourai_app_mysql_conf="${UMBREL_ROOT}/apps/samourai-server/mysql/mysql-dojo.cnf"
+samourai_data_mysql_conf="${UMBREL_ROOT}/app-data/samourai-server/mysql/mysql-dojo.cnf"
+if [[ -f "${samourai_app_mysql_conf}" ]] && [[ -f "${samourai_data_mysql_conf}" ]]; then
+  echo "Found samourai-server install, attempting to update DB configuration..."
+  cp "${samourai_app_mysql_conf}" "${samourai_data_mysql_conf}"
+fi
+
 # Handle hidden service migration for samourai-server app
 samourai_app_dojo_tor_dir="${UMBREL_ROOT}/tor/data/app-samourai-server"
 samourai_app_new_dojo_tor_dir="${UMBREL_ROOT}/tor/data/app-samourai-server-dojo"


### PR DESCRIPTION
We were polling DB based on hostname which could in some occasions resolve to a different container preventing the app from starting. We now poll based on IP.

We also hadn't updated the MySQL configuration file for existing installs. Fresh installs get the latest config file but existing installs were stuck on the previous version. `max_connections` was increased from 20 to 80 and not running the new higher limit causes the Node.js process to get disconnected from the DB.