### PR TITLE
Append to instead of overwriting resolv.conf

### DIFF
--- a/scripts/update/00-run.sh
+++ b/scripts/update/00-run.sh
@@ -39,8 +39,9 @@ RESOLV_CONF_BACKUP_FILE="/tmp/resolv.conf"
 cat "${RESOLV_CONF_FILE}" > "${RESOLV_CONF_BACKUP_FILE}"
 
 # Use Cloudflare and Google public DNS servers for update
-echo "nameserver 1.1.1.1" > "${RESOLV_CONF_FILE}"
+echo "nameserver 1.1.1.1" >> "${RESOLV_CONF_FILE}"
 echo "nameserver 8.8.8.8" >> "${RESOLV_CONF_FILE}"
+echo "options timeout:1" >> "${RESOLV_CONF_FILE}"
 
 # Update status file
 cat <<EOF > "$UMBREL_ROOT"/statuses/update-status.json


### PR DESCRIPTION
Some networks do not have access to public DNS servers (such as Google or Cloudflare), and this breaks auto-update for Umbrel in a way that's very tricky to workaround.

The public DNS's are required for Umbrel users who are using Pinhole (in which case their router's DNS may be configured to point to the Umbrel instance for DNS services, which also breaks updates!).

To manage both of these contingencies, this commit appends the public DNS servers to the temporary resolv.conf, as well as setting the failover timeout to 1 second (instead of the default 5 seconds), so that non-pinhole users will simply use the original default, while pinhole users can just failover gracefully to the public ones.