### PR TITLE
Fix docker-compose output parsing

### DIFF
--- a/scripts/memory-usage
+++ b/scripts/memory-usage
@@ -24,7 +24,7 @@ get_app_memory_use () {
 
   local app_memory=0
 
-  local app_containers=$("${UMBREL_ROOT}/scripts/app" compose "${app}" ps | awk '{print $1}' | grep -v 'Name\|-----')
+  local app_containers=$("${UMBREL_ROOT}/scripts/app" compose "${app}" ps | grep -vE '^\s' | awk '{print $1}' | grep -v 'Name\|-----')
   for container in $app_containers; do
     local container_memory=$(get_container_memory_use "${container}")
     app_memory=$(awk "BEGIN {print ${app_memory}+${container_memory}}")

--- a/scripts/status/memory
+++ b/scripts/status/memory
@@ -31,7 +31,7 @@ get_app_memory_use() {
 
   local app_memory=0
 
-  local app_containers=$("${UMBREL_ROOT}/scripts/app" compose "${app}" ps | awk '{print $1}' | grep -v 'Name\|-----')
+  local app_containers=$("${UMBREL_ROOT}/scripts/app" compose "${app}" ps | grep -vE '^\s' | awk '{print $1}' | grep -v 'Name\|-----')
   for container in $app_containers; do
     local container_memory=$(get_container_memory_use "${container}")
     app_memory=$(awk "BEGIN {print ${app_memory}+${container_memory}}")


### PR DESCRIPTION
This PR fixes the case where `docker-compose` `ps` command returns multiline output per container, resulting wrong names being passed down the line.

Tested on Ubuntu 20.04, x86, docker-compose 1.25.0

![umbrl](https://user-images.githubusercontent.com/44872722/204137982-603f94c6-dd67-487e-981c-09a4e23ebc8d.png)
