### PR TITLE
Update squeaknode app to v0.2.23

### DIFF
--- a/apps/registry.json
+++ b/apps/registry.json
@@ -577,7 +577,7 @@
         "id": "squeaknode",
         "category": "Social",
         "name": "Squeaknode",
-        "version": "0.2.20",
+        "version": "0.2.21",
         "tagline": "A peer-to-peer status feed with Lightning monetization",
         "description": "Squeaknode is a peer-to-peer microblog with posts unlocked by Lightning Network payments.\n\nThe app allows you to create, view, buy, and sell squeaks. A squeak is a post that can contain up to 280 characters.\n\nThe Squeaknode timeline is ordered by the height of the Bitcoin block hash embedded in each squeak. Each squeak must be signed with the private key of the author. Squeaks can be downloaded from any peer to any peer, but they remain locked until the downloader makes a Lightning payment to decrypt the content.",
         "developer": "Jonathan Zernik",

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -577,7 +577,7 @@
         "id": "squeaknode",
         "category": "Social",
         "name": "Squeaknode",
-        "version": "0.2.18",
+        "version": "0.2.19",
         "tagline": "A peer-to-peer status feed with Lightning monetization",
         "description": "Squeaknode is a peer-to-peer microblog with posts unlocked by Lightning Network payments.\n\nThe app allows you to create, view, buy, and sell squeaks. A squeak is a post that can contain up to 280 characters.\n\nThe Squeaknode timeline is ordered by the height of the Bitcoin block hash embedded in each squeak. Each squeak must be signed with the private key of the author. Squeaks can be downloaded from any peer to any peer, but they remain locked until the downloader makes a Lightning payment to decrypt the content.",
         "developer": "Jonathan Zernik",

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -577,7 +577,7 @@
         "id": "squeaknode",
         "category": "Social",
         "name": "Squeaknode",
-        "version": "0.2.21",
+        "version": "0.2.22",
         "tagline": "A peer-to-peer status feed with Lightning monetization",
         "description": "Squeaknode is a peer-to-peer microblog with posts unlocked by Lightning Network payments.\n\nThe app allows you to create, view, buy, and sell squeaks. A squeak is a post that can contain up to 280 characters.\n\nThe Squeaknode timeline is ordered by the height of the Bitcoin block hash embedded in each squeak. Each squeak must be signed with the private key of the author. Squeaks can be downloaded from any peer to any peer, but they remain locked until the downloader makes a Lightning payment to decrypt the content.",
         "developer": "Jonathan Zernik",

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -577,9 +577,9 @@
         "id": "squeaknode",
         "category": "Social",
         "name": "Squeaknode",
-        "version": "0.2.16",
+        "version": "0.2.17",
         "tagline": "A peer-to-peer status feed with Lightning monetization",
