### PR TITLE
Update the squeaknode app to v0.1.153

### DIFF
--- a/apps/squeaknode/docker-compose.yml
+++ b/apps/squeaknode/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: yzernik/squeaknode:v0.1.153@7443fc398198e35dd19b6650703134641548edec924fcb7203287d6b169cc46f
+    image: yzernik/squeaknode:v0.1.153@sha256:7443fc398198e35dd19b6650703134641548edec924fcb7203287d6b169cc46f
     restart: on-failure
     stop_grace_period: 1m
     ports:

--- a/apps/squeaknode/docker-compose.yml
+++ b/apps/squeaknode/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: yzernik/squeaknode:v0.1.153:7443fc398198e35dd19b6650703134641548edec924fcb7203287d6b169cc46f
+    image: yzernik/squeaknode:v0.1.153@7443fc398198e35dd19b6650703134641548edec924fcb7203287d6b169cc46f
     restart: on-failure
     stop_grace_period: 1m
     ports:

--- a/apps/squeaknode/docker-compose.yml
+++ b/apps/squeaknode/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: yzernik/squeaknode:v0.1.153:7443fc398198e35dd19b6650703134641548edec924fcb7203287d6b169cc46f
+    image: yzernik/squeaknode:v0.1.153:4d9da99a27fe4834f60961304cc7b1c47af807d5b7d7e3362ded3877d08a6814
     restart: on-failure
     stop_grace_period: 1m
     ports:

--- a/apps/squeaknode/docker-compose.yml
+++ b/apps/squeaknode/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: yzernik/squeaknode:v0.1.153:4d9da99a27fe4834f60961304cc7b1c47af807d5b7d7e3362ded3877d08a6814
+    image: yzernik/squeaknode:v0.1.153:7443fc398198e35dd19b6650703134641548edec924fcb7203287d6b169cc46f
     restart: on-failure
     stop_grace_period: 1m
     ports:

--- a/apps/squeaknode/docker-compose.yml
+++ b/apps/squeaknode/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: yzernik/squeaknode:v0.1.152@sha256:9d4859bed472314e88ec8ad76e45b60872db61267d4f1bd52937b8a5107814c8
+    image: yzernik/squeaknode:master
     restart: on-failure
     stop_grace_period: 1m
     ports:

--- a/apps/squeaknode/docker-compose.yml
+++ b/apps/squeaknode/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: yzernik/squeaknode:master
+    image: yzernik/squeaknode:v0.1.153:7443fc398198e35dd19b6650703134641548edec924fcb7203287d6b169cc46f
     restart: on-failure
     stop_grace_period: 1m
     ports:


### PR DESCRIPTION
Release notes at https://github.com/yzernik/squeaknode/releases/tag/v0.1.153