### PR TITLE
fix: dont leave apps stuck in transient states when start/stop/restart fails

### DIFF
--- a/packages/umbreld/source/modules/apps/app.ts
+++ b/packages/umbreld/source/modules/apps/app.ts
@@ -213,18 +213,26 @@ export default class App {
 	async start() {
 		this.logger.log(`Starting app ${this.id}`)
 		this.state = 'starting'
-		// We re-run the patch here to fix an edge case where 0.5.x imported apps
-		// wont run because they haven't been patched.
-		await this.patchComposeFile()
-		await pRetry(() => appScript(this.#umbreld, 'start', this.id), {
-			onFailedAttempt: (error) => {
-				this.logger.error(
-					`Attempt ${error.attemptNumber} starting app ${this.id} failed. There are ${error.retriesLeft} retries left.`,
-					error,
-				)
-			},
-			retries: 2,
-		})
+		try {
+			// We re-run the patch here to fix an edge case where 0.5.x imported apps
+			// wont run because they haven't been patched.
+			await this.patchComposeFile()
+			await pRetry(() => appScript(this.#umbreld, 'start', this.id), {
+				onFailedAttempt: (error) => {
+					this.logger.error(
+						`Attempt ${error.attemptNumber} starting app ${this.id} failed. There are ${error.retriesLeft} retries left.`,
+						error,
+					)
+				},
+				retries: 2,
+			})
+		} catch (error) {
+			// Revert to 'unknown' so the app isn't stuck in 'starting' forever if it
+			// fails to start (e.g invalid user edits to the compose file). The UI
+			// shows 'unknown' as offline and lets the user attempt a restart.
+			this.state = 'unknown'
+			throw error
+		}
 		this.state = 'ready'
 
 		// Enable auto-start on boot
@@ -235,15 +243,21 @@ export default class App {
 
 	async stop({persistState = false}: {persistState?: boolean} = {}) {
 		this.state = 'stopping'
-		await pRetry(() => appScript(this.#umbreld, 'stop', this.id), {
-			onFailedAttempt: (error) => {
-				this.logger.error(
-					`Attempt ${error.attemptNumber} stopping app ${this.id} failed. There are ${error.retriesLeft} retries left.`,
-					error,
-				)
-			},
-			retries: 2,
-		})
+		try {
+			await pRetry(() => appScript(this.#umbreld, 'stop', this.id), {
+				onFailedAttempt: (error) => {
+					this.logger.error(
+						`Attempt ${error.attemptNumber} stopping app ${this.id} failed. There are ${error.retriesLeft} retries left.`,
+						error,
+					)
+				},
+				retries: 2,
+			})
+		} catch (error) {
+			// Revert to 'unknown' so the app isn't stuck in 'stopping' forever.
+			this.state = 'unknown'
+			throw error
+		}
 		this.state = 'stopped'
 
 		// Disable auto-start on boot
@@ -256,8 +270,15 @@ export default class App {
 
 	async restart() {
 		this.state = 'restarting'
-		await appScript(this.#umbreld, 'stop', this.id)
-		await appScript(this.#umbreld, 'start', this.id)
+		try {
+			await appScript(this.#umbreld, 'stop', this.id)
+			await appScript(this.#umbreld, 'start', this.id)
+		} catch (error) {
+			// Revert to 'unknown' so the app isn't stuck in 'restarting' forever if it
+			// fails to come back up (e.g invalid user edits to the compose file).
+			this.state = 'unknown'
+			throw error
+		}
 		this.state = 'ready'
 
 		// Enable auto-start on boot

--- a/packages/umbreld/source/modules/apps/apps.integration.test.ts
+++ b/packages/umbreld/source/modules/apps/apps.integration.test.ts
@@ -252,6 +252,40 @@ test.sequential('restart() restarts an installed app', async () => {
 	// TODO: Check this actually worked
 })
 
+test.sequential('start() leaves app in a recoverable state when the compose file is invalid', async () => {
+	// Stop the app so we can attempt to start it again
+	await expect(umbreld.client.apps.stop.mutate({appId: 'sparkles-hello-world'})).resolves.toStrictEqual(true)
+
+	// Break the app's compose file with invalid YAML
+	const composeFile = path.join(
+		umbreld.instance.dataDirectory,
+		'app-data',
+		'sparkles-hello-world',
+		'docker-compose.yml',
+	)
+	const originalCompose = await fse.readFile(composeFile, 'utf8')
+	try {
+		await fse.writeFile(composeFile, `${originalCompose}\n\tthis is not: [valid yaml`)
+
+		// Attempt to start the app and verify the error is surfaced
+		await expect(umbreld.client.apps.start.mutate({appId: 'sparkles-hello-world'})).rejects.toThrow()
+
+		// Verify the app is not stuck in 'starting'
+		await expect(umbreld.client.apps.state.query({appId: 'sparkles-hello-world'})).resolves.toMatchObject({
+			state: 'unknown',
+		})
+	} finally {
+		// Always restore the compose file so a failure here doesn't break later tests
+		await fse.writeFile(composeFile, originalCompose)
+	}
+
+	// Verify the app recovers once the compose file is fixed
+	await expect(umbreld.client.apps.restart.mutate({appId: 'sparkles-hello-world'})).resolves.toStrictEqual(true)
+	await expect(umbreld.client.apps.state.query({appId: 'sparkles-hello-world'})).resolves.toMatchObject({
+		state: 'ready',
+	})
+})
+
 test.sequential('update() updates an installed app', async () => {
 	await expect(umbreld.client.apps.update.mutate({appId: 'sparkles-hello-world'})).resolves.toStrictEqual(true)
 	// TODO: Check this actually worked


### PR DESCRIPTION
Fixes #2175

## Problem

If an app fails to start, most commonly after hand-editing its `docker-compose.yml` and making a typo, the app gets stuck on "Starting..." forever. `App.start()` rejects after retries but `state` never leaves `'starting'`, so the UI spins indefinitely and the only ways out are uninstalling the app or rebooting, exactly as reported in #2175.

`stop()` and `restart()` have the same latent issue with `'stopping'` and `'restarting'`. The TODO above `AppState` in `app.ts` calls out this exact gap.

## Fix

**Revert the state to `'unknown'` on failure and re-throw**, mirroring what the boot path already does (`Apps.start()` sets `state = 'unknown'` when an app fails to start there). The UI already renders `'unknown'` as "Not running" with click-to-restart, so a user who breaks their compose file sees the app go offline, fixes the file, and clicks to bring it back. No reboot, no reinstall, no UI changes.

I kept this deliberately small. A dedicated `'failed'` state with its own UI treatment might be the fuller solution, but that touches the state schema and every UI switch over it. Happy to take that on as a follow up if you'd prefer it.

## Testing

Added an integration test: break an installed app's compose file with invalid YAML, verify `apps.start` rejects and state settles at `'unknown'` instead of sticking at `'starting'`, then restore the file and verify the app recovers to `'ready'`. The compose restore is in a `finally` so a future regression fails as one test instead of cascading through the sequential suite.

Verified in umbrel-dev (aarch64): the full apps integration suite passes 35/35 with this change, and the new test fails against master's `app.ts`. Also drove it manually in the browser: on master the app sticks on "Starting..." until a reboot; with this change it falls back to "Not running", and after fixing the compose file one click brings it back up.

## Caveat

Tested in the umbrel-dev VM (Docker/macOS), not on real umbrelOS hardware.