### PR TITLE
App update: helipad to v0.1.6

### DIFF
--- a/apps/helipad/docker-compose.yml
+++ b/apps/helipad/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: podcastindexorg/podcasting20-helipad:v0.1.5@sha256:2021a21cb650d6d010fac846268644acfee62b54ac7f75c758aae160a2c6bd39
+    image: podcastindexorg/podcasting20-helipad:v0.1.6@sha256:cc1dd6db871d81f602f4c33ed4300903231c77359c971384ac84b9ba7688343c
     init: true
     restart: on-failure
     stop_grace_period: 1m

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -662,7 +662,7 @@
         "id": "helipad",
         "category": "Lightning Node Management",
         "name": "Helipad",
-        "version": "0.1.5",
+        "version": "0.1.6",
         "tagline": "View boosts and boost-a-grams from Podcasting 2.0 enabled apps",
         "description": "Helipad shows boosts and boost-a-gram messages coming in to your Lightning node from your listeners who are using Podcasting 2.0 apps.",
         "developer": "Podcastindex.org",


### PR DESCRIPTION
Two bug fixes:  one caused a gap in the boostagram list and the other could cause the boostagram list to be blank if an unsettled invoice became the current invoice index.