### PR TITLE
Catch docker-compose up failure

### DIFF
--- a/scripts/start
+++ b/scripts/start
@@ -108,7 +108,11 @@ echo
 echo
 echo "Starting Docker services..."
 echo
-docker-compose up --detach --build --remove-orphans
+docker-compose up --detach --build --remove-orphans || {
+  echo "Failed to start containers"
+  $set_status umbrel errored docker-failed
+  exit 1
+}
 echo
 
 echo "Removing status server iptables entry..."

--- a/scripts/umbrel-os/status-server/static/index.html
+++ b/scripts/umbrel-os/status-server/static/index.html
@@ -81,6 +81,11 @@
         <p>Something went wrong when starting Umbrel. Need help? Feel free to jump on our <a href="https://community.getumbrel.comhttps://t.me/getumbrel" target="_blank">community forum</a> or <a href="https://t.me/getumbrel" target="_blank">Telegram chat</a>.</p>
       </div>
 
+      <div class="error-text docker-failed">
+        <p><b class="text-dark">Error: Failed to start containers</b></p>
+        <p>Something went wrong when starting Umbrel. Need help? Feel free to jump on our <a href="https://community.getumbrel.comhttps://t.me/getumbrel" target="_blank">community forum</a> or <a href="https://t.me/getumbrel" target="_blank">Telegram chat</a>.</p>
+      </div>
+
       <div class="error-text no-block-device">
         <p><b class="text-dark">Error: No external drive found</b></p>
         <p>Please connect an external drive (at least 1TB) to a USB 3.0 port (blue color) on your Raspberry Pi and restart your Umbrel.</p>

--- a/scripts/umbrel-os/status-server/static/styles.css
+++ b/scripts/umbrel-os/status-server/static/styles.css
@@ -50,6 +50,7 @@ p {
 [data-error="monitor-check"] .error-text.monitor-check,
 [data-error="semver-mismatch"] .error-text.semver-mismatch,
 [data-error="service-failed"] .error-text.service-failed,
+[data-error="docker-failed"] .error-text.docker-failed,
 [data-error="no-block-device"] .error-text.no-block-device,
 [data-error="multiple-block-devices"] .error-text.multiple-block-devices,
 [data-error="rebinding-failed"] .error-text.rebinding-failed {


### PR DESCRIPTION
If `docker-compose up` fails for some reason, which it sometimes does if containers weren't shutdown cleanly, the user will get stuck in an endless loop saying "Starting Umbrel..." on the status server.

This change catches that specific error and shows a "Failed to start containers" error message.