### PR TITLE
Adding an `Open in DevZero` Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Just like the cloud, but one that you own and control.
 - [Instructions to install umbrelOS on a Raspberry Pi 4 and Pi 5](https://umbrel.com/umbrelos#install)
 - [Instructions to install umbrelOS on any x86 system](https://github.com/getumbrel/umbrel/wiki/Install-umbrelOS-on-x86-systems)
 
+[![Open in DevZero](https://assets.devzero.io/open-in-devzero.svg)](https://www.devzero.io/dashboard/recipes/new?repo-url=https://github.com/getumbrel/umbrel)
+
 ## Umbrel App Store
 
 <br />


### PR DESCRIPTION
DevZero is a dev environment platform. Using this link, all contributors to this project will be able to use a DevZero environment as the dev workspace. DevZero supports a free plan that individual contributors to OSS projects can utilize to make the contributions and/or to just test out the project.