### PR TITLE
scripts: remove "no issue detected" message in debug script

### DIFF
--- a/scripts/debug
+++ b/scripts/debug
@@ -186,5 +186,3 @@ if [[ ! -z "${UMBREL_OS:-}" ]]; then
         exit 0
     fi
 fi
-
-echo "The debug script did not automatically detect any issues with your Umbrel."

--- a/scripts/debug
+++ b/scripts/debug
@@ -186,3 +186,5 @@ if [[ ! -z "${UMBREL_OS:-}" ]]; then
         exit 0
     fi
 fi
+
+echo "==== END ====="


### PR DESCRIPTION
The debug script will output this line no matter what happens. Users seeing this think there is no need to send the debug logs to me even though I asked for them, so support takes a few additional messages.