### PR TITLE
Distroless images improves security posture

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -39,7 +39,7 @@ RUN apt-get update
 RUN apt-get install -y git python3 build-essential
 RUN npm ci --production
 
-FROM node:12-buster-slim
+FROM gcr.io/distroless/nodejs:12
 
 USER 1000
 WORKDIR /build


### PR DESCRIPTION
Restricting what's in your runtime container to precisely what's necessary for your app is a best practice employed by Google and other tech giants that have used containers in production for many years. It improves the signal to noise of scanners (e.g. CVE) and reduces the burden of establishing provenance to just what you need.

Distroless images are very small. The smallest distroless image, gcr.io/distroless/static, is around 650 kB. That's about 25% of the size of alpine (~2.5 MB), and less than 1.5% of the size of debian (50 MB).

For example, gcr.io/distroless/static is a container image that's much smaller than this image of a shipping container. It's about 1/3rd the size of all the resources on this page you're reading right now. It's very small.

https://github.com/GoogleContainerTools/distroless#why-should-i-use-distroless-images
https://github.com/GoogleContainerTools/distroless#how-do-i-verify-distroless-images