### PR TITLE
changed method of pulling hostname to be more universal

### DIFF
--- a/scripts/app
+++ b/scripts/app
@@ -106,7 +106,7 @@ compose() {
   local env_file="${UMBREL_ROOT}/.env"
   local app_base_compose_file="${UMBREL_ROOT}/apps/docker-compose.common.yml"
   local app_compose_file="${app_dir}/docker-compose.yml"
-  local app_domain="$(hostname -s 2>/dev/null || echo "umbrel").local"
+  local app_domain="$(cat /proc/sys/kernel/hostname -s 2>/dev/null || echo "umbrel").local"
   local app_hidden_servive_file="${UMBREL_ROOT}/tor/data/app-${app}/hostname"
   local app_entropy_identifier="app-${app}-seed"
 

--- a/scripts/app
+++ b/scripts/app
@@ -106,7 +106,7 @@ compose() {
   local env_file="${UMBREL_ROOT}/.env"
   local app_base_compose_file="${UMBREL_ROOT}/apps/docker-compose.common.yml"
   local app_compose_file="${app_dir}/docker-compose.yml"
-  local app_domain="$(cat /proc/sys/kernel/hostname -s 2>/dev/null || echo "umbrel").local"
+  local app_domain="$(cat /proc/sys/kernel/hostname 2>/dev/null || echo "umbrel").local"
   local app_hidden_servive_file="${UMBREL_ROOT}/tor/data/app-${app}/hostname"
   local app_entropy_identifier="app-${app}-seed"
 

--- a/scripts/configure
+++ b/scripts/configure
@@ -346,7 +346,7 @@ sed -i "s#DOCKER_BINARY=<path>#DOCKER_BINARY=$DOCKER_BINARY#g;" "$ENV_FILE"
 sed -i "/server_banner/s/<version>/$UMBREL_VERSION/g;" "$ELECTRS_CONF_FILE"
 
 # Add hostname to lnd.conf for TLS certificate
-DEVICE_HOSTNAME="$(hostname)"
+DEVICE_HOSTNAME="$(cat /proc/sys/kernel/hostname)"
 sed -i "s/tlsextradomain=<hostname>/tlsextradomain=$DEVICE_HOSTNAME.local/g;" "$LND_CONF_FILE"
 
 # If node is already synced, do not reset to neutrino

--- a/scripts/start
+++ b/scripts/start
@@ -66,7 +66,7 @@ fi
 
 # Whitelist device IP, hostname and hidden service for CORS
 DEVICE_IP="$(ip -o route get to 8.8.8.8 | sed -n 's/.*src \([0-9.]\+\).*/\1/p')"
-DEVICE_HOSTNAME="$(hostname)"
+DEVICE_HOSTNAME="$(cat /proc/sys/kernel/hostname)"
 DEVICE_HOSTS="http://${DEVICE_IP},http://${DEVICE_HOSTNAME}.local,https://${DEVICE_HOSTNAME}.local,http://${DEVICE_HOSTNAME},https://${DEVICE_HOSTNAME}"
 if [[ -f "${UMBREL_ROOT}/tor/data/web/hostname" ]]; then
     hidden_service_url=$(cat "${UMBREL_ROOT}/tor/data/web/hostname")

--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -162,7 +162,7 @@ if [[ "${current_umbrel_version}" = "0.4.0" ]] && [[ -f "${nextcloud_config_file
   echo
   echo "Fixing broken Umbrel v0.4.0 Nextcloud install..."
   nextcloud_hs=$(cat "${nextcloud_tor_file}")
-  nextcloud_local_url="$(hostname -s 2>/dev/null || echo "umbrel").local:8081"
+  nextcloud_local_url="$(cat /proc/sys/kernel/hostname -s 2>/dev/null || echo "umbrel").local:8081"
   sed \
     -e '/trusted_domains\x27 => $/,/)/!b' \
     -e '/)/!d;a\  \x27trusted_domains\x27 => array ( 0 => \x27localhost\x27, 1 => \x27'$nextcloud_local_url'\x27, 2 => \x27'$nextcloud_hs'\x27),' \

--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -162,7 +162,7 @@ if [[ "${current_umbrel_version}" = "0.4.0" ]] && [[ -f "${nextcloud_config_file
   echo
   echo "Fixing broken Umbrel v0.4.0 Nextcloud install..."
   nextcloud_hs=$(cat "${nextcloud_tor_file}")
-  nextcloud_local_url="$(cat /proc/sys/kernel/hostname -s 2>/dev/null || echo "umbrel").local:8081"
+  nextcloud_local_url="$(cat /proc/sys/kernel/hostname 2>/dev/null || echo "umbrel").local:8081"
   sed \
     -e '/trusted_domains\x27 => $/,/)/!b' \
     -e '/)/!d;a\  \x27trusted_domains\x27 => array ( 0 => \x27localhost\x27, 1 => \x27'$nextcloud_local_url'\x27, 2 => \x27'$nextcloud_hs'\x27),' \


### PR DESCRIPTION
I was getting errors when trying to install/run umbrel on an Arch system. It appears that `hostname` is an Ubuntu-specific command (or at least it doesn't exist in Arch). This should allow Umbrel to be compatible with more Linux systems, as long as they have all of the dependencies installed.