### PR TITLE
Update Squeaknode app to v0.2.8

### DIFF
--- a/apps/registry.json
+++ b/apps/registry.json
@@ -552,7 +552,7 @@
         "id": "squeaknode",
         "category": "Social",
         "name": "Squeaknode",
-        "version": "0.2.6",
+        "version": "0.2.7",
         "tagline": "A peer-to-peer status feed with Lightning monetization",
         "description": "The Squeaknode app allows you to create, view, buy, and sell squeaks. A squeak is a single post that can contain up to 280 characters.\n\nThe Squeaknode timeline is ordered by the height of the block hash embedded in each squeak. Each squeak is signed with the digital signature of the author. Squeaks can be downloaded from any peer to any peer, but they remain locked until the downloader makes a Lightning payment to decrypt the content.",
         "developer": "Jonathan Zernik",

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -552,7 +552,7 @@
         "id": "squeaknode",
         "category": "Social",
         "name": "Squeaknode",
-        "version": "0.2.4",
+        "version": "0.2.5",
         "tagline": "A peer-to-peer status feed with Lightning monetization",
         "description": "The Squeaknode app allows you to create, view, buy, and sell squeaks. A squeak is a single post that can contain up to 280 characters.\n\nThe Squeaknode timeline is ordered by the height of the block hash embedded in each squeak. Each squeak is signed with the digital signature of the author. Squeaks can be downloaded from any peer to any peer, but they remain locked until the downloader makes a Lightning payment to decrypt the content.",
         "developer": "Jonathan Zernik",

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -552,7 +552,7 @@
         "id": "squeaknode",
         "category": "Social",
         "name": "Squeaknode",
-        "version": "0.2.7",
+        "version": "0.2.8",
         "tagline": "A peer-to-peer status feed with Lightning monetization",
         "description": "The Squeaknode app allows you to create, view, buy, and sell squeaks. A squeak is a single post that can contain up to 280 characters.\n\nThe Squeaknode timeline is ordered by the height of the block hash embedded in each squeak. Each squeak is signed with the digital signature of the author. Squeaks can be downloaded from any peer to any peer, but they remain locked until the downloader makes a Lightning payment to decrypt the content.",
         "developer": "Jonathan Zernik",

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -552,7 +552,7 @@
         "id": "squeaknode",
         "category": "Social",
         "name": "Squeaknode",
-        "version": "0.2.5",
+        "version": "0.2.6",
         "tagline": "A peer-to-peer status feed with Lightning monetization",
         "description": "The Squeaknode app allows you to create, view, buy, and sell squeaks. A squeak is a single post that can contain up to 280 characters.\n\nThe Squeaknode timeline is ordered by the height of the block hash embedded in each squeak. Each squeak is signed with the digital signature of the author. Squeaks can be downloaded from any peer to any peer, but they remain locked until the downloader makes a Lightning payment to decrypt the content.",
         "developer": "Jonathan Zernik",

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -552,7 +552,7 @@
         "id": "squeaknode",
         "category": "Social",
         "name": "Squeaknode",
-        "version": "0.2.3",
+        "version": "0.2.4",
         "tagline": "A peer-to-peer status feed with Lightning monetization",
         "description": "The Squeaknode app allows you to create, view, buy, and sell squeaks. A squeak is a single post that can contain up to 280 characters.\n\nThe Squeaknode timeline is ordered by the height of the block hash embedded in each squeak. Each squeak is signed with the digital signature of the author. Squeaks can be downloaded from any peer to any peer, but they remain locked until the downloader makes a Lightning payment to decrypt the content.",
         "developer": "Jonathan Zernik",

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -552,9 +552,9 @@
         "id": "squeaknode",
         "category": "Social",
         "name": "Squeaknode",
-        "version": "0.1.187",
+        "version": "0.2.2",
         "tagline": "A peer-to-peer status feed with Lightning monetization",
