### PR TITLE
fix: use https instead of git protocol in github actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -49,7 +49,7 @@ jobs:
         sudo systemctl restart docker
     - name: Download Umbrel OS build scripts
       run: |
-        git clone git://github.com/getumbrel/umbrel-os.git
+        git clone https://github.com/getumbrel/umbrel-os.git
       
     - name: Build Umbrel OS
       run: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -34,7 +34,7 @@ jobs:
         sudo systemctl restart docker
     - name: Download Umbrel OS build scripts
       run: |
-        git clone git://github.com/getumbrel/umbrel-os.git
+        git clone https://github.com/getumbrel/umbrel-os.git
     - name: Setting env vars
       run: |
         UMBREL_OS_VERSION="dev"


### PR DESCRIPTION
Adapts 
`git clone git://github.com/getumbrel/umbrel-os.git` 
to 
`git clone https://github.com/getumbrel/umbrel-os.git`
in GitHub actions. No further changes are made.

Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.