### PR TITLE
Fix broken link due to missing 'v' in OS version

### DIFF
--- a/scripts/update/update
+++ b/scripts/update/update
@@ -83,7 +83,7 @@ fi
 if [[ "${update_type}" == "ota" ]]; then
   RELEASE=$(cat "$UMBREL_ROOT"/statuses/update-status.json | jq .updateTo -r)
 elif [[ "${update_type}" == "path" ]]; then
-  RELEASE=$(cat "$update_path"/info.json | jq .version -r)
+  RELEASE=v$(cat "$update_path"/info.json | jq .version -r)
 fi
 
 echo


### PR DESCRIPTION
Hi I found this bug when trying to upgrade manually from a Linux OS running Umbrel to Umbrel v0.5.4

Debian 11 Default  Version Umbrel v0.5.3

```console
root@umbrel:/mnt/umbrel# ./scripts/update/update --repo getumbrel/umbrel#v0.5.4
Cloning into '/tmp/umbrel-update'...
remote: Enumerating objects: 6306, done.
remote: Counting objects: 100% (1473/1473), done.
remote: Compressing objects: 100% (482/482), done.
remote: Total 6306 (delta 999), reused 1387 (delta 963), pack-reused 4833
Receiving objects: 100% (6306/6306), 14.05 MiB | 18.22 MiB/s, done.
Resolving deltas: 100% (3723/3723), done.
Note: switching to 'd299a7ad05dfd31d18f8b5d1828cecd459760dd5'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false


=======================================
=============== UPDATE ================
=======================================
========== Stage: Download ============
=======================================

Creating lock
Cleaning up any previous mess
Copying Umbrel 0.5.4 from /tmp/umbrel-update/
Running update install scripts of the new release

== Begin Update Script bootstrap-run.sh ==
Bootstrapping umbreld
Saving current Umbrel Docker images to clean up later
Reading file: /mnt/umbrel/docker-compose.yml
getumbrel/tor:0.4.7.8@sha256:2ace83f22501f58857fa9b403009f595137fa2e7986c4fda79d82a8119072b6a
nginx:1.17.8@sha256:380eb808e2a3b0dd954f92c1cae2f845e6558a15037efefcabc5b4e03d666d03
getumbrel/dashboard:v0.5.8@sha256:9cfb822da25eee75ed0d74525b7864e0068b1f21edde5ad1c01c9347d24b34b1
getumbrel/manager:v0.5.3@sha256:69caf866f5eb471789726a4584c5dd74eabc34e4b31ca5c846ad26424a7eb534
getumbrel/auth-server:v0.5.1@sha256:afcd9065eab02f98ee6bf705045170a4b385fb5f81e3b168bb92ffb8ac7a1760
Detected architecture: amd64
Installing umbreld to "/mnt/umbrel/bin/umbreld"
Downloading umbreld from "https://github.com/getumbrel/umbrel/releases/download/0.5.4/umbreld-0.5.4-amd64.tar.gz"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404

gzip: stdin: unexpected end of file
tar: Child returned status 1
tar: Error is not recoverable: exiting now
Update failed!
== End Update Script bootstrap-run.sh ==

Deleting cloned repository
Removing lock

root@umbrel:/mnt/umbrel#
```

Debian 11 Fixed Version Umbrel v0.5.3

