### PR TITLE
Allow permission changes to fail in confifgure script

### DIFF
--- a/scripts/configure
+++ b/scripts/configure
@@ -467,7 +467,7 @@ fi
 
 echo "Configuring permissions..."
 echo
-find "$UMBREL_ROOT" -path "$UMBREL_ROOT/app-data" -prune -o -exec chown 1000:1000 {} +
+find "$UMBREL_ROOT" -path "$UMBREL_ROOT/app-data" -prune -o -exec chown 1000:1000 {} + || true
 
 # Create configured status
 touch "${STATUS_DIR}/configured"


### PR DESCRIPTION
This always fails in umbrel-dev on Apple silicon where we use SSHFS for filesystem sharing. This change just allows it to silently fail without killing the configure process.