### PR TITLE
Update Jam to `v0.0.5`

### DIFF
--- a/apps/jam/docker-compose.yml
+++ b/apps/jam/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   jam:
-    image: ghcr.io/joinmarket-webui/joinmarket-webui-standalone:v0.0.4-clientserver-v0.9.5@sha256:45a47e5a2ea69183479f69df0683e59ea226d20e601a868439b2980a568ca2f6
+    image: ghcr.io/joinmarket-webui/joinmarket-webui-standalone:v0.0.5-clientserver-v0.9.5@sha256:5fbbc766b25449e87f5fffb689d236b0a0c9b6332c1cb75478bcbc7225d04ad9
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -479,9 +479,9 @@
         "id": "jam",
         "category": "Wallets",
         "name": "Jam",
-        "version": "v0.0.4",
+        "version": "v0.0.5",
         "tagline": "A user-friendly UI for JoinMarket",
-        "description": "Jam is a user-interface for JoinMarket with a focus on user-friendliness.\nIt is time for top-notch privacy for your bitcoin. Widespread use of JoinMarket improves bitcoin's fungibility and privacy for all.\n\nThe app provides sensible defaults and is easy to use for beginners while still providing the features advanced users expect.",
+        "description": "Jam is a user-interface for JoinMarket with focus on user-friendliness.\nIt is time for top-notch privacy for your bitcoin. Widespread use of JoinMarket improves bitcoin's fungibility and privacy for all.\n\nThe app provides sensible defaults and is easy to use for beginners while still providing the features advanced users expect.",
         "developer": "JoinMarket WebUI Organisation",
         "website": "https://github.com/joinmarket-webui",
         "dependencies": [


### PR DESCRIPTION
This version includes:
- joinmarket-webui: [v0.0.5](https://github.com/joinmarket-webui/joinmarket-webui/releases/tag/v0.0.5)
- joinmarket-clientserver: [v0.9.5](https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.5)

All notable changes of the UI can be seen in the [Jam `v0.0.5` changelog](https://github.com/joinmarket-webui/joinmarket-webui/blob/v0.0.5/CHANGELOG.md)

Updates to the image:
- Colorize bash output [#28](https://github.com/joinmarket-webui/joinmarket-webui-docker/pull/28)