### PR TITLE
Update to LND v0.13.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,7 @@ services:
                         ipv4_address: $BITCOIN_IP
         lnd:
                 container_name: lnd
-                image: lightninglabs/lnd:v0.13.3-beta@sha256:b8f96d4d7fb9dcd349542240a6bff1ca0170715a16e6d79b0e9188e34ea18471
+                image: lightninglabs/lnd:v0.13.4-beta@sha256:8be9811a7fec1bffb02239745cdc1a28ba5635a01b8f5e5cbfa1b5853b7e3e6b
                 user: 1000:1000
                 depends_on: [ tor, manager ]
                 volumes:


### PR DESCRIPTION
https://github.com/lightningnetwork/lnd/releases/tag/v0.13.4-beta

This resolves some issues expected to affect neutrino users once taproot activates.