### PR TITLE
fix: guard raid setup and fix file share over-removal

### DIFF
--- a/packages/umbreld/source/modules/files/files.ts
+++ b/packages/umbreld/source/modules/files/files.ts
@@ -692,7 +692,8 @@ export default class Files {
 		if (virtualPath.startsWith('/External/')) {
 			const shares = (await this.#umbreld.store.get('files.shares')) || []
 			for (const share of shares) {
-				if (share.path.startsWith(virtualPath)) await this.samba.removeShare(share.path)
+				if (share.path === virtualPath || share.path.startsWith(`${virtualPath}/`))
+					await this.samba.removeShare(share.path)
 			}
 		}
 

--- a/packages/umbreld/source/modules/files/files.ts
+++ b/packages/umbreld/source/modules/files/files.ts
@@ -680,6 +680,8 @@ export default class Files {
 
 	// Permanently delete a file or directory
 	async delete(virtualPath: string) {
+		virtualPath = normalizePath(virtualPath)
+
 		// Check if operation is allowed
 		const allowedOperations = await this.getAllowedOperations(virtualPath)
 		if (!allowedOperations.includes('delete')) throw new Error('[operation-not-allowed]')

--- a/packages/umbreld/source/modules/hardware/raid.ts
+++ b/packages/umbreld/source/modules/hardware/raid.ts
@@ -923,6 +923,10 @@ export default class Raid {
 		if (deviceIds.length === 0) throw new Error('At least one device is required')
 		if (raidType === 'failsafe' && deviceIds.length < 2) throw new Error('Failsafe mode requires at least two devices')
 
+		// Don't wipe an existing array. setup() partitions the devices and creates a
+		// fresh pool, so running it again would destroy the live array.
+		if ((await this.getStatus()).exists) throw new Error('A RAID array already exists')
+
 		const devices = deviceIds.map((id) => `/dev/disk/by-umbrel-id/${id}`)
 		for (const device of devices) {
 			if (!(await fse.pathExists(device))) throw new Error(`Device not found: ${device}`)


### PR DESCRIPTION
Two small safety fixes from going over the storage code, both independent.

**raid setup guard**
`setup()` partitions the devices and creates a fresh pool. The `setup` tRPC route is still live (marked dev/testing) and doesn't check for an existing array, so calling it with the current devices would wipe the live pool. Added a check to throw if an array already exists. Safe on fresh devices (getStatus returns exists: false with no pool) and on the onboarding setup path which runs before any pool exists.

**file share over-removal**
When deleting a path under /External we remove its shares with `startsWith`, which also matched siblings. Deleting /External/Drive/Foo would remove the share for /External/Drive/Foobar too. Now matches the exact path or a real child (path + '/').

Typecheck passes.