### PR TITLE
Update helipad app to v0.1.8

### DIFF
--- a/apps/helipad/docker-compose.yml
+++ b/apps/helipad/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: podcastindexorg/podcasting20-helipad:v0.1.6@sha256:cc1dd6db871d81f602f4c33ed4300903231c77359c971384ac84b9ba7688343c
+    image: podcastindexorg/podcasting20-helipad:v0.1.8@sha256:12ea841b931cf93e80461a67f13ae44fad6741f65f396530add4015121ec4621
     init: true
     restart: on-failure
     stop_grace_period: 1m

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -686,7 +686,7 @@
         "id": "helipad",
         "category": "Lightning Node Management",
         "name": "Helipad",
-        "version": "0.1.5",
+        "version": "0.1.8",
         "tagline": "View boosts & boost-a-grams from Podcasting 2.0 apps",
         "description": "Helipad shows boosts and boost-a-gram messages coming in to your Lightning node from your listeners who are using Podcasting 2.0 apps.",
         "developer": "Podcastindex.org",


### PR DESCRIPTION
This release adds CSV export, better db initialization ui, a /streams endpoint, CORS support for boosts and some important bug fixes in the JSON payload deserializer.