-        "description": "The Squeaknode app allows you to create, view, buy, and sell squeaks. A squeak is a single post that can contain up to 280 characters.\n\nThe Squeaknode timeline is ordered by the height of the block hash embedded in each squeak. Each squeak is signed with a digital signature of the private key of the author. Squeaks can be downloaded from any peer to any peer, but they remain locked until the downloader makes a Lightning payment to decrypt the content.",
+        "description": "The Squeaknode app allows you to create, view, buy, and sell squeaks. A squeak is a single post that can contain up to 280 characters.\n\nThe Squeaknode timeline is ordered by the height of the block hash embedded in each squeak. Each squeak is signed with the digital signature of the author. Squeaks can be downloaded from any peer to any peer, but they remain locked until the downloader makes a Lightning payment to decrypt the content.",
         "developer": "Jonathan Zernik",
         "website": "https://squeaknode.org",
         "dependencies": [

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -552,7 +552,7 @@
         "id": "squeaknode",
         "category": "Social",
         "name": "Squeaknode",
-        "version": "0.2.2",
+        "version": "0.2.3",
         "tagline": "A peer-to-peer status feed with Lightning monetization",
         "description": "The Squeaknode app allows you to create, view, buy, and sell squeaks. A squeak is a single post that can contain up to 280 characters.\n\nThe Squeaknode timeline is ordered by the height of the block hash embedded in each squeak. Each squeak is signed with the digital signature of the author. Squeaks can be downloaded from any peer to any peer, but they remain locked until the downloader makes a Lightning payment to decrypt the content.",
         "developer": "Jonathan Zernik",

--- a/apps/squeaknode/docker-compose.yml
+++ b/apps/squeaknode/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: ghcr.io/squeaknode/squeaknode:v0.2.3@sha256:6d8b01b60d6824afeb5a654ffdaa40fa6dcf78386a8624627b8a687f43d5410c
+    image: ghcr.io/squeaknode/squeaknode:v0.2.4@sha256:f5c91b5a36f39849afaf177bd2e93ee17800a124753e8408863137039b7120fe
     restart: on-failure
     stop_grace_period: 1m
     ports:

--- a/apps/squeaknode/docker-compose.yml
+++ b/apps/squeaknode/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: ghcr.io/squeaknode/squeaknode:v0.2.5@sha256:c461bbbd1ce40ac1a968d07b03ad46feb187c007fe1ec2dc3f03a14aa002b7b6
+    image: ghcr.io/squeaknode/squeaknode:v0.2.6@sha256:ebdb52f3a510401da2e14d2eda38762af283b30ffd3c4e3e5ce356c922b474a5
     restart: on-failure
     stop_grace_period: 1m
     ports:

--- a/apps/squeaknode/docker-compose.yml
+++ b/apps/squeaknode/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: ghcr.io/squeaknode/squeaknode:v0.2.4@sha256:f5c91b5a36f39849afaf177bd2e93ee17800a124753e8408863137039b7120fe
+    image: ghcr.io/squeaknode/squeaknode:v0.2.5@sha256:c461bbbd1ce40ac1a968d07b03ad46feb187c007fe1ec2dc3f03a14aa002b7b6
     restart: on-failure
     stop_grace_period: 1m
     ports:

--- a/apps/squeaknode/docker-compose.yml
+++ b/apps/squeaknode/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: ghcr.io/squeaknode/squeaknode:v0.2.7@sha256:eeacac3b208391572af34eeab4cc4987d39363140b35a420cce48d933fbb4e79
+    image: ghcr.io/squeaknode/squeaknode:v0.2.8@sha256:731b36821185eedf5031e725234977bb472eecc7bbcecb431ee2b060058d2725
     restart: on-failure
     stop_grace_period: 1m
     ports:

--- a/apps/squeaknode/docker-compose.yml
+++ b/apps/squeaknode/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: ghcr.io/squeaknode/squeaknode:v0.1.194@sha256:fd1150908604e058426e5dda6eb9360d2b5931bdab4d852e4222ba20c35d82b9
+    image: ghcr.io/squeaknode/squeaknode:v0.2.2@sha256:155f08467508f5bd69f0ce5e7e9aa01f2d0d6cbbf8f712ed8dce8a5d3f2fb862
     restart: on-failure
     stop_grace_period: 1m
     ports:

--- a/apps/squeaknode/docker-compose.yml
+++ b/apps/squeaknode/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: ghcr.io/squeaknode/squeaknode:v0.2.6@sha256:ebdb52f3a510401da2e14d2eda38762af283b30ffd3c4e3e5ce356c922b474a5
+    image: ghcr.io/squeaknode/squeaknode:v0.2.7@sha256:eeacac3b208391572af34eeab4cc4987d39363140b35a420cce48d933fbb4e79
     restart: on-failure
     stop_grace_period: 1m
     ports:

--- a/apps/squeaknode/docker-compose.yml
+++ b/apps/squeaknode/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: ghcr.io/squeaknode/squeaknode:v0.2.2@sha256:155f08467508f5bd69f0ce5e7e9aa01f2d0d6cbbf8f712ed8dce8a5d3f2fb862
+    image: ghcr.io/squeaknode/squeaknode:v0.2.3@sha256:6d8b01b60d6824afeb5a654ffdaa40fa6dcf78386a8624627b8a687f43d5410c
     restart: on-failure
     stop_grace_period: 1m
     ports:


### PR DESCRIPTION
Update Squeaknode app to version 0.2

This version comes with a re-designed frontend:

![Screenshot from 2022-02-23 03-53-50](https://user-images.githubusercontent.com/890133/155315208-7f4105a1-0fb9-42ca-a29c-b64eb4fe7bec.png)
![Screenshot from 2022-02-23 03-55-02](https://user-images.githubusercontent.com/890133/155315214-a05e4a80-5302-4cf7-b509-8c69772486ad.png)
![Screenshot from 2022-02-23 03-55-45](https://user-images.githubusercontent.com/890133/155315217-2690e374-cc0e-47da-9107-564681f24049.png)
![Screenshot from 2022-02-23 03-56-35](https://user-images.githubusercontent.com/890133/155315229-89465781-2d18-43a5-8bf5-b3dd30a808a4.png)
![Screenshot from 2022-02-23 03-57-18](https://user-images.githubusercontent.com/890133/155315238-7cce0d8f-4db4-43b5-ad17-dff80e8eeb8a.png)
