### PR TITLE
Using docker compose instead of docker-compose

### DIFF
--- a/containers/app-auth/test/test.sh
+++ b/containers/app-auth/test/test.sh
@@ -2,4 +2,4 @@
 
 export MANAGER_IP="10.21.21.4"
 
-docker-compose up
+docker compose up

--- a/containers/app-proxy/test/test.sh
+++ b/containers/app-proxy/test/test.sh
@@ -34,4 +34,4 @@ echo "Proxy booting on port: ${APP_PORT}"
 # Generate random project id
 PROJECT=$(echo -n "${COMPOSE_FILE}" | sha256sum)
 
-docker-compose --env-file "${UMBREL_ENV_FILE}" --project-name "${PROJECT}" -f ./docker-compose.yml -f "${COMPOSE_FILE}" up
+docker compose --env-file "${UMBREL_ENV_FILE}" --project-name "${PROJECT}" -f ./docker-compose.yml -f "${COMPOSE_FILE}" up

--- a/containers/tor/test/test-entrypoint.sh
+++ b/containers/tor/test/test-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-docker-compose -f docker-compose.entrypoint.yml up --detach web
-docker-compose -f docker-compose.entrypoint.yml up --detach tor
+docker compose -f docker-compose.entrypoint.yml up --detach web
+docker compose -f docker-compose.entrypoint.yml up --detach tor
 
 echo
 echo "Hostname:"

--- a/containers/tor/test/test.sh
+++ b/containers/tor/test/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-docker-compose up --detach web
-docker-compose up --detach tor
+docker compose up --detach web
+docker compose up --detach tor
 
 echo
 echo "Hostname:"

--- a/scripts/app
+++ b/scripts/app
@@ -245,7 +245,7 @@ compose() {
   # Merge compose files and args. passed into 'compose'
   compose_args=("${compose_files[@]}" "${@}")
 
-  docker-compose \
+  docker compose \
     --env-file "${umbrel_env_file}" \
     --project-name "${app}" \
     "${compose_args[@]}"

--- a/scripts/debug
+++ b/scripts/debug
@@ -128,13 +128,13 @@ echo
 echo "Umbrel logs"
 echo "-----------"
 echo
-docker-compose logs --tail=30 manager
+docker compose logs --tail=30 manager
 
 echo
 echo "Tor Proxy logs"
 echo "--------"
 echo
-docker-compose logs --tail=10 tor_proxy
+docker compose logs --tail=10 tor_proxy
 
 installed_apps=$(./scripts/app ls-installed)
 if [[ ! -z "${installed_apps:-}" ]]; then

--- a/scripts/start
+++ b/scripts/start
@@ -147,7 +147,7 @@ fi
 echo
 echo "Starting Docker services..."
 echo
-docker-compose "${compose_files[@]}" up --detach --build --remove-orphans || {
+docker compose "${compose_files[@]}" up --detach --build --remove-orphans || {
   echo "Failed to start containers"
   $set_status umbrel errored docker-failed
   exit 1

--- a/scripts/stop
+++ b/scripts/stop
@@ -63,4 +63,4 @@ fi
 
 echo "Stopping Docker services..."
 echo
-docker-compose "${compose_files[@]}" down
+docker compose "${compose_files[@]}" down


### PR DESCRIPTION
`docker-compose` is the V1 syntax, [which is now deprecated](https://docs.docker.com/compose/). The V2 syntax is `docker compose`, since it's now a plugin and not a separate command.

This pull request should fix #1785 