### PR TITLE
Update Tor to 0.4.7.8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.7'
 services:
         tor_proxy:
                 container_name: tor
-                image: lncm/tor:0.4.7.7@sha256:3c4ae833d2fefbea7d960f833a1e89fc9b2069a6e5f360109b5ddc9334ac0227
+                image: lncm/tor:0.4.7.8@sha256:aab30ebb496aa25934d6096951d8b200347c3c3ce5db3493695229efa2601f7b
                 user: toruser
                 restart: on-failure
                 volumes:

--- a/scripts/support/docker-compose.tor.yml
+++ b/scripts/support/docker-compose.tor.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   tor_server:
-    image: lncm/tor:0.4.7.7@sha256:3c4ae833d2fefbea7d960f833a1e89fc9b2069a6e5f360109b5ddc9334ac0227
+    image: lncm/tor:0.4.7.8@sha256:aab30ebb496aa25934d6096951d8b200347c3c3ce5db3493695229efa2601f7b
     restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/torrc:/etc/tor/torrc:ro


### PR DESCRIPTION
A DDoS vulnerability was discovered in 0.4.7.7 so this pull updates Tor to 0.4.7.8.

```
Changes in version 0.4.7.8 - 2022-06-17

  This version fixes several bugfixes including a High severity security issue
  categorized as a Denial of Service. Everyone running an earlier version
  should upgrade to this version.
  
  |   | o Major bugfixes (congestion control, TROVE-2022-001):
  |   | - Fix a scenario where RTT estimation can become wedged, seriously
  |   | degrading congestion control performance on all circuits. This
  |   | impacts clients, onion services, and relays, and can be triggered
  |   | remotely by a malicious endpoint. Tracked as CVE-2022-33903. Fixes
  |   | bug 40626; bugfix on 0.4.7.5-alpha.
  |   |  
  |   | o Minor features (fallbackdir):
  |   | - Regenerate fallback directories generated on June 17, 2022.
  |   |  
  |   | o Minor features (geoip data):
  |   | - Update the geoip files to match the IPFire Location Database, as
  |   | retrieved on 2022/06/17.
  |   |  
  |   | o Minor bugfixes (linux seccomp2 sandbox):
  |   | - Allow the rseq system call in the sandbox. This solves a crash
  |   | issue with glibc 2.35 on Linux. Patch from pmu-ipf. Fixes bug
  |   | 40601; bugfix on 0.3.5.11.
  |   |  
  |   | o Minor bugfixes (logging):
  |   | - Demote a harmless warn log message about finding a second hop to
  |   | from warn level to info level, if we do not have enough
  |   | descriptors yet. Leave it at notice level for other cases. Fixes
  |   | bug 40603; bugfix on 0.4.7.1-alpha.
  |   | - Demote a notice log message about "Unexpected path length" to info
  |   | level. These cases seem to happen arbitrarily, and we likely will
  |   | never find all of them before the switch to arti. Fixes bug 40612;
  |   | bugfix on 0.4.7.5-alpha.
  |   |  
  |   | o Minor bugfixes (relay, logging):
  |   | - Demote a harmless XOFF log message to from notice level to info
  |   | level. Fixes bug 40620; bugfix on 0.4.7.5-alpha.
  |   |  
```