### PR TITLE
fix: add /usr/sbin and /sbin to PATH in update-script

### DIFF
--- a/scripts/update-script
+++ b/scripts/update-script
@@ -5,6 +5,10 @@ set -euo pipefail
 # The update server references it in the form:
 # https://raw.githubusercontent.com/getumbrel/umbrel/<tag>/scripts/update-script
 
+# Fix PATH so that commands like sfdisk (used by rugix-ctrl) can be found
+# sfdisk lives in /usr/sbin and /sbin which are not always in the inherited PATH
+export PATH="/usr/local/sbin:/usr/sbin:/sbin:$PATH"
+
 update_url=""
 download_prefix="https://download.umbrel.com/release/1.7.3"
 


### PR DESCRIPTION
## Summary

The `update-script` does not include `/usr/sbin` or `/sbin` in its PATH, causing `rugix-ctrl` to fail with `No such file or directory` when it runs `sfdisk` (located at `/usr/sbin/sfdisk`) during OS updates. This was reported in issue #2153.

As described in that issue:
- The update hangs at 93% with the bundle fully written to the inactive slot
- The boot-slot switch never happens because rugix-ctrl cannot execute sfdisk
- `system.updateStatus` reports `running: true` indefinitely

## Fix

Added the standard sbin directories to PATH at the top of `scripts/update-script`:

```bash
export PATH="/usr/local/sbin:/usr/sbin:/sbin:$PATH"
```

This follows the suggested approach from the issue — it scopes the PATH fix to the update flow only, making it a safe and targeted change.

## Testing

The issue author verified that running `rugix-ctrl system info` with the same truncated PATH reproduces the error. With the PATH corrected, sfdisk is found and rugix-ctrl can read the partition table.

Fixes #2153
