### PR TITLE
App Submission: Bitfeed

### DIFF
--- a/apps/bitfeed/docker-compose.yml
+++ b/apps/bitfeed/docker-compose.yml
@@ -1,0 +1,39 @@
+version: "2.1"
+
+services:
+  web:
+    image: bitfeed/client:2.1.2@sha256:a35ccd4d5149ae62b8b9daa7ddaad9b2fe127ddfc0d0bf3af3646dfb9bae1739
+    restart: on-failure
+    stop_grace_period: 1m
+    depends_on:
+      - "api"
+    environment:
+      TARGET: "umbrel"
+      BACKEND_HOST: "$APP_BITFEED_API_IP"
+      BACKEND_PORT: "$APP_BITFEED_API_PORT"
+    ports:
+      - "$APP_BITFEED_PORT:80"
+    networks:
+      default:
+        ipv4_address: $APP_BITFEED_IP
+
+  api:
+    image: bitfeed/server:2.1.2@sha256:2b5097274b2c433e30cb82b7fdda13c0b856527957ddd15545bd498034be8e51
+    user: "1000:1000"
+    restart: on-failure
+    stop_grace_period: 1m
+    environment:
+      PORT: "$APP_BITFEED_API_PORT"
+      BITCOIN_HOST: "$BITCOIN_IP"
+      BITCOIN_ZMQ_RAWTX_PORT: "$BITCOIN_ZMQ_RAWTX_PORT"
+      BITCOIN_ZMQ_RAWBLOCK_PORT: "$BITCOIN_ZMQ_RAWBLOCK_PORT"
+      BITCOIN_RPC_PORT: "$BITCOIN_RPC_PORT"
+      BITCOIN_RPC_USER: "$BITCOIN_RPC_USER"
+      BITCOIN_RPC_PASS: "$BITCOIN_RPC_PASS"
+    ports:
+      - "$APP_BITFEED_API_PORT:$APP_BITFEED_API_PORT"
+    volumes:
+      - ${APP_DATA_DIR}/data:/app/data
+    networks:
+      default:
+        ipv4_address: $APP_BITFEED_API_IP

--- a/apps/bitfeed/docker-compose.yml
+++ b/apps/bitfeed/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2.1"
 
 services:
   web:
-    image: bitfeed/client:2.1.2@sha256:a35ccd4d5149ae62b8b9daa7ddaad9b2fe127ddfc0d0bf3af3646dfb9bae1739
+    image: bitfeed/client:2.1.2@sha256:2ee766841cfdc0741bbfa5f9e5ca777ca02a135cba1bcbf232e5dee255b8268c
     restart: on-failure
     stop_grace_period: 1m
     depends_on:
@@ -30,8 +30,6 @@ services:
       BITCOIN_RPC_PORT: "$BITCOIN_RPC_PORT"
       BITCOIN_RPC_USER: "$BITCOIN_RPC_USER"
       BITCOIN_RPC_PASS: "$BITCOIN_RPC_PASS"
