### PR TITLE
Umbrel v0.4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Make sure your User ID is `1000` (verify it by running `id -u`) and ensure that 
 > Run this in an empty directory where you want to install Umbrel. If using an external storage such as an SSD or HDD, run this inside an empty directory on that drive.
 
 ```bash
-curl -L https://github.com/getumbrel/umbrel/archive/v0.4.3.tar.gz | tar -xz --strip-components=1
+curl -L https://github.com/getumbrel/umbrel/archive/v0.4.4.tar.gz | tar -xz --strip-components=1
 ```
 
 ### Step 2. Run Umbrel

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
-    "version": "0.4.3",
-    "name": "Umbrel v0.4.3",
+    "version": "0.4.4",
+    "name": "Umbrel v0.4.4",
     "requires": ">=0.2.1",
-    "notes": "SECURITY UPDATE: This version of Umbrel brings the latest LND 0.13.3 which includes an important security fix.\n\nIf you face any difficulties while updating, please message us on Telegram: https://t.me/getumbrel"
+    "notes": "This version of Umbrel brings Bitcoin Core 22.0, lower disk space usage (free up ~50GB), 3 brand new apps in the Umbrel App Store — Node-RED, Krystal Bull and LN Markets, performance improvements, updated apps, and more.\n\nPlease note that the Electrum server on your Umbrel will be unavailable for ~12 hours after the update, and any wallets connected to it (BitBoxApp, BlueWallet on-chain only, Electrum Wallet and Sparrow) will not be able to connect to your Umbrel during that time, along with the Mempool and BTC RPC Explorer apps.\n\nIf you face any difficulties while updating, please message us on Telegram: https://t.me/getumbrel"
 }


### PR DESCRIPTION
This version of Umbrel brings Bitcoin Core 22.0, lower disk space usage (free up ~50GB), 3 brand new apps in the Umbrel App Store — Node-RED, Krystal Bull and LN Markets, performance improvements, updated apps, and more.

Please note that the Electrum server on your Umbrel will be unavailable for ~12 hours after the update, and any wallets connected to it (BitBoxApp, BlueWallet on-chain only, Electrum Wallet and Sparrow) will not be able to connect to your Umbrel during that time, along with the Mempool and BTC RPC Explorer apps.

If you face any difficulties while updating, please message us on Telegram: https://t.me/getumbrel"