### PR TITLE
Change squeaknode tagline

### DIFF
--- a/apps/registry.json
+++ b/apps/registry.json
@@ -481,7 +481,7 @@
         "category": "Social",
         "name": "Squeaknode",
         "version": "0.1.152",
-        "tagline": "A peer-to-peer status feed on Lightning",
+        "tagline": "A peer-to-peer status feed with lightning monetization",
         "description": "The Squeaknode app allows you to create, view, buy, and sell squeaks. A squeak is a single post that can contain up to 280 characters.\n\nThe Squeaknode timeline is ordered by the timestamp/blockhash embedded in each squeak. Each squeak is signed with a digital signature of the private key of the author. Squeaks can be downloaded from any peer to any peer, but they remain locked until the downloader makes a Lightning payment to decrypt the content.",
         "developer": "Jonathan Zernik",
         "website": "https://github.com/yzernik",

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -481,7 +481,7 @@
         "category": "Social",
         "name": "Squeaknode",
         "version": "0.1.152",
-        "tagline": "A peer-to-peer status feed with lightning monetization",
+        "tagline": "A peer-to-peer status feed with Lightning monetization",
         "description": "The Squeaknode app allows you to create, view, buy, and sell squeaks. A squeak is a single post that can contain up to 280 characters.\n\nThe Squeaknode timeline is ordered by the timestamp/blockhash embedded in each squeak. Each squeak is signed with a digital signature of the private key of the author. Squeaks can be downloaded from any peer to any peer, but they remain locked until the downloader makes a Lightning payment to decrypt the content.",
         "developer": "Jonathan Zernik",
         "website": "https://github.com/yzernik",


### PR DESCRIPTION
This would update the squeaknode tagline. I think the current tagline may confuse users, because they may think that squeaknode uses lightning network itself to send messages between peers.