### PR TITLE
[Snowflake] Add --title-format command

### DIFF
--- a/apps/snowflake/docker-compose.yml
+++ b/apps/snowflake/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     stop_grace_period: 1m
     ports:
      - $APP_SNOWFLAKE_PORT:$APP_SNOWFLAKE_PORT
-    command: --port $APP_SNOWFLAKE_PORT --index "/snowflake/index.html" bash -c 'tail -n 10000 -f /snowflake/snowflake.log | grep "Traffic Relayed"'
+    command: --port $APP_SNOWFLAKE_PORT --index "/snowflake/index.html" --title-format "Tor Snowflake Proxy" bash -c 'tail -n 10000 -f /snowflake/snowflake.log | grep "Traffic Relayed"'
     volumes:
       - ${APP_DATA_DIR}/data:/snowflake
     networks:


### PR DESCRIPTION
It looks like gotty adds its own title to the HTML template. Adding the --title-format explicitly sets the page title displayed in browser tabs.