```console
root@umbrel:/mnt/umbrel# ./scripts/update/update --repo getumbrel/umbrel#v0.5.4
Cloning into '/tmp/umbrel-update'...
remote: Enumerating objects: 6306, done.
remote: Counting objects: 100% (1473/1473), done.
remote: Compressing objects: 100% (482/482), done.
remote: Total 6306 (delta 999), reused 1387 (delta 963), pack-reused 4833
Receiving objects: 100% (6306/6306), 14.05 MiB | 17.38 MiB/s, done.
Resolving deltas: 100% (3723/3723), done.
Note: switching to 'd299a7ad05dfd31d18f8b5d1828cecd459760dd5'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false


=======================================
=============== UPDATE ================
=======================================
========== Stage: Download ============
=======================================

Creating lock
Cleaning up any previous mess
Copying Umbrel v0.5.4 from /tmp/umbrel-update/
Running update install scripts of the new release

== Begin Update Script bootstrap-run.sh ==
Bootstrapping umbreld
Saving current Umbrel Docker images to clean up later
Reading file: /mnt/umbrel/docker-compose.yml
getumbrel/tor:0.4.7.8@sha256:2ace83f22501f58857fa9b403009f595137fa2e7986c4fda79d82a8119072b6a
nginx:1.17.8@sha256:380eb808e2a3b0dd954f92c1cae2f845e6558a15037efefcabc5b4e03d666d03
getumbrel/dashboard:v0.5.8@sha256:9cfb822da25eee75ed0d74525b7864e0068b1f21edde5ad1c01c9347d24b34b1
getumbrel/manager:v0.5.3@sha256:69caf866f5eb471789726a4584c5dd74eabc34e4b31ca5c846ad26424a7eb534
getumbrel/auth-server:v0.5.1@sha256:afcd9065eab02f98ee6bf705045170a4b385fb5f81e3b168bb92ffb8ac7a1760
Detected architecture: amd64
Installing umbreld to "/mnt/umbrel/bin/umbreld"
Downloading umbreld from "https://github.com/getumbrel/umbrel/releases/download/v0.5.4/umbreld-v0.5.4-amd64.tar.gz"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 34.9M  100 34.9M    0     0  12.7M      0  0:00:02  0:00:02 --:--:-- 18.2M
Running "umbreld --update"
Running migrations from "/mnt/umbrel/.umbrel-v0.5.4" on "/mnt/umbrel"
Updating "/mnt/umbrel/scripts/start"...
Updating "/mnt/umbrel/scripts/stop"...
Updating "/mnt/umbrel/docker-compose.yml"...
Updating "/mnt/umbrel/docker-compose.dev.yml"...
Updating "/mnt/umbrel/packages"...
Updating "/mnt/umbrel/info.json"...
Starting "umbreld"
Skipping status update when not on Umbrel OS

======================================
============= STARTING ===============
============== UMBREL ================
======================================

Setting environment variables...

Starting karen...

Starting status monitors...
Starting memory monitor...

Starting backup monitor...

Starting decoy backup trigger...

Starting umbreld...


Starting Docker services...

[+] Running 11/11
 ✔ dashboard 7 layers [⣿⣿⣿⣿⣿⣿⣿]      0B/0B      Pulled                                                                                                                                                                                 5.5s
   ✔ 4be315f6562f Already exists                                                                                                                                                                                                       0.0s
   ✔ 96866e173b1b Already exists                                                                                                                                                                                                       0.0s
   ✔ 314d33570bef Already exists                                                                                                                                                                                                       0.0s
   ✔ 2144fa0b6cd5 Already exists                                                                                                                                                                                                       0.0s
   ✔ 3c2fcd160641 Already exists                                                                                                                                                                                                       0.0s
   ✔ 4a6690d8bf16 Pull complete                                                                                                                                                                                                        2.7s
   ✔ 68d51f1a482c Pull complete                                                                                                                                                                                                        3.0s
 ✔ manager 2 layers [⣿⣿]      0B/0B      Pulled                                                                                                                                                                                        7.9s
   ✔ 0eec24a4b59b Pull complete                                                                                                                                                                                                        5.3s
   ✔ 4f4fb700ef54 Pull complete                                                                                                                                                                                                        5.3s
[+] Running 5/5
 ✔ Container dashboard  Started                                                                                                                                                                                                        2.8s
 ✔ Container auth       Running                                                                                                                                                                                                        0.0s
 ✔ Container manager    Started                                                                                                                                                                                                        2.7s
 ✔ Container tor_proxy  Running                                                                                                                                                                                                        0.0s
 ✔ Container nginx      Started                                                                                                                                                                                                        1.5s

Removing status server iptables entry...
Exiting iptables setup when not on Umbrel OS

Starting installed apps...

Starting app electrs...
Starting app lightning...
Starting app bitcoin...
Executing hook: /mnt/umbrel/app-data/electrs/hooks/pre-start
Executing hook: /mnt/umbrel/app-data/bitcoin/hooks/pre-start
Executing hook: /mnt/umbrel/app-data/lightning/hooks/pre-start
WARN[0000] network default: network.external.name is deprecated. Please set network.name with external: true
[+] Running 5/0
 ✔ Container bitcoin-i2pd_daemon-1  Running                                                                                                                                                                                            0.0s
 ✔ Container bitcoin-tor-1          Running                                                                                                                                                                                            0.0s
 ✔ Container bitcoin-app_proxy-1    Running                                                                                                                                                                                            0.0s
 ✔ Container bitcoin-bitcoind-1     Running                                                                                                                                                                                            0.0s
 ✔ Container bitcoin-server-1       Running                                                                                                                                                                                            0.0s
WARN[0000] network default: network.external.name is deprecated. Please set network.name with external: true
[+] Running 4/0
 ✔ Container electrs-tor-1        Running                                                                                                                                                                                              0.0s
 ✔ Container electrs-app_proxy-1  Running                                                                                                                                                                                              0.0s
 ✔ Container electrs-electrs-1    Running                                                                                                                                                                                              0.0s
 ✔ Container electrs-app-1        Running                                                                                                                                                                                              0.0s
WARN[0000] network default: network.external.name is deprecated. Please set network.name with external: true
WARN[0000] The "APP_MEMPOOL_PORT" variable is not set. Defaulting to a blank string.
WARN[0000] The "APP_MEMPOOL_HIDDEN_SERVICE" variable is not set. Defaulting to a blank string.
[+] Running 4/0
 ✔ Container lightning-tor-1        Running                                                                                                                                                                                            0.0s
 ✔ Container lightning-app-1        Running                                                                                                                                                                                            0.0s
 ✔ Container lightning-app_proxy-1  Running                                                                                                                                                                                            0.0s
 ✔ Container lightning-lnd-1        Running                                                                                                                                                                                            0.0s

Umbrel is now accessible at
  http://umbrel.local
  http://192.168.122.82
Skipping status update when not on Umbrel OS
Deleting previous images
Untagged: getumbrel/dashboard:v0.5.8@sha256:9cfb822da25eee75ed0d74525b7864e0068b1f21edde5ad1c01c9347d24b34b1
Deleted: sha256:83f845165026bbdb6ab94c2b34a87027c226b456f6e62b4730185b6359675c39
Deleted: sha256:52024193b3c46bf0534a17903361e6ea418064a65148913d6afbc38351569456
Deleted: sha256:49701b777db3eaae62985291a26ed969bc651f0ed95b3fcedd0d61efab00e774
Untagged: getumbrel/manager:v0.5.3@sha256:69caf866f5eb471789726a4584c5dd74eabc34e4b31ca5c846ad26424a7eb534
Deleted: sha256:67ce5a09f1863a66ef39d7f51a40208c3619c7f6465d9d36913d51ef7841cbba
Deleted: sha256:d1e0bbf3771110e9320194c1543a68931a65af50a394dea4b014ec956189c0c6
Deleted: sha256:15fdab2c76a3353ba686016119a192599365e867b6334a4591a5a075af840f01
Error response from daemon: conflict: unable to remove repository reference "getumbrel/tor:0.4.7.8@sha256:2ace83f22501f58857fa9b403009f595137fa2e7986c4fda79d82a8119072b6a" (must force) - container 4a6ecad1cc1d is using its referenced image b3f3dff13ac2
Error response from daemon: conflict: unable to remove repository reference "nginx:1.17.8@sha256:380eb808e2a3b0dd954f92c1cae2f845e6558a15037efefcabc5b4e03d666d03" (must force) - container 052f987bb90a is using its referenced image a1523e859360
Error response from daemon: conflict: unable to remove repository reference "getumbrel/auth-server:v0.5.1@sha256:afcd9065eab02f98ee6bf705045170a4b385fb5f81e3b168bb92ffb8ac7a1760" (must force) - container af219285522a is using its referenced image 66551b5ccae7
Successfully installed Umbrel v0.5.4
== End Update Script bootstrap-run.sh ==

Deleting cloned repository
Removing lock
root@umbrel:/mnt/umbrel#
```
