### PR TITLE
Enable accepting Atomic Multipath Payment (AMP)

### DIFF
--- a/templates/lnd-sample.conf
+++ b/templates/lnd-sample.conf
@@ -13,6 +13,7 @@ tlsextradomain=<hostname>
 tlsautorefresh=1
 tlsdisableautofill=1
 feeurl=<lndfeeurl>
+accept-amp=1
 
 [Bitcoind]
 bitcoind.rpchost=<bitcoin-ip>


### PR DESCRIPTION
Since v13.0 lnd supports AMP between paying and receiving lnd nodes. 

For umbrel nodes to support receiving amp, they need to be enabled in `lnd.conf`. This patch allows for both `amp` and `keysend` transactions to be received by the node. 

See: https://docs.lightning.engineering/lightning-network-tools/lnd/amp