### PR TITLE
Revert "Update LNMarkets to v1.1.3"

### DIFF
--- a/apps/lnmarkets/docker-compose.yml
+++ b/apps/lnmarkets/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   lnmarkets:
-    image: ghcr.io/lnmarkets/umbrel:v1.1.3@sha256:7f72864171bbe7922929d940a63c31faed6aa7525b6a236f5a4e0d2680ccdeba
+    image: ghcr.io/lnmarkets/umbrel:v1.0.0@sha256:e7bfe4ae840bfddc0af398a9bc700044778d1090a7a56389265116d23dc13cab
     user: 1000:1000
     init: true
     restart: on-failure

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -574,7 +574,7 @@
         "id": "lnmarkets",
         "category": "Finance",
         "name": "LN Markets",
-        "version": "1.1.3",
+        "version": "1.0.0",
         "tagline": "Trade Bitcoin derivatives on Lightning",
         "description": "LN Markets is the first Lightning-native Bitcoin derivatives trading platform.\n\nLN Markets enables traders to take minimal counterparty risk: you can trade directly from your Lightning wallet for instant and almost costless transactions. Since March 2020, we have processed over $200 million of trading volume, with a median fee of 1 sat for instant P&L delivery to your wallet.\n\nThis Umbrel App gives you another way to interact with LN Markets: you can directly deposit, withdraw, get trading stats and get instantly connected to your account to take positions as usual. More features may come in the future!\n\nThank you for your support and let’s keep building the future of finance together!",
         "developer": "LN Markets",


### PR DESCRIPTION
Reverts getumbrel/umbrel#1091

Failing with

```
Error response from daemon: Get "https://ghcr.io/v2/lnmarkets/umbrel/manifests/sha256:7f72864171bbe7922929d940a63c31faed6aa7525b6a236f5a4e0d2680ccdeba": denied
```