### PR TITLE
Update samourai-server app dojo-db image to newest fixed version

### DIFF
--- a/apps/samourai-server/docker-compose.yml
+++ b/apps/samourai-server/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   db:
-    image: louneskmt/dojo-db:1.3.0-low-mem@sha256:6ca2bb6a3f0861abf1b5c9df7c4b6e85d13c3bf697fe81ea8d3d0d861116fe3b
+    image: louneskmt/dojo-db:1.3.0-low-mem@sha256:76dd4bc0bd3386195adc4564dc6a712c50af9b8400707c4e6ffcb0a859f76c71
     init: true
     restart: on-failure
     stop_grace_period: 5m


### PR DESCRIPTION
This fixes an issue on new installations, where the database couldn't initialise.

https://github.com/louneskmt/umbrel-samourai-dojo/pull/1

