### PR TITLE
feat(pi): mount USB drives in Files without auto data-disk migration

### DIFF
--- a/packages/os/overlay-pi/opt/umbrel-external-storage/umbrel-external-storage
+++ b/packages/os/overlay-pi/opt/umbrel-external-storage/umbrel-external-storage
@@ -2,15 +2,17 @@
 
 set -euo pipefail
 
-# This script will:
-# - Look for external storage devices
-# - Check if they contain an Umbrel install
-# - If yes
-# - - Mount it
-# - If no
-# - - Format it
-# - - Mount it
-# - - Install Umbrel on it
+# This script ONLY runs when the user has opted in via umbrel-allow-external-format on
+# the SD card boot partition. It migrates Umbrel's data directory to a USB drive.
+#
+# Normal USB drives (media, backups, etc.) are mounted by umbreld under Files → External
+# and must not be handled here.
+#
+# When opted in, this script will:
+# - Look for a single external storage device
+# - Check if it contains an Umbrel install
+# - If yes, mount it
+# - If no, format it (only with opt-in), mount it, and install Umbrel on it
 # - Bind mount the external installation on top of the local installation
 
 UMBREL_ROOT="/home/umbrel/umbrel"
@@ -238,6 +240,14 @@ main () {
     echo "This script should only run when umbrelOS boots from an SD card, exiting..."
     exit
   fi
+
+  if ! is_external_format_explicitly_allowed; then
+    echo "No opt-in for Umbrel external data disk (umbrel-allow-external-format); skipping."
+    echo "USB drives are mounted by umbreld under Files → External."
+    exit 0
+  fi
+
+  echo "Opt-in detected: setting up external drive as Umbrel data disk..."
 
   no_of_block_devices=$(list_block_devices | wc -l)
 

--- a/packages/os/overlay-pi/opt/umbrel-external-storage/umbrel-external-storage
+++ b/packages/os/overlay-pi/opt/umbrel-external-storage/umbrel-external-storage
@@ -108,6 +108,71 @@ is_partition_ext4 () {
   blkid -o value -s TYPE "${partition_path}" | grep --quiet '^ext4$'
 }
 
+get_partition_fstype () {
+  partition_path="${1}"
+  sync
+  blkid -o value -s TYPE "${partition_path}" 2>/dev/null || true
+}
+
+# Explicit opt-in is required before we wipe a user's USB drive.
+# See https://github.com/getumbrel/umbrel/issues/1956
+UMBREL_ALLOW_FORMAT_PATHS=(
+  "/boot/firmware/umbrel-allow-external-format"
+  "/boot/umbrel-allow-external-format"
+)
+
+is_external_format_explicitly_allowed () {
+  if [[ "${UMBREL_ALLOW_EXTERNAL_FORMAT:-}" == "1" ]]; then
+    return 0
+  fi
+  for path in "${UMBREL_ALLOW_FORMAT_PATHS[@]}"; do
+    if [[ -f "${path}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+device_has_filesystem_signatures () {
+  device_path="${1}"
+  signatures=$(wipefs --noheadings "${device_path}" 2>/dev/null || true)
+  [[ -n "${signatures}" ]]
+}
+
+refuse_automatic_format () {
+  reason="${1}"
+  echo "ERROR: Refusing to automatically format external storage: ${reason}"
+  echo "Umbrel will continue running from the SD card."
+  echo "To intentionally use this drive as Umbrel data storage (this erases all data), create:"
+  echo "  /boot/firmware/umbrel-allow-external-format"
+  echo "on the SD card boot partition, then reboot."
+  exit 1
+}
+
+assert_safe_to_format () {
+  block_device="${1}"
+  partition_path="${2}"
+  device_path="/dev/${block_device}"
+
+  if is_external_format_explicitly_allowed; then
+    echo "Explicit consent to format external storage detected, continuing..."
+    return 0
+  fi
+
+  if device_has_filesystem_signatures "${device_path}"; then
+    refuse_automatic_format "existing filesystem signatures detected on ${device_path}"
+  fi
+
+  fstype=$(get_partition_fstype "${partition_path}")
+  if [[ -n "${fstype}" && "${fstype}" != "ext4" ]]; then
+    refuse_automatic_format "partition ${partition_path} uses filesystem type '${fstype}'"
+  fi
+
+  if [[ "${fstype}" == "ext4" ]]; then
+    refuse_automatic_format "ext4 partition exists but is not a recognised Umbrel data drive"
+  fi
+}
+
 # Wipes a block device and reformats it with a single EXT4 partition
 format_block_device () {
   device="${1}"
@@ -139,6 +204,8 @@ setup_new_device () {
   block_device="${1}"
   partition_path="${2}"
 
+  assert_safe_to_format "${block_device}" "${partition_path}"
+
   echo "Formatting device..."
   format_block_device $block_device
 
@@ -164,7 +231,7 @@ copy_docker_to_external_storage () {
 main () {
   echo "Running external storage mount script..."
   check_root
-  check_dependencies sed wipefs parted mount sync umount
+  check_dependencies sed wipefs parted mount sync umount blkid
 
   if [[ "$(running_off_sdcard)" == "false" ]]
   then

--- a/packages/os/umbrelos.Dockerfile
+++ b/packages/os/umbrelos.Dockerfile
@@ -150,10 +150,7 @@ RUN apt-get install --yes python3 fswatch jq rsync git gettext-base gnupg procps
 RUN systemctl disable smbd wsdd2
 
 # Filessystem support
-RUN apt-get install --yes gdisk parted e2fsprogs exfatprogs
-# For some reason this always fails on arm64 but it's ok since we
-# don't support external storage on Pi anyway.
-RUN [ "${TARGETARCH}" = "amd64" ] && apt-get install --yes ntfs-3g || true
+RUN apt-get install --yes gdisk parted e2fsprogs exfatprogs ntfs-3g
 
 # Install Node.js
 RUN NODE_ARCH=$([ "${TARGETARCH}" = "arm64" ] && echo "arm64" || echo "x64") && \

--- a/packages/ui/src/features/files/hooks/use-external-storage.ts
+++ b/packages/ui/src/features/files/hooks/use-external-storage.ts
@@ -21,10 +21,8 @@ export function useExternalStorage() {
 	const utils = trpcReact.useUtils()
 	const {add} = useQueryParams()
 
-	// Check device information to determine if external storage is supported (currently not supported on Raspberry Pi)
-	const {data: deviceInfo} = trpcReact.systemNg.device.getIdentity.useQuery()
-
-	const isExternalStorageSupported = deviceInfo?.productName !== 'Raspberry Pi'
+	const {data: isExternalStorageSupported = false} =
+		trpcReact.files.isExternalStorageSupported.useQuery()
 
 	// Subscribe to files:external-storage:change events that fire when devices are mounted/unmounted
 	// and invalidate the external storage queries

--- a/packages/umbreld/source/modules/files/external-storage.integration.test.ts
+++ b/packages/umbreld/source/modules/files/external-storage.integration.test.ts
@@ -82,9 +82,9 @@ describe('enabled', () => {
 		await expect(umbreld.instance.files.externalStorage.supported()).resolves.toBe(true)
 	})
 
-	test('is disabled on Raspberry Pi', async () => {
+	test('is enabled on Raspberry Pi', async () => {
 		isRaspberryPiMockValue = true
-		await expect(umbreld.instance.files.externalStorage.supported()).resolves.toBe(false)
+		await expect(umbreld.instance.files.externalStorage.supported()).resolves.toBe(true)
 	})
 })
 

--- a/packages/umbreld/source/modules/files/external-storage.ts
+++ b/packages/umbreld/source/modules/files/external-storage.ts
@@ -100,12 +100,10 @@ export default class ExternalStorage {
 		this.logger = umbreld.logger.createChildLogger(`files:${name.toLocaleLowerCase()}`)
 	}
 
-	// Only enable this module on non raspberry pi devices.
-	// We disable on Pi due to unreliable power issues when running USB storage devices
-	// and also due to complexities with the current mount script.
+	// External storage is supported on all devices, including Raspberry Pi.
+	// Use a powered USB hub for hard drives; the UI warns about power limits on Pi.
 	async supported() {
-		const isNotRaspberryPi = !(await isRaspberryPi())
-		return isNotRaspberryPi
+		return true
 	}
 
 	// Add listener
@@ -115,6 +113,12 @@ export default class ExternalStorage {
 		if (!isEnabled) return
 
 		this.logger.log('Starting external storage')
+
+		if (await isRaspberryPi()) {
+			this.logger.log('Running UAS driver blacklist check for Raspberry Pi USB stability')
+			const blacklistUas = (await import('../blacklist-uas/blacklist-uas.js')).default
+			await blacklistUas().catch((error) => this.logger.error('UAS blacklist check failed', error))
+		}
 
 		// Safely clean up any left over mount points
 		await this.#cleanLeftOverMountPoints()
@@ -362,7 +366,23 @@ export default class ExternalStorage {
 		const systemDiskIds = await this.#getSystemDiskIds(blockDevices)
 
 		// Filter out any non-USB devices and disks that back the running system.
-		return blockDevices.filter((device) => device.transport === 'usb' && !systemDiskIds.has(device.id))
+		return blockDevices.filter(
+			(device) =>
+				device.transport === 'usb' &&
+				!systemDiskIds.has(device.id) &&
+				!this.#isUmbrelExternalDataDisk(device),
+		)
+	}
+
+	// The Pi data-disk migration script mounts the Umbrel data volume at /mnt/data.
+	#isUmbrelExternalDataDisk(device: BlockDevice) {
+		const umbrelDataMount = '/mnt/data'
+		return device.partitions.some((partition) =>
+			partition.mountpoints.some(
+				(mountpoint) =>
+					mountpoint === umbrelDataMount || mountpoint.startsWith(`${umbrelDataMount}/`),
+			),
+		)
 	}
 
 	// Get disks used by the running system so they are never treated as external storage.

--- a/packages/umbreld/source/modules/files/routes.ts
+++ b/packages/umbreld/source/modules/files/routes.ts
@@ -195,6 +195,10 @@ export default router({
 		ctx.umbreld.files.externalStorage.getExternalDevicesWithVirtualMountPoints(),
 	),
 
+	isExternalStorageSupported: publicProcedureWhenNoUserExists.query(async ({ctx}) =>
+		ctx.umbreld.files.externalStorage.supported(),
+	),
+
 	// Unmount an external device
 	unmountExternalDevice: privateProcedure
 		.input(z.object({deviceId: z.string()}))


### PR DESCRIPTION
## Summary

Raspberry Pi currently uses a boot-time script (`umbrel-external-storage`) that treats any single USB disk as a **Umbrel data disk** (wipe + `mkfs.ext4 -L umbrel`). The Files app external storage feature is disabled on Pi in both backend and UI.

This PR separates the two flows:

- **Default (no opt-in):** USB drives are left alone at boot and mounted by `umbreld` under **Files → External**, like on Umbrel Home / x86.
- **Opt-in only:** The legacy data-disk migration script runs only if `umbrel-allow-external-format` exists on the SD card boot partition (same flag as the format-safety PR).

Fixes the common case where users plug in a drive with existing data (NTFS/exFAT/ext4) expecting removable storage, not a wiped Umbrel data volume.

**Depends on:** #2148 (fix/pi-refuse-auto-format-external-usb)


## Problem

On Pi, connecting a USB drive could trigger:

1. `wipefs` + GPT + `mkfs.ext4 -L umbrel` (if not ext4 / no `.umbrel`)
2. UI message: “External storage not supported”
3. No way to use the drive in Files without erasing it

## Changes

### Boot script (`umbrel-external-storage`)
- Exit immediately (success) when `umbrel-allow-external-format` is **not** present
- Log that USB is handled by umbreld under Files → External
- Data-disk migration (format + bind mount `/home/umbrel`) only runs with explicit opt-in

### `umbreld` external storage
- Enable external storage module on **Raspberry Pi** (`supported()` → `true`)
- Run UAS blacklist check on Pi start (moved from boot script path when data-disk script is skipped)
- Exclude disks already mounted at `/mnt/data` (Umbrel data volume) from `/External`
- New API: `files.isExternalStorageSupported`

### UI
- Use `files.isExternalStorageSupported` instead of hardcoded `productName !== 'Raspberry Pi'`
- External storage sidebar / eject works on Pi when OS is updated

### OS image
- Install `ntfs-3g` on **arm64** (was amd64-only)