### PR TITLE
Fix Kopia writing cache/config to root overlay

### DIFF
--- a/packages/umbreld/source/modules/backups/backups.ts
+++ b/packages/umbreld/source/modules/backups/backups.ts
@@ -74,6 +74,11 @@ export default class Backups {
 		this.running = true
 		this.startedAt = Date.now()
 
+		// Ensure kopia directories exist on the SSD
+        await fse.mkdir(`${this.#umbreld.dataDirectory}/kopia/cache`, {recursive: true})
+        await fse.mkdir(`${this.#umbreld.dataDirectory}/kopia/config`, {recursive: true})
+        await fse.mkdir(`${this.#umbreld.dataDirectory}/kopia/logs`, {recursive: true})		
+
 		// Cleanup any left over backup mounts
 		await this.unmountAll().catch((error) => this.logger.error('Error unmounting backups', error))
 
@@ -183,9 +188,14 @@ export default class Backups {
 		const spawnKopiaProcess = async () => {
 			// Spawn process
 			const env = {
-				KOPIA_CHECK_FOR_UPDATES: 'false',
-				XDG_CACHE_HOME: '/kopia/cache',
-				XDG_CONFIG_HOME: '/kopia/config',
+				...process.env,
+                KOPIA_CHECK_FOR_UPDATES: 'false',
+                XDG_CACHE_HOME: '/kopia/cache',
+                XDG_CONFIG_HOME: '/kopia/config',
+                XDG_CACHE_HOME: `${this.#umbreld.dataDirectory}/kopia/cache`,
+                XDG_CONFIG_HOME: `${this.#umbreld.dataDirectory}/kopia/config`,
+                KOPIA_CACHE_DIRECTORY: `${this.#umbreld.dataDirectory}/kopia/cache`,
+                KOPIA_LOG_DIR: `${this.#umbreld.dataDirectory}/kopia/logs`,
 			}
 			const process = execa('kopia', flags, {env})
 


### PR DESCRIPTION
### Problem
Kopia writes cache, config and logs to the root filesystem by default.
On SD-card based Umbrel installs, this fills the root overlay (~4 GB) and
breaks built-in backups despite sufficient free space on /mnt/data.

### Solution
Redirect Kopia cache, config and log directories to Umbrel’s data directory.
All required directories are created defensively before starting Kopia.

### Impact
- Prevents root filesystem from filling up
- No breaking changes
- Works for SD, SSD and USB-based installs
