### PR TITLE
Patch PwnKit (CVE-2021-4034)

### DIFF
--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -61,6 +61,13 @@ if [[ ! -z "${UMBREL_OS:-}" ]]; then
         DEBIAN_FRONTEND=noninteractive apt-get install unattended-upgrades -y
     fi
 
+    # Patch PwnKit
+    # https://security-tracker.debian.org/tracker/CVE-2021-4034
+    policykit_version=$(dpkg -s policykit-1 | grep '^Version:')
+    if [[ "$policykit_version" != "Version: 0.105-25+rpt1+deb10u1" ]]; then
+      apt-get install --yes --only-upgrade policykit-1
+    fi
+
     # Make sure dhcpd ignores virtual network interfaces
     dhcpd_conf="/etc/dhcpcd.conf"
     dhcpd_rule="denyinterfaces veth*"


### PR DESCRIPTION
This is pretty low severity for Umbrel since nothing really runs on the host, all the apps are running in Docker containers. To exploit this vuln on Umbrel an attacker would have to:

- Find an app on Umbrel with a remote code execution vulnerability
- Get remote access to this app
- Exploit the RCE to get a shell inside the container
- Find a Docker zero day to break out of the container and get a shell on the host
- Exploit PwnKit to get root on the host

As far as we know no such vuln exists in any Umbrel appa or Docker, and getting remote access to Umbrel apps also isn't trivial.