### PR TITLE
Update squeaknode app to v0.1.188

### DIFF
--- a/apps/registry.json
+++ b/apps/registry.json
@@ -528,7 +528,7 @@
         "id": "squeaknode",
         "category": "Social",
         "name": "Squeaknode",
-        "version": "0.1.187",
+        "version": "0.1.188",
         "tagline": "A peer-to-peer status feed with Lightning monetization",
         "description": "The Squeaknode app allows you to create, view, buy, and sell squeaks. A squeak is a single post that can contain up to 280 characters.\n\nThe Squeaknode timeline is ordered by the height of the block hash embedded in each squeak. Each squeak is signed with a digital signature of the private key of the author. Squeaks can be downloaded from any peer to any peer, but they remain locked until the downloader makes a Lightning payment to decrypt the content.",
         "developer": "Jonathan Zernik",

--- a/apps/squeaknode/docker-compose.yml
+++ b/apps/squeaknode/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: ghcr.io/squeaknode/squeaknode:v0.1.187@sha256:3f46e255688d07ad28fd90db9c50de56adf68baba1ba23f113edda7c6048d39d
+    image: ghcr.io/squeaknode/squeaknode:v0.1.188@sha256:9436d61ebd75cff1d9cecc2d34fa4a142f85c0cb00328efcdb3ed177d3d34ffd
     restart: on-failure
     stop_grace_period: 1m
     ports:


### PR DESCRIPTION
Changes:
https://github.com/squeaknode/squeaknode/releases/tag/v0.1.188

Release v0.1.188 includes a new feature in which a user can create a private encrypted squeak for a specific recipient.