### PR TITLE
Add mention of "update" command to scripts/app help

### DIFF
--- a/scripts/app
+++ b/scripts/app
@@ -155,33 +155,34 @@ if [[ "$command" = "ls-installed" ]]; then
   exit
 fi
 
+# All other commands need an app specified
 if [ -z ${2+x} ]; then
   show_help
   exit 1
-else
-  app="$2"
+fi
 
-  repo=$(cat "${USER_FILE}" 2> /dev/null | jq -r ".appOrigin.\"${app}\"" || true)
-  repo_path=$("${UMBREL_ROOT}/scripts/repo" "path" "${repo}")
-  app_repo_dir="${repo_path}/${app}"
-  app_data_dir="${UMBREL_ROOT}/app-data/${app}"
-  
-  app_hidden_service_file="${UMBREL_ROOT}/tor/data/app-${app}/hostname"
-  
-  if [[ "${app}" == "installed" ]]; then
-    for app in $(list_installed_apps); do
-      if [[ "${app}" != "" ]]; then
-        "${0}" "${1}" "${app}" "${@:3}" &
-      fi
-    done
-    wait
-    exit
-  fi
-  
-  if [[ -z "${app}" ]]; then
-    >&2 echo "Error: \"${app}\" is not a valid app"
-    exit 1
-  fi
+app="$2"
+
+repo=$(cat "${USER_FILE}" 2> /dev/null | jq -r ".appOrigin.\"${app}\"" || true)
+repo_path=$("${UMBREL_ROOT}/scripts/repo" "path" "${repo}")
+app_repo_dir="${repo_path}/${app}"
+app_data_dir="${UMBREL_ROOT}/app-data/${app}"
+
+app_hidden_service_file="${UMBREL_ROOT}/tor/data/app-${app}/hostname"
+
+if [[ "${app}" == "installed" ]]; then
+  for app in $(list_installed_apps); do
+    if [[ "${app}" != "" ]]; then
+      "${0}" "${1}" "${app}" "${@:3}" &
+    fi
+  done
+  wait
+  exit
+fi
+
+if [[ -z "${app}" ]]; then
+  >&2 echo "Error: \"${app}\" is not a valid app"
+  exit 1
 fi
 
 if [ -z ${3+x} ]; then

--- a/scripts/app
+++ b/scripts/app
@@ -25,6 +25,7 @@ Commands:
     start                      Starts an installed app
     stop                       Stops an installed app
     restart                    Restarts an installed app
+    update                     Updates an installed app to the latest version
     compose                    Passes all arguments to docker-compose
     ls-installed               Lists installed apps
 EOF


### PR DESCRIPTION
The `scripts/app` shell script has an `update` command, but that wasn't mentioned in the help.  Commit ab4ebf5703146487e962705adc0893163f3dbdf1 adds that command to the help message.

Also while reading through the script I noticed that the bit which checks that an app has been specified on the commmand line (for all commands except `ls-installed`) uses an `if`/`else`, but because the `if` clause ends in an `exit` there's no need for the `else` clause.  Commit ddbce830ceb9543023d2dcf6d0db0c1ed043f1c3 tidies that up.