### PR TITLE
docs: Add Docker install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Just like the cloud, but one that you own and control.
 - [Install umbrelOS on a Raspberry Pi 5](https://github.com/getumbrel/umbrel/wiki/Install-umbrelOS-on-a-Raspberry-Pi-5)
 - [Install umbrelOS on any x86 system](https://github.com/getumbrel/umbrel/wiki/Install-umbrelOS-on-x86-Systems)
 - [Install umbrelOS in a VM](https://github.com/getumbrel/umbrel/wiki/Install-umbrelOS-on-a-Linux-VM)
-
+- [Install umbrelOS in a Docker container](https://github.com/dockur/umbrel)
 
 ## Umbrel App Store
 


### PR DESCRIPTION
Additional installation method for running umbrelOS inside a Docker container instead of on a dedicated device.