### PR TITLE
workflow: git clone https://github.com/getumbrel/umbrel-os.git

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -34,7 +34,7 @@ jobs:
         sudo systemctl restart docker
     - name: Download Umbrel OS build scripts
       run: |
-        git clone git://github.com/getumbrel/umbrel-os.git
+        git clone https://github.com/getumbrel/umbrel-os.git
     - name: Setting env vars
       run: |
         UMBREL_OS_VERSION="dev"


### PR DESCRIPTION
Use https:// instead of git://
git:// no longer deprecated 