### PR TITLE
Add support for docker-compose.override.yml

### DIFF
--- a/scripts/app
+++ b/scripts/app
@@ -187,7 +187,6 @@ compose() {
 
   local -r umbrel_env_file="${UMBREL_ROOT}/.env"
   local -r app_compose_file="${app_data_dir}/docker-compose.yml"
-  
   local -r app_compose_override_file="${app_data_dir}/docker-compose.override.yml"
 
   export TOR_DATA_DIR="${UMBREL_ROOT}/tor/data"
@@ -196,11 +195,6 @@ compose() {
   # To allow vars. in the app's compose file to override variables
   compose_files=()
   
-  # Detect if a docker override file exists for the app
-  if [[ -f "${app_compose_override_file}" ]]; then
-    compose_files+=( "--file" "${app_compose_override_file}" )
-  fi
-
   # Detect if the 'app_proxy' service has been defined
   # In the app's docker-compose file
   APP_PROXY_SERVICE_NAME="app_proxy"
@@ -220,6 +214,11 @@ compose() {
   # Any of the other compose files
   compose_files+=( "--file" "${common_compose_file}" )
   compose_files+=( "--file" "${app_compose_file}" )
+  
+  # Detect if a docker override file exists for the app
+  if [[ -f "${app_compose_override_file}" ]]; then
+    compose_files+=( "--file" "${app_compose_override_file}" )
+  fi
 
   # Merge compose files and args. passed into 'compose'
   compose_args=("${compose_files[@]}" "${@}")

--- a/scripts/app
+++ b/scripts/app
@@ -187,12 +187,19 @@ compose() {
 
   local -r umbrel_env_file="${UMBREL_ROOT}/.env"
   local -r app_compose_file="${app_data_dir}/docker-compose.yml"
+  
+  local -r app_compose_override_file="${app_data_dir}/docker-compose.override.yml"
 
   export TOR_DATA_DIR="${UMBREL_ROOT}/tor/data"
 
   # We need to use the proxy compose file first
   # To allow vars. in the app's compose file to override variables
   compose_files=()
+  
+  # Detect if a docker override file exists for the app
+  if [[ -f "${app_compose_override_file}" ]]; then
+    compose_files+=( "--file" "${app_compose_override_file}" )
+  fi
 
   # Detect if the 'app_proxy' service has been defined
   # In the app's docker-compose file


### PR DESCRIPTION
This will add support for optional `docker-compose.override.yml` files in app-data directories. This will also align with the default docker-compose behavior documented in the [docker-compose docs](https://docs.docker.com/compose/extends/#multiple-compose-files):

> By default, Compose reads two files, a docker-compose.yml and an optional docker-compose.override.yml file.