### PR TITLE
Improved Docker error handling

### DIFF
--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -139,6 +139,7 @@ EOF
   sleep 1
   ./scripts/stop || {
     # If this doesn't catch the error, start Umbrel again before failing so the web UI is still accessible
+    echo "That didn't work, attempting to restart containers"
     ./scripts/start
     false
   }

--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -135,7 +135,7 @@ cd "$UMBREL_ROOT"
   cat <<EOF > "$UMBREL_ROOT"/statuses/update-status.json
 {"state": "installing", "progress": 70, "description": "Attempting to autofix Docker failure", "updateTo": "$RELEASE"}
 EOF
-  sudo systemctl restart docker
+  sudo systemctl restart docker || true # Soft fail on environments that don't use systemd
   sleep 1
   ./scripts/stop
 }

--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -137,7 +137,11 @@ cd "$UMBREL_ROOT"
 EOF
   sudo systemctl restart docker || true # Soft fail on environments that don't use systemd
   sleep 1
-  ./scripts/stop
+  ./scripts/stop || {
+    # If this doesn't catch the error, start Umbrel again before failing so the web UI is still accessible
+    ./scripts/start
+    false
+  }
 }
 
 # Fix broken Nextcloud installs from Umbrel v0.4.0 to be accessible from both

--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -138,7 +138,7 @@ EOF
   sudo systemctl restart docker || true # Soft fail on environments that don't use systemd
   sleep 1
   ./scripts/stop || {
-    # If this doesn't catch the error, start Umbrel again before failing so the web UI is still accessible
+    # If this doesn't resolve the issue, start containers again before failing so the web UI is still accessible
     echo "That didn't work, attempting to restart containers"
     ./scripts/start
     false


### PR DESCRIPTION
Following on from https://github.com/getumbrel/umbrel/pull/1154 this change will additionally not fail if a non Umbrel OS install doesn't use systemd and will also attempt to restart containers if the Docker restart doesn't resolve the issue so the user isn't left without access to the web interface.