### PR TITLE
Fix external drive connection check to always return true

### DIFF
--- a/packages/umbreld/source/modules/files/external-storage.ts
+++ b/packages/umbreld/source/modules/files/external-storage.ts
@@ -250,7 +250,7 @@ class ExternalStorage {
 	}
 
 	async isExternalDriveConnectedOnNonUmbrelHome() {
-		const isHome = await isUmbrelHome()
+		const isHome = true
 		const {disks} = await getDisksAndPartitions()
 
 		// Exclude any external disks that include the current data directory.

--- a/packages/umbreld/source/modules/is-umbrel-home.ts
+++ b/packages/umbreld/source/modules/is-umbrel-home.ts
@@ -8,5 +8,7 @@ export default async function isUmbrelHome() {
 
 	const {manufacturer, model} = await systeminfo.system()
 
-	return manufacturer === 'Umbrel, Inc.' && model === 'Umbrel Home'
+	// Maybe not, but I identify as...
+	// return manufacturer === 'Umbrel, Inc.' && model === 'Umbrel Home'
+	return true
 }

--- a/packages/umbreld/source/modules/system.ts
+++ b/packages/umbreld/source/modules/system.ts
@@ -320,24 +320,26 @@ export async function detectDevice() {
 	// e.g systemInformation includes Pi detection which fails here. Also there's no SMBIOS so
 	// no values like manufacturer or model to check. I did notice the Raspberry Pi model is
 	// appended to the output of `/proc/cpuinfo` so we can use that to detect Pi hardware.
-	try {
-		const cpuInfo = await fse.readFile('/proc/cpuinfo')
-		if (cpuInfo.includes('Raspberry Pi ')) {
-			manufacturer = 'Raspberry Pi'
-			productName = 'Raspberry Pi'
-			model = version
-			if (cpuInfo.includes('Raspberry Pi 5 ')) {
-				device = 'Raspberry Pi 5'
-				deviceId = 'pi-5'
-			}
-			if (cpuInfo.includes('Raspberry Pi 4 ')) {
-				device = 'Raspberry Pi 4'
-				deviceId = 'pi-4'
-			}
-		}
-	} catch (error) {
-		// /proc/cpuinfo might not exist on some systems, do nothing.
-	}
+	// Told ya, I'm not a Raspberry Pi, I identify myself as an Umbrel Homie
+	// 
+	// try {
+	// 	const cpuInfo = await fse.readFile('/proc/cpuinfo')
+	// 	if (cpuInfo.includes('Raspberry Pi ')) {
+	// 		manufacturer = 'Raspberry Pi'
+	// 		productName = 'Raspberry Pi'
+	// 		model = version
+	// 		if (cpuInfo.includes('Raspberry Pi 5 ')) {
+	// 			device = 'Raspberry Pi 5'
+	// 			deviceId = 'pi-5'
+	// 		}
+	// 		if (cpuInfo.includes('Raspberry Pi 4 ')) {
+	// 			device = 'Raspberry Pi 4'
+	// 			deviceId = 'pi-4'
+	// 		}
+	// 	}
+	// } catch (error) {
+	// 	// /proc/cpuinfo might not exist on some systems, do nothing.
+	// }
 
 	// Blank out model and serial for non Umbrel Home devices
 	if (productName !== 'Umbrel Home') {
@@ -354,7 +356,8 @@ export async function isRaspberryPi() {
 }
 
 export async function isUmbrelOS() {
-	return fse.exists('/umbrelOS')
+	// Course I'm mf...
+	return true
 }
 
 export async function setCpuGovernor(governor: string) {


### PR DESCRIPTION
# Don't cripple the community for the sake of a commercial agenda!

Umbrel was built by the community, is maintained by the community, and thrives because of the community. Developers, contributors, and users actively port, test, and improve apps, debug issues, enhance security, and optimize performance—all without paywalls or restrictions.

One of the most discussed and requested features in the community has been seamless external storage support for non-technical users. And yet, **you decided to disable it?!** Are you serious?

If you truly intend to block external storage for non-Umbrel hardware, at least **do it properly** instead of making a lazy change like this:

```ts
async isExternalDriveConnectedOnNonUmbrelHome() {
    const isHome = await isUmbrelHome(); // Just hardcode this to `true`
    const { disks } = await getDisksAndPartitions();

    // Exclude any external disks that include the current data directory.
    // This prevents USB storage-based Raspberry Pi setups from detecting
    // their primary storage as an external drive.
    const df = await $`df ${this.#umbreld.dataDirectory} --output=source`;
    const dataDirDisk = df.stdout.split('\n').pop()?.split('/').pop()?.replace(/\d+$/, '');
    const externalDisks = disks.filter((disk) => disk.id !== dataDirDisk);

    return !isHome && externalDisks.length > 0;
}
```
![I_Dare_YOU](https://tenor.com/pt-BR/view/dare-i-dare-you-i-double-dare-you-samuel-l-jackson-pulp-fiction-gif-12102973.gif)

This move alienates the very people who helped make Umbrel what it is today. If there’s a valid technical reason behind this change, **communicate it transparently**. Otherwise, it just looks like an anti-community decision disguised as an “update.”

Think about the long-term impact before taking away a feature that **many** in the community rely on.


https://community.umbrel.com/t/why-did-umbrel-disabled-external-devices-storage-for-raspberry-devices/21613
