### PR TITLE
Lnbits: Add admin key UI

### DIFF
--- a/apps/lnbits/docker-compose.yml
+++ b/apps/lnbits/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: lnbitsdocker/lnbits:ec874ba@sha256:be659f3c11556fd757cd27f55f3a6bf07ab31302765f63b6a44fba60e393763b
+    image: ghcr.io/runcitadel/lnbits:feat-admin-password@sha256:d62fe931a83fbd9ad35cb88b468c9d29bc800a7fada6c93430918757b163831b
     user: 1000:1000
     init: true
     restart: on-failure
@@ -28,6 +28,8 @@ services:
       LNBITS_SITE_TITLE: "LNbits - Umbrel"
       LNBITS_DEFAULT_WALLET_NAME: "LNbits wallet"
       LNBITS_DISABLED_EXTENSIONS: "amilk"
+      LNBITS_ADMIN_LOGIN_KEY: $APP_PASSWORD
+      LNBITS_ADMIN_EXTENSIONS: ngrok
     networks:
         default:
           ipv4_address: $APP_LNBITS_IP

--- a/apps/lnbits/docker-compose.yml
+++ b/apps/lnbits/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: ghcr.io/runcitadel/lnbits:feat-admin-password@sha256:d62fe931a83fbd9ad35cb88b468c9d29bc800a7fada6c93430918757b163831b
+    image: ghcr.io/runcitadel/lnbits-legends:feat-admin-password@sha256:caed274b15ba2deea298db829d2a67cd4e1eb3cf90b9fae26209ef383ab1f93a
     user: 1000:1000
     init: true
     restart: on-failure

--- a/apps/lnbits/docker-compose.yml
+++ b/apps/lnbits/docker-compose.yml
@@ -8,13 +8,12 @@ services:
     restart: on-failure
     stop_grace_period: 1m
     ports:
-      - "$APP_LNBITS_PORT:$APP_LNBITS_PORT"
+      - "$APP_LNBITS_PORT:5000"
     volumes:
       - ${APP_DATA_DIR}/data:/data
       - ${LND_DATA_DIR}:/lnd:ro
     environment:
       # Global
-      LNBITS_BIND: "0.0.0.0:$APP_LNBITS_PORT"
       LNBITS_DATA_FOLDER: "/data"
 
       # LND

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -497,7 +497,7 @@
         ],
         "path": "",
         "defaultUsername": "",
-        "defaultPassword": ""
+        "deterministicPassword": true
     },
     {
         "id": "btcpay-server",


### PR DESCRIPTION
Screenshots at https://github.com/lnbits/lnbits-legend/pull/522

An admin account gets access to expose their lnbits via ngrok and can set their own balance.

I'll share screenshots for the admin features soon.

---

I do not consent to my previous changes to Umbrel or any changes in Citadel being relicensed to the MIT license, but I'm fine with this PR being relicensed.