### PR TITLE
Add DEVICE_ID to exported environment vars

### DIFF
--- a/scripts/app
+++ b/scripts/app
@@ -81,6 +81,7 @@ source_app() {
   export NETWORK_IP="${NETWORK_IP}"
 
   # Set other useful vars. used in exports
+  export DEVICE_IP="$(ip -o route get to 8.8.8.8 | sed -n 's/.*src \([0-9.]\+\).*/\1/p')"
   export DEVICE_HOSTNAME="$(cat /proc/sys/kernel/hostname 2>/dev/null || echo "umbrel")"
   export DEVICE_DOMAIN_NAME="${DEVICE_HOSTNAME}.local"
 

--- a/scripts/start
+++ b/scripts/start
@@ -83,6 +83,7 @@ if [[ -f "${UMBREL_ROOT}/tor/data/web/hostname" ]]; then
     hidden_service_url=$(cat "${UMBREL_ROOT}/tor/data/web/hostname")
     DEVICE_HOSTS="${DEVICE_HOSTS},http://${hidden_service_url}"
 fi
+export DEVICE_IP=$DEVICE_IP
 export DEVICE_HOSTS=$DEVICE_HOSTS
 export DEVICE_HOSTNAME="${DEVICE_HOSTNAME}.local"
 


### PR DESCRIPTION
Exports DEVICE_ID to the environment for `start` and `app` scripts.  The PR uses the same method already present for getting the device IP address.  This is helpful to ensure that the setup for client side applications can find the device on the network.  The hostname captured in the environement can be a bit finicky depending on the user's network.