### PR TITLE
Upgrade ItchySats app to `0.3.6`

### DIFF
--- a/apps/itchysats/docker-compose.yml
+++ b/apps/itchysats/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: ghcr.io/itchysats/itchysats/taker:0.3.3@sha256:216d19fafe41860c78366737a79088f1049240723cf587ba7b049b071c1fac62
+    image: ghcr.io/itchysats/itchysats/taker:0.3.6@sha256:14f2af91a1fc5a80e565c682680aa81a2c55e7a182268c1bef1de786993656b3
     restart: on-failure
     stop_grace_period: 1m
     ports:
@@ -13,6 +13,7 @@ services:
       - --maker=mainnet.itchysats.network:9999
       - --maker-id=7e35e34801e766a6a29ecb9e22810ea4e3476c2b37bf75882edf94a68b1d9607
       - --password=$APP_PASSWORD
+      - --umbrel-seed=$APP_SEED
       - mainnet
       - --electrum=tcp://$ELECTRUM_IP:$ELECTRUM_PORT
 

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -685,7 +685,7 @@
         "id": "itchysats",
         "category": "Finance",
         "name": "ItchySats",
-        "version": "v0.3.3",
+        "version": "v0.3.6",
         "tagline": "Peer-2-peer derivatives on Bitcoin",
         "description": "ItchySats enables peer-2-peer CFD trading on Bitcoin using DLCs (discreet log contracts). No account needed, no trusted third-party - just you and your keys.\n\nThis is beta software. We tested it on test- and mainnet, but there are no guarantees that it will always behave as expected.\nPlease be mindful with how much money you trust the application with.\nCFDs trading is inherently risky, be sure to read up on it before using this application.\n\nThat said: This is pretty awesome, go nuts!\n\n1. Fund the ItchySats wallet\n2. Open a position\n3. Watch the price go up\n4. Profit\n\nLimitations of the mainnet beta:\n\n1. You can only open long positions at the moment\n2. Minimum position quantity is $100, maximum $1000\n3. CFDs period ends after 7 days - perpetual positions are in the making :)\n4. The leverage is fixed at 2\n\nWe are woking hard on perpetual positions and allowing sell positions.\nUpdate to be expected soon!",
         "developer": "ItchySats",


### PR DESCRIPTION
ItchySats now uses Umbrel's `$APP_SEED` to initialize the app's Bitcoin wallet.

Would be great if we could get this in before the Umbrel release, because it is a breaking change to the ItchySats Bitcoin wallet.
Given this is the first Umbrel release with ItchySats we added the feature to use `$APP_SEED` for deriving the wallet now, rather than upgrading a wallet that was created with a generated seed.

@lukechilds you tested opening a position. In case you still have funds in the app's wallet, when upgrading to this version please first withdraw all funds from the Bitcoin wallet and then transfer them back into the wallet derived from Umbrel's `$APP_SEED` once upgraded. 