### PR TITLE
Show update errors

### DIFF
--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -141,6 +141,7 @@ EOF
     # If this doesn't resolve the issue, start containers again before failing so the web UI is still accessible
     echo "That didn't work, attempting to restart containers"
     ./scripts/start
+    echo "Error stopping Docker containers" > "${UMBREL_ROOT}/statuses/update-failure"
     false
   }
 }

--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -139,6 +139,7 @@ EOF
   sleep 1
   ./scripts/stop || {
     # If this doesn't catch the error, start Umbrel again before failing so the web UI is still accessible
+    echo "That didn't work, attempting to restart containers"
     ./scripts/start
     false
   }

--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -135,7 +135,7 @@ cd "$UMBREL_ROOT"
   cat <<EOF > "$UMBREL_ROOT"/statuses/update-status.json
 {"state": "installing", "progress": 70, "description": "Attempting to autofix Docker failure", "updateTo": "$RELEASE"}
 EOF
-  sudo systemctl restart docker
+  sudo systemctl restart docker || true # Soft fail on environments that don't use systemd
   sleep 1
   ./scripts/stop
 }

--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -137,7 +137,11 @@ cd "$UMBREL_ROOT"
 EOF
   sudo systemctl restart docker || true # Soft fail on environments that don't use systemd
   sleep 1
-  ./scripts/stop
+  ./scripts/stop || {
+    # If this doesn't catch the error, start Umbrel again before failing so the web UI is still accessible
+    ./scripts/start
+    false
+  }
 }
 
 # Fix broken Nextcloud installs from Umbrel v0.4.0 to be accessible from both

--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -138,7 +138,7 @@ EOF
   sudo systemctl restart docker || true # Soft fail on environments that don't use systemd
   sleep 1
   ./scripts/stop || {
-    # If this doesn't catch the error, start Umbrel again before failing so the web UI is still accessible
+    # If this doesn't resolve the issue, start containers again before failing so the web UI is still accessible
     echo "That didn't work, attempting to restart containers"
     ./scripts/start
     false

--- a/scripts/update/update
+++ b/scripts/update/update
@@ -139,6 +139,16 @@ rm -f "$UMBREL_ROOT"/statuses/update-in-progress
 
 update_state=$(cat "${UMBREL_ROOT}/statuses/update-status.json" | jq .state -r)
 
+# Show error
+update_failure_status_file="${UMBREL_ROOT}/statuses/update-failure"
+if [[ -f "${update_failure_status_file}" ]]; then
+  reason=$(cat "${update_failure_status_file}")
+  rm "${update_failure_status_file}"
+  cat <<EOF > "${UMBREL_ROOT}/statuses/update-status.json"
+{"state": "failed", "progress": 100, "description": "${reason}", "updateTo": ""}
+EOF
+fi
+
 if [[ "${update_state}" != "success" ]] && [[ "${update_state}" != "failed" ]]; then
     # Sleep for a few seconds to make sure the user is on the update view
     sleep 8

--- a/scripts/update/update
+++ b/scripts/update/update
@@ -141,16 +141,13 @@ update_state=$(cat "${UMBREL_ROOT}/statuses/update-status.json" | jq .state -r)
 
 # Show error
 update_failure_status_file="${UMBREL_ROOT}/statuses/update-failure"
-echo "checking error status..."
 if [[ -f "${update_failure_status_file}" ]]; then
-  echo "file exists"
   reason=$(cat "${update_failure_status_file}")
   rm "${update_failure_status_file}"
   cat <<EOF > "${UMBREL_ROOT}/statuses/update-status.json"
 {"state": "failed", "progress": 100, "description": "${reason}", "updateTo": ""}
 EOF
 fi
-echo file does not exist
 
 if [[ "${update_state}" != "success" ]] && [[ "${update_state}" != "failed" ]]; then
     # Sleep for a few seconds to make sure the user is on the update view

--- a/scripts/update/update
+++ b/scripts/update/update
@@ -141,13 +141,16 @@ update_state=$(cat "${UMBREL_ROOT}/statuses/update-status.json" | jq .state -r)
 
 # Show error
 update_failure_status_file="${UMBREL_ROOT}/statuses/update-failure"
+echo "checking error status..."
 if [[ -f "${update_failure_status_file}" ]]; then
+  echo "file exists"
   reason=$(cat "${update_failure_status_file}")
   rm "${update_failure_status_file}"
   cat <<EOF > "${UMBREL_ROOT}/statuses/update-status.json"
 {"state": "failed", "progress": 100, "description": "${reason}", "updateTo": ""}
 EOF
 fi
+echo file does not exist
 
 if [[ "${update_state}" != "success" ]] && [[ "${update_state}" != "failed" ]]; then
     # Sleep for a few seconds to make sure the user is on the update view


### PR DESCRIPTION
There is a bug in the update process where if we catch an error and write out a failure message to `./statuses/update-status.json`, it will always get cleared by `./scripts/update/03-run.sh` and set as successful.

This workaround writes out the error to a seperate temporary status file and writes it back to the overwritten update status file if it exists at the end of the update process.

This won't take affect until the next Umbrel update happens, since the code needs to be in place in the current install to be effective, not the install that's being installed.