### PR TITLE
fix: thunderhub app password reset on start

### DIFF
--- a/apps/thunderhub/data/entrypoint.sh
+++ b/apps/thunderhub/data/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
 # Set password
-sed -i 's/masterPassword:.*/masterPassword: '${APP_PASSWORD}'/' /data/thubConfig.yaml
+sed -i 's/$APP_PASSWORD/'${APP_PASSWORD}'/' /data/thubConfig.yaml
 
 exec npm start


### PR DESCRIPTION
The current entrypoint replaces the whole password option on each start, not matter the current state (if a password is set or not). As a result, users can't set a custom (persistent) password.

This PR fixes this issue by replacing only the environment variable by its value.