### PR TITLE
Update squeaknode repo URL and support URL

### DIFF
--- a/apps/registry.json
+++ b/apps/registry.json
@@ -537,8 +537,8 @@
             "bitcoind",
             "lnd"
         ],
-        "repo": "https://github.com/yzernik/squeaknode",
-        "support": "https://github.com/yzernik/squeaknode/discussions",
+        "repo": "https://github.com/squeaknode/squeaknode",
+        "support": "https://github.com/squeaknode/squeaknode/discussions",
         "port": 12994,
         "gallery": [
             "1.jpg",


### PR DESCRIPTION
The squeaknode repo migrated to the squeaknode github organization, so there is a new URL.