### PR TITLE
Add maxbackoff=5m to lnd.conf sample file.

### DIFF
--- a/templates/lnd-sample.conf
+++ b/templates/lnd-sample.conf
@@ -12,6 +12,7 @@ tlsextraip=<lnd-ip>
 tlsextradomain=<hostname>
 tlsautorefresh=1
 tlsdisableautofill=1
+maxbackoff=5m
 feeurl=<lndfeeurl>
 
 [Bitcoind]


### PR DESCRIPTION
Maxbackoff helps avoid dead peers due to bad TOR connectivity by soft reconnecting to them.