### PR TITLE
fix: add /usr/sbin to PATH for sfdisk in update-script

### DIFF
--- a/packages/umbreld/source/modules/apps/legacy-compat/app-script
+++ b/packages/umbreld/source/modules/apps/legacy-compat/app-script
@@ -349,6 +349,11 @@ compose() {
   compose_files+=( "--file" "${common_compose_file}" )
   compose_files+=( "--file" "${app_compose_file}" )
 
+  # Add override compose file if it exists
+  if [[ -f "${app_data_dir}/docker-compose.override.yml" ]]; then
+    compose_files+=(--file "${app_data_dir}/docker-compose.override.yml")
+  fi
+
   # Merge compose files and args. passed into 'compose'
   compose_args=("${compose_files[@]}" "${@}")
 

--- a/scripts/update-script
+++ b/scripts/update-script
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+export PATH="/usr/local/sbin:/usr/sbin:/sbin:$PATH"
 
 # This script is used to bootstrap the mender update process
 # The update server references it in the form:


### PR DESCRIPTION
Fixes OS update hanging at 93% because sfdisk is not in PATH.

sfdisk lives in /usr/sbin which is not in the default PATH for non-login shells during the mender update process. This adds the standard sbin directories to PATH at the top of update-script.