### PR TITLE
Autorecover from Docker failure during update

### DIFF
--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -127,10 +127,6 @@ echo "Stopping existing containers"
 cat <<EOF > "$UMBREL_ROOT"/statuses/update-status.json
 {"state": "installing", "progress": 70, "description": "Removing old containers", "updateTo": "$RELEASE"}
 EOF
-
-# Simulate crash here
-false
-
 cd "$UMBREL_ROOT"
 ./scripts/stop
 

--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -127,6 +127,10 @@ echo "Stopping existing containers"
 cat <<EOF > "$UMBREL_ROOT"/statuses/update-status.json
 {"state": "installing", "progress": 70, "description": "Removing old containers", "updateTo": "$RELEASE"}
 EOF
+
+# Simulate crash here
+false
+
 cd "$UMBREL_ROOT"
 ./scripts/stop
 


### PR DESCRIPTION
Someimtes during an update Docker fails to stop containers and knocks the node offline due to this Docker bug: https://github.com/moby/moby/issues/17217.

Restarting the Docker service seems to resolve the issue so now we detect the failure if Docker fails to stop containers, restart the Docker service, then try again.