### PR TITLE
Update app mariadb containers to 10.5.12

### DIFF
--- a/apps/gitea/docker-compose.yml
+++ b/apps/gitea/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       default:
         ipv4_address: $APP_GITEA_IP
   db:
-    image: mariadb:10.5.8@sha256:8040983db146f729749081c6b216a19d52e0973134e2e34c0b4fd87f48bc15b0
+    image: mariadb:10.5.12@sha256:dfcba5641bdbfd7cbf5b07eeed707e6a3672f46823695a0d3aba2e49bbd9b1dd
     user: "1000:1000"
     restart: on-failure
     volumes:

--- a/apps/mempool/docker-compose.yml
+++ b/apps/mempool/docker-compose.yml
@@ -45,7 +45,7 @@ services:
        default:
          ipv4_address: $APP_MEMPOOL_API_IP
   mariadb:
-    image: mariadb:10.5.8@sha256:8040983db146f729749081c6b216a19d52e0973134e2e34c0b4fd87f48bc15b0
+    image: mariadb:10.5.12@sha256:dfcba5641bdbfd7cbf5b07eeed707e6a3672f46823695a0d3aba2e49bbd9b1dd
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m

--- a/apps/nextcloud/docker-compose.yml
+++ b/apps/nextcloud/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   db:
-    image: mariadb:10.5.8@sha256:8040983db146f729749081c6b216a19d52e0973134e2e34c0b4fd87f48bc15b0
+    image: mariadb:10.5.12@sha256:dfcba5641bdbfd7cbf5b07eeed707e6a3672f46823695a0d3aba2e49bbd9b1dd
     user: "1000:1000"
     command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
     restart: on-failure

--- a/apps/photoprism/docker-compose.yml
+++ b/apps/photoprism/docker-compose.yml
@@ -32,7 +32,7 @@ services:
         ipv4_address: ${APP_PHOTOPRISM_IP}
 
   db:
-    image: mariadb:10.5.8@sha256:8040983db146f729749081c6b216a19d52e0973134e2e34c0b4fd87f48bc15b0
+    image: mariadb:10.5.12@sha256:dfcba5641bdbfd7cbf5b07eeed707e6a3672f46823695a0d3aba2e49bbd9b1dd
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: "1m"

--- a/apps/samourai-server/docker-compose.yml
+++ b/apps/samourai-server/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   db:
-    image: mariadb:10.5.8@sha256:8040983db146f729749081c6b216a19d52e0973134e2e34c0b4fd87f48bc15b0
+    image: mariadb:10.5.12@sha256:dfcba5641bdbfd7cbf5b07eeed707e6a3672f46823695a0d3aba2e49bbd9b1dd
     init: true
     restart: on-failure
     stop_grace_period: 5m


### PR DESCRIPTION
Some users have experienced issues with MariaDB 10.5.8 where it fails to start with the error:

```
[ERROR] [Entrypoint]: mysqld failed while attempting to check config
```

 Updating to MariaDB 10.5.12 appears to resolve the issue.