### PR TITLE
Upgrade ItchySats app to `0.4.16`

### DIFF
--- a/apps/itchysats/docker-compose.yml
+++ b/apps/itchysats/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   web:
-    image: ghcr.io/itchysats/itchysats/taker:0.4.15@sha256:7e66dd8627108344bac64005eaa2aa3d69bd4a062de4dd2164ae651014906194
+    image: ghcr.io/itchysats/itchysats/taker:0.4.16@sha256:f404ace4baf85b9799bfa709c9481b35fabe22d6dcaf7fb8f664730c09230bc2
     restart: on-failure
     stop_grace_period: 1m
     ports:

--- a/apps/registry.json
+++ b/apps/registry.json
@@ -759,7 +759,7 @@
         "id": "itchysats",
         "category": "Finance",
         "name": "ItchySats",
-        "version": "v0.4.15",
+        "version": "v0.4.16",
         "tagline": "Peer-2-peer derivatives on Bitcoin",
         "description": "ItchySats enables peer-2-peer CFD trading on Bitcoin using DLCs (discreet log contracts). No account needed, no trusted third-party - just you and your keys.\n\nThis is beta software. We tested it on test- and mainnet, but there are no guarantees that it will always behave as expected.\nPlease be mindful with how much money you trust the application with.\nCFDs trading is inherently risky, be sure to read up on it before using this application.\n\nThat said: This is pretty awesome, go nuts!\n\n1. Fund the ItchySats wallet\n2. Open a position\n3. Monitor the price movement\n4. Profit\n\nLimitations of the mainnet beta:\n\n1. Minimum position quantity is $100, maximum $1000\n2. The leverage is fixed at 2\n\nWith 0.4.0 your CFDs are perpetual positions that are extended hourly. This means your CFD position will remain open forever unless you decide to close it. A funding fee is collected hourly when the CFD is extended.\n\nWith 0.4.8 you can open long and short positions, previously only long positions were possible.",
         "developer": "ItchySats",


### PR DESCRIPTION
### Changed

- Taker only re-establishes connection to maker after three minutes.
- Automatically time out xtra handlers after 2 minutes.