-        "description": "Squeaknode is a peer-to-peer microblog with posts unlocked by Lightning Network payments. The app allows you to create, view, buy, and sell squeaks. A squeak is a post that can contain up to 280 characters.\n\nThe Squeaknode timeline is ordered by the height of the Bitcoin block hash embedded in each squeak. Each squeak must be signed with the private key of the author. Squeaks can be downloaded from any peer to any peer, but they remain locked until the downloader makes a Lightning payment to decrypt the content.",
+        "description": "Squeaknode is a peer-to-peer microblog with posts unlocked by Lightning Network payments.\n\nThe app allows you to create, view, buy, and sell squeaks. A squeak is a post that can contain up to 280 characters.\n\nThe Squeaknode timeline is ordered by the height of the Bitcoin block hash embedded in each squeak. Each squeak must be signed with the private key of the author. Squeaks can be downloaded from any peer to any peer, but they remain locked until the downloader makes a Lightning payment to decrypt the content.",
         "developer": "Jonathan Zernik",
         "website": "https://squeaknode.org",
         "dependencies": [

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -577,7 +577,7 @@
         "id": "squeaknode",
         "category": "Social",
         "name": "Squeaknode",
-        "version": "0.2.22",
+        "version": "0.2.23",
         "tagline": "A peer-to-peer status feed with Lightning monetization",
         "description": "Squeaknode is a peer-to-peer microblog with posts unlocked by Lightning Network payments.\n\nThe app allows you to create, view, buy, and sell squeaks. A squeak is a post that can contain up to 280 characters.\n\nThe Squeaknode timeline is ordered by the height of the Bitcoin block hash embedded in each squeak. Each squeak must be signed with the private key of the author. Squeaks can be downloaded from any peer to any peer, but they remain locked until the downloader makes a Lightning payment to decrypt the content.",
         "developer": "Jonathan Zernik",

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -577,7 +577,7 @@
         "id": "squeaknode",
         "category": "Social",
         "name": "Squeaknode",
-        "version": "0.2.17",
+        "version": "0.2.18",
         "tagline": "A peer-to-peer status feed with Lightning monetization",
         "description": "Squeaknode is a peer-to-peer microblog with posts unlocked by Lightning Network payments.\n\nThe app allows you to create, view, buy, and sell squeaks. A squeak is a post that can contain up to 280 characters.\n\nThe Squeaknode timeline is ordered by the height of the Bitcoin block hash embedded in each squeak. Each squeak must be signed with the private key of the author. Squeaks can be downloaded from any peer to any peer, but they remain locked until the downloader makes a Lightning payment to decrypt the content.",
         "developer": "Jonathan Zernik",

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -577,7 +577,7 @@
         "id": "squeaknode",
         "category": "Social",
         "name": "Squeaknode",
-        "version": "0.2.19",
+        "version": "0.2.20",
         "tagline": "A peer-to-peer status feed with Lightning monetization",
         "description": "Squeaknode is a peer-to-peer microblog with posts unlocked by Lightning Network payments.\n\nThe app allows you to create, view, buy, and sell squeaks. A squeak is a post that can contain up to 280 characters.\n\nThe Squeaknode timeline is ordered by the height of the Bitcoin block hash embedded in each squeak. Each squeak must be signed with the private key of the author. Squeaks can be downloaded from any peer to any peer, but they remain locked until the downloader makes a Lightning payment to decrypt the content.",
         "developer": "Jonathan Zernik",

--- a/apps/squeaknode/docker-compose.yml
+++ b/apps/squeaknode/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: ghcr.io/squeaknode/squeaknode:v0.2.16@sha256:25d9bd4ce22b4265979d64ce9a2417c883492cd8dce7f171fc5488d27db6c809
+    image: ghcr.io/squeaknode/squeaknode:v0.2.17@sha256:f0da3506ba693788cafdfc3763e7af418e553a6454fa52fca61677fcfc540baf
     restart: on-failure
     stop_grace_period: 1m
     ports:

--- a/apps/squeaknode/docker-compose.yml
+++ b/apps/squeaknode/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: ghcr.io/squeaknode/squeaknode:v0.2.21@sha256:3c26d00d25e629bbee038309b54af9cc5810c6ca7c7bc29b7066ee52533cf179
+    image: ghcr.io/squeaknode/squeaknode:v0.2.22@sha256:d62815b7884cb0d438741c09ebb9afa8111135b9f9464f987387490a4926d130
     restart: on-failure
     stop_grace_period: 1m
     ports:

--- a/apps/squeaknode/docker-compose.yml
+++ b/apps/squeaknode/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: ghcr.io/squeaknode/squeaknode:v0.2.22@sha256:d62815b7884cb0d438741c09ebb9afa8111135b9f9464f987387490a4926d130
+    image: ghcr.io/squeaknode/squeaknode:v0.2.23@sha256:0b950bcc8c733881258628f7a43fa615a0e825fd45cbb455d306405cea5800a6
     restart: on-failure
     stop_grace_period: 1m
     ports:

--- a/apps/squeaknode/docker-compose.yml
+++ b/apps/squeaknode/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: ghcr.io/squeaknode/squeaknode:v0.2.18@sha256:38ce7d04006bca80439ae256e103d43a36a69594252d5c129c190b97b5eb56f9
+    image: ghcr.io/squeaknode/squeaknode:v0.2.19@sha256:102e1e73b3dae733e4daa27b2fe5fca80357b5a1c7977d8772e466397aef231e
     restart: on-failure
     stop_grace_period: 1m
     ports:

--- a/apps/squeaknode/docker-compose.yml
+++ b/apps/squeaknode/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: ghcr.io/squeaknode/squeaknode:v0.2.17@sha256:f0da3506ba693788cafdfc3763e7af418e553a6454fa52fca61677fcfc540baf
+    image: ghcr.io/squeaknode/squeaknode:v0.2.18@sha256:38ce7d04006bca80439ae256e103d43a36a69594252d5c129c190b97b5eb56f9
     restart: on-failure
     stop_grace_period: 1m
     ports:

--- a/apps/squeaknode/docker-compose.yml
+++ b/apps/squeaknode/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: ghcr.io/squeaknode/squeaknode:v0.2.19@sha256:102e1e73b3dae733e4daa27b2fe5fca80357b5a1c7977d8772e466397aef231e
+    image: ghcr.io/squeaknode/squeaknode:v0.2.20@sha256:5bb90140af7cfaaaca7173c7742c3021fb577a381aaa68b521040de1e7478b04
     restart: on-failure
     stop_grace_period: 1m
     ports:

--- a/apps/squeaknode/docker-compose.yml
+++ b/apps/squeaknode/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: ghcr.io/squeaknode/squeaknode:v0.2.20@sha256:5bb90140af7cfaaaca7173c7742c3021fb577a381aaa68b521040de1e7478b04
+    image: ghcr.io/squeaknode/squeaknode:v0.2.21@sha256:3c26d00d25e629bbee038309b54af9cc5810c6ca7c7bc29b7066ee52533cf179
     restart: on-failure
     stop_grace_period: 1m
     ports:


### PR DESCRIPTION
Changes:
https://github.com/squeaknode/squeaknode/releases/tag/v0.2.17
https://github.com/squeaknode/squeaknode/releases/tag/v0.2.18
https://github.com/squeaknode/squeaknode/releases/tag/v0.2.19
https://github.com/squeaknode/squeaknode/releases/tag/v0.2.20
https://github.com/squeaknode/squeaknode/releases/tag/v0.2.21
https://github.com/squeaknode/squeaknode/releases/tag/v0.2.22
https://github.com/squeaknode/squeaknode/releases/tag/v0.2.23

This version supports resqueak (similar to retweet in Twitter).

![Screenshot from 2022-04-25 13-08-44](https://user-images.githubusercontent.com/890133/165166790-1326984b-6e8e-49a7-a865-149cb1781b0a.png)

