### PR TITLE
Update Jam to `v0.0.4`

### DIFF
--- a/apps/jam/docker-compose.yml
+++ b/apps/jam/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   jam:
-    image: ghcr.io/joinmarket-webui/joinmarket-webui-standalone:v0.0.3-clientserver-v0.9.5@sha256:d33817e4daec4ddaaf95a1c08e54f50cff4893b7d8c5b3bbe8b179ced74bbaa2
+    image: ghcr.io/joinmarket-webui/joinmarket-webui-standalone:v0.0.4-clientserver-v0.9.5@sha256:45a47e5a2ea69183479f69df0683e59ea226d20e601a868439b2980a568ca2f6
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/apps/jam/docker-compose.yml
+++ b/apps/jam/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       jm_rpc_password: "${BITCOIN_RPC_PASS}"
       jm_rpc_wallet_file: jam_default
       jm_network: $BITCOIN_NETWORK
-      jm_max_cj_fee_abs: 30000  # in sats
+      jm_max_cj_fee_abs: 300000 # in sats
       jm_max_cj_fee_rel: 0.0003 # 0.03%
     networks:
       default:

--- a/apps/jam/docker-compose.yml
+++ b/apps/jam/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - ${APP_DATA_DIR}/data/joinmarket:/root/.joinmarket
     environment:
       ENSURE_WALLET: 1
+      RESTORE_DEFAULT_CONFIG: 1
       APP_USER: umbrel
       APP_PASSWORD: "${APP_PASSWORD}"
       jm_tor_control_host: $TOR_PROXY_IP

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -479,7 +479,7 @@
         "id": "jam",
         "category": "Wallets",
         "name": "Jam",
-        "version": "v0.0.3",
+        "version": "v0.0.4",
         "tagline": "A user-friendly UI for JoinMarket",
         "description": "Jam is a user-interface for JoinMarket with a focus on user-friendliness.\nIt is time for top-notch privacy for your bitcoin. Widespread use of JoinMarket improves bitcoin's fungibility and privacy for all.\n\nThe app provides sensible defaults and is easy to use for beginners while still providing the features advanced users expect.",
         "developer": "JoinMarket WebUI Organisation",


### PR DESCRIPTION
- [x] summary of most notable changes
- [x] release the new image
- [x] update image+hash in PR

All notable changes of the UI can be seen in the [Jam `v0.0.4` changelog](https://github.com/joinmarket-webui/joinmarket-webui/releases/tag/v0.0.4). Most of the issues have been reported by Umbrel users. Thanks to all who helped to find and repair these bugs. :pray: 

Updates to the image:
- Adding [a slightly adapted default config](https://github.com/joinmarket-webui/joinmarket-webui-docker/pull/25):
  - use onion irc server instead of clearnet (Closes #1300)
  - add default max fee settings
- Support for websocket connection

In order to guarantee that all current users will benefit from the changes, an option to always use the adapted default config is introduced. It it also ensured that everyone already using Jam with a locally adapted version can opt-out of this behaviour. This mostly applies to power users (which Jam generally is not tailored at).

> With upstream changes https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1049 and https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1061 on the horizon, there is a chance to revert these changes and using a generated default configuration file once again.