### PR TITLE
Add automatic decrypt and restore SCB script

### DIFF
--- a/scripts/backup/restore
+++ b/scripts/backup/restore
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/../..)"
+
+show_help() {
+  cat << EOF
+restore 0.0.1
+
+CLI for restoring Umbrel backups (SCB). The file is decrypted if necessary.
+
+Usage: restore <path-to-backup-file>
+EOF
+}
+
+check_dependencies () {
+  for cmd in "$@"; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      echo "This script requires \"${cmd}\" to be installed"
+      exit 1
+    fi
+  done
+}
+
+check_dependencies openssl tar gpg
+
+# Deterministically derives 128 bits of cryptographically secure entropy
+derive_entropy () {
+  identifier="${1}"
+  umbrel_seed=$(cat "${UMBREL_ROOT}/db/umbrel-seed/seed") || true
+
+  if [[ -z "$umbrel_seed" ]] || [[ -z "$identifier" ]]; then
+    >&2 echo "Missing derivation parameter, this is unsafe, exiting."
+    exit 1
+  fi
+
+  # We need `sed 's/^.* //'` to trim the "(stdin)= " prefix from some versions of openssl
+  printf "%s" "${identifier}" | openssl dgst -sha256 -hmac "${umbrel_seed}" | sed 's/^.* //'
+}
+
+echo "Deriving keys..."
+
+backup_id=$(derive_entropy "umbrel_backup_id")
+encryption_key=$(derive_entropy "umbrel_backup_encryption_key")
+
+if [ -z ${1+x} ]; then
+  show_help
+  exit 1
+else
+  BACKUP_FILE="$1"
+fi
+
+if [[ "$BACKUP_FILE" == *.pgp ]]; then
+  echo "Backup is encrypted, decrypting backup..."
+
+  BACKUP_FOLDER_PATH="/tmp/backup"
+  mkdir -p "${BACKUP_FOLDER_PATH}"
+
+  cat "${BACKUP_FILE}" | gpg \
+    --batch \
+    --decrypt \
+    --passphrase "${encryption_key}" \
+    | tar \
+    --extract \
+    --verbose \
+    --gzip \
+    --directory "$BACKUP_FOLDER_PATH" \
+    || {
+      echo "Failed to decrypt backup, exiting..."
+      exit 1
+    }
+
+  BACKUP_FILE="$BACKUP_FOLDER_PATH/backup/channel.backup"
+
+  echo "Backup decrypted."
+fi
+
+echo "Extracting backup data from file..."
+
+BACKUP_DATA="$(cat $BACKUP_FILE | xxd -p | tr -d '\n')"
+
+echo "Restoring channel backup..."
+echo "This can take a while, depending on your number of channels."
+
+$UMBREL_ROOT/bin/lncli restorechanbackup --multi_backup "$BACKUP_DATA"
+
+rm -Rf "$BACKUP_FOLDER_PATH"

--- a/scripts/backup/restore
+++ b/scripts/backup/restore
@@ -85,4 +85,8 @@ echo "This can take a while, depending on your number of channels."
 
 $UMBREL_ROOT/bin/lncli restorechanbackup --multi_file "/data/.lnd/channel-$RESTORE_ID.backup"
 
+echo "Cleaning files..."
+
 rm -Rf "$BACKUP_FOLDER_PATH" "$BACKUP_FILE_LND"
+
+echo "Done!"

--- a/scripts/backup/restore
+++ b/scripts/backup/restore
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 UMBREL_ROOT="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/../..)"
+RESTORE_ID="$RANDOM"
 
 show_help() {
   cat << EOF
@@ -54,7 +55,7 @@ fi
 if [[ "$BACKUP_FILE" == *.pgp ]]; then
   echo "Backup is encrypted, decrypting backup..."
 
-  BACKUP_FOLDER_PATH="/tmp/backup"
+  BACKUP_FOLDER_PATH="/tmp/backup-$RESTORE_ID"
   mkdir -p "${BACKUP_FOLDER_PATH}"
 
   cat "${BACKUP_FILE}" | gpg \
@@ -76,13 +77,12 @@ if [[ "$BACKUP_FILE" == *.pgp ]]; then
   echo "Backup decrypted."
 fi
 
-echo "Extracting backup data from file..."
-
-BACKUP_DATA="$(cat $BACKUP_FILE | xxd -p | tr -d '\n')"
+BACKUP_FILE_LND="$UMBREL_ROOT/lnd/channel-$RESTORE_ID.backup"
+mv -f "$BACKUP_FILE" "$BACKUP_FILE_LND"
 
 echo "Restoring channel backup..."
 echo "This can take a while, depending on your number of channels."
 
-$UMBREL_ROOT/bin/lncli restorechanbackup --multi_backup "$BACKUP_DATA"
+$UMBREL_ROOT/bin/lncli restorechanbackup --multi_file "/data/.lnd/channel-$RESTORE_ID.backup"
 
-rm -Rf "$BACKUP_FOLDER_PATH"
+rm -Rf "$BACKUP_FOLDER_PATH" "$BACKUP_FILE_LND"


### PR DESCRIPTION
This PR integrates into Umbrel codebase a script I've been using with users for a couple of weeks. It reads the backup from a specified path and automatically decrypts the file if necessary (i.e. if it is an automatic Umbrel backup, PGP encrypted), and restores the SCB.

This is temporary, as we'll be moving LND into the App Store at some point.