### PR TITLE
Update lnd to v0.14.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
                         ipv4_address: $BITCOIN_IP
         lnd:
                 container_name: lnd
-                image: lightninglabs/lnd:v0.14.1-beta@sha256:810f290f4da51adaf57d53bc1f1e65b52b03c543f322da0b98fb8c47be94a27a
+                image: lightninglabs/lnd:v0.14.2-beta@sha256:8318a24a3ad7319e424253eb56efcbf38e820ebc6d6b6edeec6a8a4e3e9314a0
                 user: 1000:1000
                 depends_on: [ tor_proxy, manager ]
                 volumes:


### PR DESCRIPTION
- https://github.com/lightningnetwork/lnd/releases/tag/v0.14.2-beta

> This is the second minor release of the 0.14x cycle! This release contains no new larger/major features, and instead packages up a series of bug fixes (several obscure crash fixes), and enhancements (like begin able to convert a node to a watch-only mode for use with the remote signer feature).
>
> We strongly recommend that all users update!