-    ports:
-      - "$APP_BITFEED_API_PORT:$APP_BITFEED_API_PORT"
     volumes:
       - ${APP_DATA_DIR}/data:/app/data
     networks:

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -282,6 +282,30 @@
         "defaultPassword": ""
     },
     {
+        "id": "bitfeed",
+        "category": "Explorers",
+        "name": "Bitfeed",
+        "version": "2.1.2",
+        "tagline": "A live visualization of your node's mempool",
+        "description": "A self-hosted version of Bitfeed - the open source mempool & block visualizer available at https://bits.monospace.live. Watch as new transactions drop into your node's mempool, before being packaged into newly mined blocks. Monitor Bitcoin network activity, explore the composition of the latest block, or simply enjoy a soothing Bitcoin screensaver.",
+        "developer": "Mononaut",
+        "website": "https://monospace.live",
+        "dependencies": [
+            "bitcoind"
+        ],
+        "repo": "https://github.com/bitfeed-project/bitfeed",
+        "support": "https://github.com/bitfeed-project/bitfeed/issues",
+        "port": 8314,
+        "gallery": [
+            "1.jpg",
+            "2.jpg",
+            "3.jpg"
+        ],
+        "path": "",
+        "defaultUsername": "",
+        "defaultPassword": ""
+    },
+    {
         "id": "btc-rpc-explorer",
         "category": "Explorers",
         "name": "BTC RPC Explorer",

--- a/scripts/configure
+++ b/scripts/configure
@@ -219,6 +219,11 @@ APP_LIGHTNING_SHELL_PORT="7681"
 APP_LIGHTNING_SHELL_IP="10.21.21.66"
 APP_SATSALE_PORT="5000"
 APP_SATSALE_IP="10.21.21.67"
+APP_BITFEED_IP="10.21.21.68"
+APP_BITFEED_PORT="8314"
+APP_BITFEED_API_IP="10.21.21.69"
+APP_BITFEED_API_PORT="8315"
+
 
 # Generate RPC credentials
 if [[ -z ${BITCOIN_RPC_USER+x} ]] || [[ -z ${BITCOIN_RPC_PASS+x} ]] || [[ -z ${BITCOIN_RPC_AUTH+x} ]]; then
@@ -440,6 +445,10 @@ for template in "${NGINX_CONF_FILE}" "${BITCOIN_CONF_FILE}" "${LND_CONF_FILE}" "
   sed -i "s/<app-lightning-shell-ip>/${APP_LIGHTNING_SHELL_IP}/g" "${template}"
   sed -i "s/<app-satsale-port>/${APP_SATSALE_PORT}/g" "${template}"
   sed -i "s/<app-satsale-ip>/${APP_SATSALE_IP}/g" "${template}"
+  sed -i "s/<app-bitfeed-ip>/${APP_BITFEED_IP}/g" "${template}"
+  sed -i "s/<app-bitfeed-port>/${APP_BITFEED_PORT}/g" "${template}"
+  sed -i "s/<app-bitfeed-api-ip>/${APP_BITFEED_API_IP}/g" "${template}"
+  sed -i "s/<app-bitfeed-api-port>/${APP_BITFEED_API_PORT}/g" "${template}"
 done
 
 ##########################################################

--- a/templates/.env-sample
+++ b/templates/.env-sample
@@ -119,3 +119,7 @@ APP_LIGHTNING_SHELL_PORT=<app-lightning-shell-port>
 APP_LIGHTNING_SHELL_IP=<app-lightning-shell-ip>
 APP_SATSALE_PORT=<app-satsale-port>
 APP_SATSALE_IP=<app-satsale-ip>
+APP_BITFEED_IP=<app-bitfeed-ip>
+APP_BITFEED_PORT=<app-bitfeed-port>
+APP_BITFEED_API_IP=<app-bitfeed-api-ip>
+APP_BITFEED_API_PORT=<app-bitfeed-api-port>

--- a/templates/torrc-server-sample
+++ b/templates/torrc-server-sample
@@ -176,3 +176,7 @@ HiddenServicePort 80 <app-lightning-shell-ip>:7681
 # satsale Hidden Service
 HiddenServiceDir /data/app-satsale
 HiddenServicePort 80 <app-satsale-ip>:5000
+
+# bitfeed Hidden Service
+HiddenServiceDir /data/app-bitfeed
+HiddenServicePort 80 <app-bitfeed-ip>:80


### PR DESCRIPTION
# App Submission

### App name
Bitfeed

### Version
2.1.2

### One line description of the app
A live visualization of your node's mempool.

### Summary of the app
A self-hosted version of Bitfeed - the open source mempool & block visualizer available at https://bits.monospace.live. Watch as new transactions drop into your node's mempool, before being packaged into newly mined blocks. Monitor Bitcoin network activity, explore the composition of the latest block, or simply enjoy a soothing Bitcoin screensaver.

### Developer name
Mononaut

### Developer website
https://monospace.live

### Source code link
https://github.com/bitfeed-project/bitfeed

### Support link
https://github.com/bitfeed-project/bitfeed/issues

### Requires
- [x] Bitcoin Core
- [ ] Electrum server
- [ ] LND

### 256x256 SVG icon
![image](https://bits.monospace.live/img/bitfeed-logo.svg)

### Gallery images

![umbrel local_8314_1](https://user-images.githubusercontent.com/83316221/150704413-3b79788e-e489-472a-a9a6-9db54f676bc1.png)
![umbrel local_8314_2](https://user-images.githubusercontent.com/83316221/150704414-a96cfcc4-420a-40f0-bfb7-aa878b9b461a.png)
![umbrel local_8314_3](https://user-images.githubusercontent.com/83316221/150704421-aefc8373-cac4-4fdc-bd5f-b4e508de3658.png)

### I have tested my app on:
- [ ] [Umbrel dev environment](https://github.com/getumbrel/umbrel-dev)
- [x] [Umbrel OS on a Raspberry Pi 4](https://github.com/getumbrel/umbrel-os)
- [ ] [Custom Umbrel install on Linux](https://github.com/getumbrel/umbrel#-installation)