### PR TITLE
feat(os): sync umbrel SSH keys to root on boot

### DIFF
--- a/packages/os/overlay/etc/ssh/sshd_config.d/99-umbrel-root-key-login.conf
+++ b/packages/os/overlay/etc/ssh/sshd_config.d/99-umbrel-root-key-login.conf
@@ -1,0 +1,3 @@
+# Managed by umbrel-ssh-root-keys — root login via SSH keys only (no password).
+PermitRootLogin prohibit-password
+PubkeyAuthentication yes

--- a/packages/os/overlay/etc/systemd/system/multi-user.target.wants/umbrel-ssh-root-keys.service
+++ b/packages/os/overlay/etc/systemd/system/multi-user.target.wants/umbrel-ssh-root-keys.service
@@ -1,0 +1,1 @@
+../umbrel-ssh-root-keys.service

--- a/packages/os/overlay/etc/systemd/system/umbrel-ssh-root-keys.service
+++ b/packages/os/overlay/etc/systemd/system/umbrel-ssh-root-keys.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Sync umbrel SSH authorized_keys to root
+Documentation=https://github.com/LuckyCoders/umbrel
+After=local-fs.target
+RequiresMountsFor=/home/umbrel
+Before=ssh.service sshd.service
+Wants=umbrel-ssh-host-key-hydration.service
+After=umbrel-ssh-host-key-hydration.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/umbrel-ssh-root-keys/umbrel-ssh-root-keys
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/os/overlay/opt/umbrel-ssh-root-keys/umbrel-ssh-root-keys
+++ b/packages/os/overlay/opt/umbrel-ssh-root-keys/umbrel-ssh-root-keys
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# After OTA updates the system overlay (including /root) is replaced, while
+# /home/umbrel lives on the data partition and keeps authorized_keys.
+# Sync umbrel's SSH public keys to root on every boot so root key login survives updates.
+
+UMBREL_KEYS=${UMBREL_KEYS:-"/home/umbrel/.ssh/authorized_keys"}
+ROOT_SSH=${ROOT_SSH:-"/root/.ssh"}
+ROOT_KEYS="${ROOT_SSH}/authorized_keys"
+SSHD_DROPIN=${SSHD_DROPIN:-"/etc/ssh/sshd_config.d/99-umbrel-root-key-login.conf"}
+
+mkdir -p /etc/ssh/sshd_config.d
+cat > "${SSHD_DROPIN}" <<'EOF'
+# Managed by umbrel-ssh-root-keys — root login via SSH keys only (no password).
+PermitRootLogin prohibit-password
+PubkeyAuthentication yes
+EOF
+
+if [[ ! -f "${UMBREL_KEYS}" ]] || [[ ! -s "${UMBREL_KEYS}" ]]; then
+	echo "No umbrel authorized_keys found; skipping root key sync"
+	exit 0
+fi
+
+mkdir -p "${ROOT_SSH}"
+chmod 700 "${ROOT_SSH}"
+
+tmp="$(mktemp)"
+trap 'rm -f "${tmp}"' EXIT
+
+# Prefer umbrel keys, then keep any extra root-only keys that aren't duplicates.
+grep -vE '^[[:space:]]*(#|$)' "${UMBREL_KEYS}" > "${tmp}" || true
+
+if [[ -f "${ROOT_KEYS}" ]]; then
+	while IFS= read -r line || [[ -n "${line}" ]]; do
+		[[ -z "${line}" || "${line}" =~ ^[[:space:]]*# ]] && continue
+		if ! grep -Fqx -- "${line}" "${tmp}"; then
+			printf '%s\n' "${line}" >> "${tmp}"
+		fi
+	done < "${ROOT_KEYS}"
+fi
+
+install -o root -g root -m 600 "${tmp}" "${ROOT_KEYS}"
+echo "Synced SSH authorized_keys from umbrel to root ($(wc -l < "${ROOT_KEYS}") key(s))"


### PR DESCRIPTION
## Summary
- After OTA updates, `/root` (system overlay) is replaced and root `authorized_keys` are lost
- `/home/umbrel/.ssh/authorized_keys` lives on the data partition and survives updates
- Add a boot oneshot that syncs umbrel SSH public keys into root before `sshd` starts
- Enable `PermitRootLogin prohibit-password` via sshd drop-in so root key login works after updates

## Test plan
- [ ] Add an SSH public key to `/home/umbrel/.ssh/authorized_keys`
- [ ] Reboot (or run `systemctl start umbrel-ssh-root-keys`)
- [ ] Confirm the same key appears in `/root/.ssh/authorized_keys`
- [ ] SSH as `root` with that key succeeds
- [ ] Install an OTA update, reboot, and confirm root key login still works without manually re-adding keys