### PR TITLE
Improved polling rate while updating Umbrel

### DIFF
--- a/packages/ui/src/providers/global-system-state/update.tsx
+++ b/packages/ui/src/providers/global-system-state/update.tsx
@@ -18,7 +18,7 @@ export function useUpdate({onMutate, onSuccess}: {onMutate?: () => void; onSucce
 export function UpdatingCover({onRetry}: {onRetry: () => void}) {
 	const latestVersionQ = trpcReact.system.checkUpdate.useQuery()
 	const updateStatusQ = trpcReact.system.updateStatus.useQuery(undefined, {
-		refetchInterval: 500,
+		refetchInterval: 2500,
 	})
 	const latestVersion = latestVersionQ.data
 


### PR DESCRIPTION
Changed the polling rate from 500ms to 2500ms (2.5s) to reduce strain on both the server and client during updates, especially when the update process takes longer. A 500ms polling rate is a bit too frequent for an update indicator, and increasing it to 2500ms strikes a better balance between performance and providing timely feedback.