### PR TITLE
feat(os): install kernel 6.12 from bookworm-backports for Alder Lake-…

### DIFF
--- a/packages/os/build-steps/initialize.sh
+++ b/packages/os/build-steps/initialize.sh
@@ -11,6 +11,8 @@ deb http://deb.debian.org/debian-security bookworm-security main non-free-firmwa
 deb-src http://deb.debian.org/debian-security bookworm-security main non-free-firmware
 deb http://deb.debian.org/debian bookworm-updates main non-free-firmware
 deb-src http://deb.debian.org/debian bookworm-updates main non-free-firmware
+deb http://deb.debian.org/debian bookworm-backports main non-free-firmware
+deb-src http://deb.debian.org/debian bookworm-backports main non-free-firmware
 EOF
 
 apt-get update --yes

--- a/packages/os/umbrelos.Dockerfile
+++ b/packages/os/umbrelos.Dockerfile
@@ -54,11 +54,13 @@ COPY packages/os/build-steps /build-steps
 RUN /build-steps/initialize.sh
 
 # Install Linux kernel and non-free firmware.
-RUN apt-get install --yes \
+# Install kernel 6.12+ from backports for Intel Alder Lake-N GPU support.
+RUN apt-get install --yes -t bookworm-backports \
     linux-image-amd64 \
     intel-microcode \
     amd64-microcode \
-    firmware-linux \
+    firmware-linux-nonfree \
+    firmware-misc-nonfree \
     firmware-realtek \
     firmware-iwlwifi
 


### PR DESCRIPTION
## Summary

Installs Linux kernel 6.12 and updated firmware from Debian bookworm-backports to enable Intel Alder Lake-N GPU support.

Fixes #2058

## Problem

Kernel 6.1 (Bookworm stable) lacks support for Intel Alder Lake-N processors (N97, N150, N250), which includes Umbrel Home hardware. This prevents:
- i915 GPU driver initialization
- `/dev/dri/` device creation
- Hardware acceleration for Jellyfin, Frigate, Plex, etc.

## Solution

Install kernel 6.12 and firmware from bookworm-backports, which includes full Alder Lake-N support. This approach:
- Stays on Debian Bookworm (stable base)
- Aligns with Raspberry Pi OS (which uses kernel 6.12 on Bookworm)
- Minimal change for quick release

## Changes

- `packages/os/build-steps/initialize.sh` - Added bookworm-backports repository
- `packages/os/umbrelos.Dockerfile` - Install kernel 6.12 and firmware from backports

## Testing

- ✅ AMD64 base image builds successfully
- ✅ Kernel 6.12.43 installed from backports
- ✅ All firmware packages updated to April 2025 release
- ⚠️ Full platform testing (Pi 4, Pi 5, x86) recommended before merge