### PR TITLE
Upgrade ItchySats app to `0.4.15`

### DIFF
--- a/apps/itchysats/docker-compose.yml
+++ b/apps/itchysats/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: ghcr.io/itchysats/itchysats/taker:0.4.12@sha256:d83f62995cedf7d499d4b2da13d7d1c3d1edf79d9334e8a66f2578255d5539c1
+    image: ghcr.io/itchysats/itchysats/taker:0.4.14@sha256:ae760e9685144d18c4ec11af05024fb93f8b70ad093efd640e427d9c0bc9d6b1
     restart: on-failure
     stop_grace_period: 1m
     ports:
@@ -10,8 +10,6 @@ services:
     volumes:
       - ${APP_DATA_DIR}/data:/data
     command:
-      - --maker=$BITCOIN_NETWORK.itchysats.network:10000
-      - --maker-id=7e35e34801e766a6a29ecb9e22810ea4e3476c2b37bf75882edf94a68b1d9607
       - --password=$APP_PASSWORD
       - --umbrel-seed=$APP_SEED
       - $BITCOIN_NETWORK

--- a/apps/itchysats/docker-compose.yml
+++ b/apps/itchysats/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: ghcr.io/itchysats/itchysats/taker:0.4.10@sha256:6ce4691fa1d940a59598e1271f5c808869acfe8e6d639bead28076b5f7172414
+    image: ghcr.io/itchysats/itchysats/taker:0.4.12@sha256:d83f62995cedf7d499d4b2da13d7d1c3d1edf79d9334e8a66f2578255d5539c1
     restart: on-failure
     stop_grace_period: 1m
     ports:

--- a/apps/itchysats/docker-compose.yml
+++ b/apps/itchysats/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: ghcr.io/itchysats/itchysats/taker:0.4.14@sha256:ae760e9685144d18c4ec11af05024fb93f8b70ad093efd640e427d9c0bc9d6b1
+    image: ghcr.io/itchysats/itchysats/taker:0.4.15@sha256:7e66dd8627108344bac64005eaa2aa3d69bd4a062de4dd2164ae651014906194
     restart: on-failure
     stop_grace_period: 1m
     ports:

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -759,7 +759,7 @@
         "id": "itchysats",
         "category": "Finance",
         "name": "ItchySats",
-        "version": "v0.4.14",
+        "version": "v0.4.15",
         "tagline": "Peer-2-peer derivatives on Bitcoin",
         "description": "ItchySats enables peer-2-peer CFD trading on Bitcoin using DLCs (discreet log contracts). No account needed, no trusted third-party - just you and your keys.\n\nThis is beta software. We tested it on test- and mainnet, but there are no guarantees that it will always behave as expected.\nPlease be mindful with how much money you trust the application with.\nCFDs trading is inherently risky, be sure to read up on it before using this application.\n\nThat said: This is pretty awesome, go nuts!\n\n1. Fund the ItchySats wallet\n2. Open a position\n3. Monitor the price movement\n4. Profit\n\nLimitations of the mainnet beta:\n\n1. Minimum position quantity is $100, maximum $1000\n2. The leverage is fixed at 2\n\nWith 0.4.0 your CFDs are perpetual positions that are extended hourly. This means your CFD position will remain open forever unless you decide to close it. A funding fee is collected hourly when the CFD is extended.\n\nWith 0.4.8 you can open long and short positions, previously only long positions were possible.",
         "developer": "ItchySats",

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -759,7 +759,7 @@
         "id": "itchysats",
         "category": "Finance",
         "name": "ItchySats",
-        "version": "v0.4.10",
+        "version": "v0.4.12",
         "tagline": "Peer-2-peer derivatives on Bitcoin",
         "description": "ItchySats enables peer-2-peer CFD trading on Bitcoin using DLCs (discreet log contracts). No account needed, no trusted third-party - just you and your keys.\n\nThis is beta software. We tested it on test- and mainnet, but there are no guarantees that it will always behave as expected.\nPlease be mindful with how much money you trust the application with.\nCFDs trading is inherently risky, be sure to read up on it before using this application.\n\nThat said: This is pretty awesome, go nuts!\n\n1. Fund the ItchySats wallet\n2. Open a position\n3. Monitor the price movement\n4. Profit\n\nLimitations of the mainnet beta:\n\n1. Minimum position quantity is $100, maximum $1000\n2. The leverage is fixed at 2\n\nWith 0.4.0 your CFDs are perpetual positions that are extended hourly. This means your CFD position will remain open forever unless you decide to close it. A funding fee is collected hourly when the CFD is extended.\n\nWith 0.4.8 you can open long and short positions, previously only long positions were possible.",
         "developer": "ItchySats",

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -759,7 +759,7 @@
         "id": "itchysats",
         "category": "Finance",
         "name": "ItchySats",
-        "version": "v0.4.12",
+        "version": "v0.4.14",
         "tagline": "Peer-2-peer derivatives on Bitcoin",
         "description": "ItchySats enables peer-2-peer CFD trading on Bitcoin using DLCs (discreet log contracts). No account needed, no trusted third-party - just you and your keys.\n\nThis is beta software. We tested it on test- and mainnet, but there are no guarantees that it will always behave as expected.\nPlease be mindful with how much money you trust the application with.\nCFDs trading is inherently risky, be sure to read up on it before using this application.\n\nThat said: This is pretty awesome, go nuts!\n\n1. Fund the ItchySats wallet\n2. Open a position\n3. Monitor the price movement\n4. Profit\n\nLimitations of the mainnet beta:\n\n1. Minimum position quantity is $100, maximum $1000\n2. The leverage is fixed at 2\n\nWith 0.4.0 your CFDs are perpetual positions that are extended hourly. This means your CFD position will remain open forever unless you decide to close it. A funding fee is collected hourly when the CFD is extended.\n\nWith 0.4.8 you can open long and short positions, previously only long positions were possible.",
         "developer": "ItchySats",


### PR DESCRIPTION
Note that since version `0.4.12` the parameters for the maker are defaulted per network, that's why we remove the parameters from container startup.
This allows to start the container more easily for `mainnet` and `testnet` with the correct parameters.

Please refer to the commit messages for detailed changelogs.