### PR TITLE
Handle mount script fail

### DIFF
--- a/scripts/umbrel-os/external-storage/mount
+++ b/scripts/umbrel-os/external-storage/mount
@@ -146,6 +146,7 @@ copy_docker_to_external_storage () {
 
 main () {
   $set_status mount started
+  trap '[[ "$?" != "0" ]] && $set_status mount errored mount-script-exit' EXIT
   echo "Running external storage mount script..."
   check_root
   check_dependencies sed wipefs parted mount sync umount

--- a/scripts/umbrel-os/status-server/static/index.html
+++ b/scripts/umbrel-os/status-server/static/index.html
@@ -77,8 +77,8 @@
       </div>
 
       <div class="error-text mount-script-exit">
-        <p><b class="text-dark">Error: Mount script failed</b></p>
-        <p>Something went wrong when mounting or formatting your external drive.</p>
+        <p><b class="text-dark">Error: Mounting external drive failed</b></p>
+        <p>Something went wrong when trying to connect to the external drive.</p>
       </div>
 
       <div class="error-text no-block-device">

--- a/scripts/umbrel-os/status-server/static/index.html
+++ b/scripts/umbrel-os/status-server/static/index.html
@@ -76,6 +76,11 @@
         <p>The version of UmbrelOS on your microSD card is not compatible with the version of Umbrel on your external drive.</p>
       </div>
 
+      <div class="error-text mount-script-exit">
+        <p><b class="text-dark">Error: Mount script failed</b></p>
+        <p>Something went wrong when mounting or formatting your external drive.</p>
+      </div>
+
       <div class="error-text no-block-device">
         <p><b class="text-dark">Error: No external drive found</b></p>
         <p>Please connect an external drive (at least 1TB) to a USB 3.0 port (blue color) on your Raspberry Pi and restart your Umbrel.</p>

--- a/scripts/umbrel-os/status-server/static/styles.css
+++ b/scripts/umbrel-os/status-server/static/styles.css
@@ -49,6 +49,7 @@ p {
 }
 [data-error="monitor-check"] .error-text.monitor-check,
 [data-error="semver-mismatch"] .error-text.semver-mismatch,
+[data-error="mount-script-exit"] .error-text.mount-script-exit,
 [data-error="no-block-device"] .error-text.no-block-device,
 [data-error="multiple-block-devices"] .error-text.multiple-block-devices,
 [data-error="rebinding-failed"] .error-text.rebinding-failed {


### PR DESCRIPTION
If the mount script fails to format or mount the drive in a way that causes the mount script to exit but isn't caught by our existing error catching logic, the user will see "Starting Umbrel..." forever when booting.

This change adds an extra error case to catch any non-zero exit code from the mount script and show a warning to the user during boot.