### PR TITLE
Update ride-the-lightning app entrypoint to use sh

### DIFF
--- a/apps/ride-the-lightning/rtl/entrypoint.sh
+++ b/apps/ride-the-lightning/rtl/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # Migrate legacy default password
 sed -i 's/"multiPassHashed": "70c882380045d35807b45245bd49185991904ff47a5036dfe82103c49f9f0f31"/"multiPass": "'${APP_PASSWORD}'"/' $RTL_CONFIG_PATH/RTL-Config.json


### PR DESCRIPTION
RTL Docker image for amd64 uses node alpine as base, which doesn't include `bash`. Changing `bash` to `sh` should solve the issue of RTL not starting for Umbrel setups on amd64. 

Resolves #1112. 