### PR TITLE
Upgrade ItchySats app to `0.4.1`

### DIFF
--- a/apps/itchysats/docker-compose.yml
+++ b/apps/itchysats/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: ghcr.io/itchysats/itchysats/taker:0.4.0@sha256:410332660845d7973c29a4a6b79b59b0748653dd73faade5b40e7c98061793ff
+    image: ghcr.io/itchysats/itchysats/taker:0.4.1@sha256:debe9a8b0ce275f48b8ed3bc43430241ea91c9d8c2a65eaa7f6d8a534453c099
     restart: on-failure
     stop_grace_period: 1m
     ports:

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -734,7 +734,7 @@
         "id": "itchysats",
         "category": "Finance",
         "name": "ItchySats",
-        "version": "v0.4.0",
+        "version": "v0.4.1",
         "tagline": "Peer-2-peer derivatives on Bitcoin",
         "description": "ItchySats enables peer-2-peer CFD trading on Bitcoin using DLCs (discreet log contracts). No account needed, no trusted third-party - just you and your keys.\n\nThis is beta software. We tested it on test- and mainnet, but there are no guarantees that it will always behave as expected.\nPlease be mindful with how much money you trust the application with.\nCFDs trading is inherently risky, be sure to read up on it before using this application.\n\nThat said: This is pretty awesome, go nuts!\n\n1. Fund the ItchySats wallet\n2. Open a position\n3. Watch the price go up\n4. Profit\n\nLimitations of the mainnet beta:\n\n1. You can only open long positions at the moment\n2. Minimum position quantity is $100, maximum $1000\n3. The leverage is fixed at 2\n\nWith 0.4.0 your CFDs are perpetual positions that are extended hourly. This means your CFD position will remain open forever unless you decide to close it. A funding fee is collected hourly when the CFD is extended.\nUpdate for going short to be expected soon!",
         "developer": "ItchySats",


### PR DESCRIPTION
0.4.1 includes:
- Bugfix for outdated price feed due to price feed actor restart failure

Would be great if that could be patched before the next release; the bug does not result in an error on the UI, the user can unfortunately only notice that something is wrong when either the `P/L` and `payout` values are wrongly displayed, or when `Close` leads to an error that the price is outdated.

 Before this patch release, the only workaround for resolving the bug is to restart the daemon, i.e. the container (or umbrel for users that don't SSH into umbrel). 