### PR TITLE
Umbrel v0.5.3

### DIFF
--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
-    "version": "0.5.2",
-    "name": "Umbrel v0.5.2",
+    "version": "0.5.3",
+    "name": "Umbrel v0.5.3",
     "requires": ">=0.5.0",
-    "notes": "Introducing Umbrel 0.5.2 with Community App Stores, the ability to enable/disable remote Tor access, new live search in the app store, bugfixes and performance improvements.\n\nAnyone can create a community app store for Umbrel and distribute their apps for others or personal use. Docs: github.com/getumbrel/umbrel-community-app-store\n\nIf you face any issues while updating, please message us on Telegram: https://t.me/getumbrel"
+    "notes": "This update fixes any missing app icons in storage and RAM usage statistics in the settings, and disables microSD card health check for Raspberry Pi users.\n\nIf you face any issues while updating, please message us on Telegram: https://t.me/getumbrel"
 }


### PR DESCRIPTION
Introducing Umbrel 0.5.3 with bugfixes for missing app icons in storage and RAM usage statistics in the settings, and disables microSD card health check for Raspberry Pi users.

### Umbrel v0.5.3
- Disable SD card health check @nevets963 https://github.com/getumbrel/umbrel/pull/1532

### Dashboard
- Read correct property for app name in storage/RAM usage @nevets963 https://github.com/getumbrel/umbrel-dashboard/pull/438

### Manager
- Fetch app name and icon from manifests with storage/RAM usage APIs @nevets963 https://github.com/getumbrel/umbrel-manager/pull/123