### PR TITLE
Remove unused configs for squeaknode envoy ip and port

### DIFF
--- a/scripts/configure
+++ b/scripts/configure
@@ -202,8 +202,6 @@ APP_SQUEAKNODE_PORT="12994"
 APP_SQUEAKNODE_GRPC_PORT="8994"
 APP_SQUEAKNODE_P2P_PORT="8555"
 APP_SQUEAKNODE_P2P_TESTNET_PORT="18555"
-APP_SQUEAKNODE_ENVOY_IP="10.21.21.55"
-APP_SQUEAKNODE_ENVOY_PORT="15081"
 
 # Generate RPC credentials
 if [[ -z ${BITCOIN_RPC_USER+x} ]] || [[ -z ${BITCOIN_RPC_PASS+x} ]] || [[ -z ${BITCOIN_RPC_AUTH+x} ]]; then
@@ -402,8 +400,6 @@ for template in "${NGINX_CONF_FILE}" "${BITCOIN_CONF_FILE}" "${LND_CONF_FILE}" "
   sed -i "s/<app-squeaknode-grpc-port>/${APP_SQUEAKNODE_GRPC_PORT}/g" "${template}"
   sed -i "s/<app-squeaknode-p2p-port>/${APP_SQUEAKNODE_P2P_PORT}/g" "${template}"
   sed -i "s/<app-squeaknode-p2p-testnet-port>/${APP_SQUEAKNODE_P2P_TESTNET_PORT}/g" "${template}"
-  sed -i "s/<app-squeaknode-envoy-ip>/${APP_SQUEAKNODE_ENVOY_IP}/g" "${template}"
-  sed -i "s/<app-squeaknode-envoy-port>/${APP_SQUEAKNODE_ENVOY_PORT}/g" "${template}"
 done
 
 ##########################################################

--- a/templates/.env-sample
+++ b/templates/.env-sample
@@ -96,5 +96,3 @@ APP_SQUEAKNODE_PORT=<app-squeaknode-port>
 APP_SQUEAKNODE_GRPC_PORT=<app-squeaknode-grpc-port>
 APP_SQUEAKNODE_P2P_PORT=<app-squeaknode-p2p-port>
 APP_SQUEAKNODE_P2P_TESTNET_PORT=<app-squeaknode-p2p-testnet-port>
-APP_SQUEAKNODE_ENVOY_IP=<app-squeaknode-envoy-ip>
-APP_SQUEAKNODE_ENVOY_PORT=<app-squeaknode-envoy-port>

--- a/templates/torrc-apps-3-sample
+++ b/templates/torrc-apps-3-sample
@@ -15,7 +15,6 @@ HiddenServicePort 80 <app-code-server-ip>:8080
 # squeaknode Hidden Service
 HiddenServiceDir /var/lib/tor/app-squeaknode
 HiddenServicePort 80 <app-squeaknode-ip>:<app-squeaknode-port>
-HiddenServicePort <app-squeaknode-envoy-port> <app-squeaknode-envoy-ip>:<app-squeaknode-envoy-port>
 
 # squeaknode p2p Hidden Service
 HiddenServiceDir /var/lib/tor/app-squeaknode-p2p


### PR DESCRIPTION
These configs were added during development when squeaknode was still using envoy, but they are unused now.