### PR TITLE
Expose Umbrel user name to app environments

### DIFF
--- a/packages/umbreld/source/modules/apps/apps.integration.test.ts
+++ b/packages/umbreld/source/modules/apps/apps.integration.test.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import {expect, beforeAll, afterAll, test, vi} from 'vitest'
 import fse from 'fs-extra'
 import yaml from 'js-yaml'
+import {$} from 'execa'
 
 import createTestUmbreld from '../test-utilities/create-test-umbreld.js'
 import {BACKUP_RESTORE_FIRST_START_FLAG} from '../../constants.js'
@@ -110,6 +111,12 @@ test.sequential('state() becomes ready once install completes', async () => {
 		await setTimeout(1000)
 	} while (true)
 	await expect(lastState).toMatchObject({state: 'ready'})
+})
+
+test.sequential('install() exposes the Umbrel user name to app compose files', async () => {
+	const {stdout} =
+		await $`docker inspect sparkles-hello-world_server_1 --format=${'{{range .Config.Env}}{{println .}}{{end}}'}`
+	expect(stdout.split('\n')).toContain('APP_UMBREL_USER_NAME=satoshi')
 })
 
 test.sequential('list() lists installed apps', async () => {

--- a/packages/umbreld/source/modules/apps/legacy-compat/app-script
+++ b/packages/umbreld/source/modules/apps/legacy-compat/app-script
@@ -163,6 +163,7 @@ source_app() {
   # Set other useful vars. used in exports
   export DEVICE_HOSTNAME="$(cat /proc/sys/kernel/hostname 2>/dev/null || echo "umbrel")"
   export DEVICE_DOMAIN_NAME="${DEVICE_HOSTNAME}.local"
+  export UMBREL_USER_NAME="${SCRIPT_USER_NAME:-}"
 
   # Set env using all transitive dependencies exports.sh
   # Do this first so that no app exports can

--- a/packages/umbreld/source/modules/apps/legacy-compat/app-script.ts
+++ b/packages/umbreld/source/modules/apps/legacy-compat/app-script.ts
@@ -19,6 +19,7 @@ export default async function appScript(umbreld: Umbreld, command: string, arg: 
 		SCRIPT_APP_REPO_DIR = await umbreld.appStore.getAppTemplateFilePath(arg)
 	} catch {}
 	const torEnabled = await umbreld.store.get('torEnabled')
+	const user = await umbreld.user.get()
 	return $({
 		stdio: inheritStdio ? 'inherit' : 'pipe',
 		env: {
@@ -32,6 +33,7 @@ export default async function appScript(umbreld: Umbreld, command: string, arg: 
 			TOR_PASSWORD: 'mLcLDdt5qqMxlq3wv8Din3UD44bTZHzRFhIktw38kWg=',
 			TOR_HASHED_PASSWORD: '16:158FBE422B1A9D996073BE2B9EC38852C70CE12362CA016F8F6859C426',
 			REMOTE_TOR_ACCESS: torEnabled ? 'true' : 'false',
+			SCRIPT_USER_NAME: user?.name ?? '',
 		},
 	})`${scriptPath} ${command} ${arg}`
 }

--- a/packages/umbreld/source/modules/test-utilities/fixtures/community-repo/sparkles-hello-world/docker-compose.yml
+++ b/packages/umbreld/source/modules/test-utilities/fixtures/community-repo/sparkles-hello-world/docker-compose.yml
@@ -10,3 +10,5 @@ services:
     image: getumbrel/community-app-store-hello-world:latest
     user: '1000:1000'
     init: true
+    environment:
+      APP_UMBREL_USER_NAME: ${UMBREL_USER_NAME}


### PR DESCRIPTION
## Summary
- expose the Umbrel account display name to legacy app scripts as `UMBREL_USER_NAME`
- pass `user.name` from umbreld into the app compatibility script without changing existing app env vars
- add fixture coverage for app compose opt-in via `UMBREL_USER_NAME`

Apps can opt in by referencing `${UMBREL_USER_NAME}` in their compose files or scripts. The value is not injected into app containers unless an app passes it through.

## Test plan
- `npm run format:check`
- `npm run typecheck`
- `npm run test -- apps.integration.test` *(local environment timed out during beforeAll because /var/run/dbus/system_bus_socket is unavailable; no test body ran)*