### PR TITLE
Fix HTTPS issue by using APP_PROTOCOL in axios baseURL

### DIFF
--- a/containers/app-proxy/utils/manager.js
+++ b/containers/app-proxy/utils/manager.js
@@ -4,7 +4,7 @@ const package = require('../package.json');
 const CONSTANTS = require('./const.js');
 
 const axiosInstance = axios.create({
-	baseURL: `http://${CONSTANTS.MANAGER_IP}:${CONSTANTS.MANAGER_PORT}`,
+	baseURL: `${CONSTANTS.APP_PROTOCOL}://${CONSTANTS.MANAGER_IP}:${CONSTANTS.MANAGER_PORT}`,
 	headers: {
 		common: {
 			"User-Agent": `${package.name}/${package.version}`


### PR DESCRIPTION
This change fixes a compatibility issue with HTTPS when using the Cloudflare Tunnel to expose the Umbrel instance. The issue occurred because axios was configured with a fixed HTTP protocol. By modifying the configuration to use the protocol defined in the APP_PROTOCOL constant, all requests are now correctly made with HTTP or HTTPS as configured, preventing the browser from blocking requests when HTTPS is in use.