### PR TITLE
Remove outdated network echo

### DIFF
--- a/scripts/configure
+++ b/scripts/configure
@@ -55,7 +55,7 @@ if [[ -f "${STATUS_DIR}/configured" ]]; then
 else
   echo "============ CONFIGURING ============="
 fi
-echo "========= UMBREL (${BITCOIN_NETWORK}) ==========="
+echo "=============== UMBREL ==============="
 echo "======================================"
 echo
 


### PR DESCRIPTION
Small edit to remove `echo` reference to Bitcoin network in configuration script. 

Need to remove all reference to Bitcoin network in the script at a future date.