### PR TITLE
Add dosfstools dependency

### DIFF
--- a/packages/os/umbrelos.Dockerfile
+++ b/packages/os/umbrelos.Dockerfile
@@ -90,7 +90,7 @@ RUN systemctl enable acpid
 RUN apt-get install --yes isc-dhcp-client network-manager ntp openssh-server
 
 # Install essential system utilities
-RUN apt-get install --yes sudo nano vim less man iproute2 iputils-ping curl wget ca-certificates dmidecode usbutils
+RUN apt-get install --yes sudo nano vim less man iproute2 iputils-ping curl wget ca-certificates dmidecode usbutils dosfstools
 
 # Add Umbrel user
 RUN adduser --gecos "" --disabled-password umbrel


### PR DESCRIPTION
I had trouble updating my Umbrel 1.0.4 to 1.1 on my Raspberry Pi 4. Installing `dosfstools` fixed this issue for me, so I added it into the Dockerfile