### PR TITLE
Update LN Markets to v1.1.4

### DIFF
--- a/apps/lnmarkets/docker-compose.yml
+++ b/apps/lnmarkets/docker-compose.yml
@@ -1,10 +1,10 @@
-version: '3.7'
+version: "3.7"
 
 services:
   lnmarkets:
-    image: ghcr.io/ln-markets/umbrel:v1.0.0@sha256:e7bfe4ae840bfddc0af398a9bc700044778d1090a7a56389265116d23dc13cab
-    user: 1000:1000
+    image: ghcr.io/ln-markets/umbrel:v1.1.4@sha256:d9168a2a3e1016b7cd302cde579ae3013aac57ebeaf89c44f5dbc02f604779cc
     init: true
+    user: 1000:1000
     restart: on-failure
     stop_grace_period: 1m
     ports:
@@ -12,14 +12,12 @@ services:
     volumes:
       - ${LND_DATA_DIR}:/lnd:ro
     environment:
-      APP_URL: 0.0.0.0
-      API_PORT: $APP_LNMARKETS_PORT
-
       LND_IP: $LND_IP
       LND_GRPC_PORT: $LND_GRPC_PORT
-      LND_REST_PORT: $LND_REST_PORT
-
       BITCOIN_NETWORK: $BITCOIN_NETWORK
+      APP_HIDDEN_SERVICE: $APP_HIDDEN_SERVICE
+      APP_DOMAIN: $APP_DOMAIN
+      API_PORT: $APP_LNMARKETS_PORT
     networks:
       default:
         ipv4_address: $APP_LNMARKETS_IP

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -574,7 +574,7 @@
         "id": "lnmarkets",
         "category": "Finance",
         "name": "LN Markets",
-        "version": "1.1.0",
+        "version": "1.1.4",
         "tagline": "Trade Bitcoin derivatives on Lightning",
         "description": "LN Markets is the first Lightning-native Bitcoin derivatives trading platform.\n\nLN Markets enables traders to take minimal counterparty risk: you can trade directly from your Lightning wallet for instant and almost costless transactions. Since March 2020, we have processed over $200 million of trading volume, with a median fee of 1 sat for instant P&L delivery to your wallet.\n\nThis Umbrel App gives you another way to interact with LN Markets: you can directly deposit, withdraw, get trading stats and get instantly connected to your account to take positions as usual. More features may come in the future!\n\nThank you for your support and let’s keep building the future of finance together!",
         "developer": "LN Markets",
@@ -582,8 +582,8 @@
         "dependencies": [
             "lnd"
         ],
-        "repo": "https://github.com/lnmarkets/umbrel",
-        "support": "https://www.t.me/lnmarkets",
+        "repo": "https://github.com/ln-markets/umbrel",
+        "support": "https://discord.gg/5HwDJFx2Jz",
         "port": 4242,
         "gallery": [
             "1.jpg",


### PR DESCRIPTION
Update image to v1.1.4

Patch note [v1.1.4](https://github.com/ln-markets/umbrel/releases/tag/v1.1.4)