### PR TITLE
Give exitcode to systemd service

### DIFF
--- a/scripts/start
+++ b/scripts/start
@@ -188,3 +188,6 @@ if [[ "${REMOTE_TOR_ACCESS}" == "true" ]] && [[ -f "${TOR_HS_WEB_HOSTNAME_FILE}"
 fi
 
 $set_status umbrel completed
+
+# Required for SYSTEMD
+exit 0

--- a/scripts/stop
+++ b/scripts/stop
@@ -60,3 +60,6 @@ fi
 echo "Stopping Docker services..."
 echo
 docker-compose "${compose_files[@]}" down
+
+# Required for SYSTEMD
+exit 0


### PR DESCRIPTION
Always when booting my system I get this error in my log:

`systemd[1]: umbrel-startup.service: Failed with result 'exit-code'.`

I have verified that the start script runs succesfully until the end, and the system is working fine. 

So my only guess is that systemd requires you to set the succesful exitcode explicitly, and this patch takes care of that.