### PR TITLE
 fix: link app dependencies to their community app store

### DIFF
--- a/packages/ui/src/modules/app-store/app-page/dependencies.tsx
+++ b/packages/ui/src/modules/app-store/app-page/dependencies.tsx
@@ -7,6 +7,7 @@ import {arrayIncludes} from 'ts-extras'
 import {AppIcon} from '@/components/app-icon'
 import {Loading} from '@/components/ui/loading'
 import {cn} from '@/lib/utils'
+import {getAppStoreLink} from '@/modules/app-store/utils'
 import {useApps} from '@/providers/apps'
 import {useAllAvailableApps} from '@/providers/available-apps'
 import {installedStates, RegistryApp} from '@/trpc/trpc'
@@ -69,13 +70,14 @@ const Dependency = ({
 	showDependencies?: (dependencyId?: string) => void
 }) => {
 	const {t} = useTranslation()
+	const storeLink = getAppStoreLink(app)
 	return (
 		<div className='flex w-full items-center gap-2.5 pl-2'>
-			<Link to={`/app-store/${app.id}`} state={{fromAppStore: true}}>
+			<Link to={storeLink} state={{fromAppStore: true}}>
 				<AppIcon src={app.icon} size={36} className='rounded-8' />
 			</Link>
 			<div className='flex-col gap-4'>
-				<Link to={`/app-store/${app.id}`} state={{fromAppStore: true}} className='flex gap-1.5'>
+				<Link to={storeLink} state={{fromAppStore: true}} className='flex gap-1.5'>
 					<h3 className='truncate text-14 leading-tight font-semibold -tracking-3'>{app.name}</h3>
 					{installed && <TbCircleCheckFilled className='h-[16px] w-[16px] text-slate-500' />}
 				</Link>

--- a/packages/ui/src/modules/app-store/select-dependencies-dialog.tsx
+++ b/packages/ui/src/modules/app-store/select-dependencies-dialog.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import {ScrollArea} from '@/components/ui/scroll-area'
 import {cn} from '@/lib/utils'
+import {getAppStoreLink} from '@/modules/app-store/utils'
 import {useApps} from '@/providers/apps'
 import {useAllAvailableApps} from '@/providers/available-apps'
 import {AppState, installedStates, RegistryApp} from '@/trpc/trpc'
@@ -184,6 +185,7 @@ export function SelectDependencies({
 							</span>
 							<DependencyStateText
 								appId={app.id}
+								app={app}
 								appState={userAppsKeyed?.[app.id]?.state ?? 'not-installed'}
 								onClick={onInstallClick}
 							/>
@@ -205,6 +207,7 @@ export function SelectDependencies({
 						/>
 						<DependencyStateText
 							appId={selectedDependencies[dependencyId]}
+							app={appsKeyed[selectedDependencies[dependencyId]]}
 							appState={userAppsKeyed?.[selectedDependencies[dependencyId]]?.state ?? 'not-installed'}
 							onClick={onInstallClick}
 						/>
@@ -219,7 +222,17 @@ const listClass = tw`divide-y divide-white/6 overflow-hidden rounded-12 bg-white
 const listItemClass = tw`flex items-center pl-3 pr-4 h-[50px] text-[14px] font-medium -tracking-3 justify-between`
 const listItemClassWithDropdown = tw`flex items-center pl-3 pr-4 h-[60px] text-[14px] font-medium -tracking-3 justify-between`
 
-function DependencyStateText({appId, appState, onClick}: {appId: string; appState: AppState; onClick?: () => void}) {
+function DependencyStateText({
+	appId,
+	app,
+	appState,
+	onClick,
+}: {
+	appId: string
+	app?: RegistryApp
+	appState: AppState
+	onClick?: () => void
+}) {
 	const {t} = useTranslation()
 	const buttonClass = 'w-[70px]' // Fixed width for both buttons
 
@@ -233,9 +246,11 @@ function DependencyStateText({appId, appState, onClick}: {appId: string; appStat
 
 	if (appState === 'not-installed') {
 		return (
-			// TODO: link to community app store if needed using `getAppStoreAppFromInstalledApp`
 			<ButtonLink
-				to={`/app-store/${appId}`}
+				// Fall back to the official app store route if the app is no longer
+				// present in any store, for example because a community app store
+				// has been removed
+				to={app ? getAppStoreLink(app) : `/app-store/${appId}`}
 				state={{fromAppStore: true}}
 				onClick={onClick}
 				variant='primary'

--- a/packages/ui/src/modules/app-store/utils.ts
+++ b/packages/ui/src/modules/app-store/utils.ts
@@ -1,7 +1,7 @@
 import {RegistryApp} from '@/trpc/trpc'
 import {preloadImage} from '@/utils/misc'
 
-import {categoryDescriptionsKeyed, categoryishDescriptions, type Categoryish} from './constants'
+import {categoryDescriptionsKeyed, categoryishDescriptions, UMBREL_APP_STORE_ID, type Categoryish} from './constants'
 
 const alreadyPreloadedFirstFewGalleryImages = new Set<string>()
 
@@ -9,6 +9,15 @@ export function preloadFirstFewGalleryImages(app: RegistryApp) {
 	if (alreadyPreloadedFirstFewGalleryImages.has(app.id)) return
 	alreadyPreloadedFirstFewGalleryImages.add(app.id)
 	app.gallery.slice(0, 3).map(preloadImage)
+}
+
+// Returns the store page path for an app, linking community store apps to
+// their community app store instead of the official Umbrel App Store
+export function getAppStoreLink(app: Pick<RegistryApp, 'id' | 'appStoreId'>): string {
+	if (app.appStoreId && app.appStoreId !== UMBREL_APP_STORE_ID) {
+		return `/community-app-store/${app.appStoreId}/${app.id}`
+	}
+	return `/app-store/${app.id}`
 }
 
 export function getCategoryLabel(categoryId: string): string {


### PR DESCRIPTION
## Problem

On a community app store's app page, the Requires section links every dependency to `/app-store/<id>`. When the dependency lives in that community store, the route has no app and lands on the error boundary. The Install button in the dependency selection dialog has the same hardcoded path. There's an existing TODO acknowledging it, but it points at `getAppStoreAppFromInstalledApp`, which was removed in 4cf8ec34.

Fixes #2194

## Fix

Add a `getAppStoreLink` helper to `app-store/utils.ts` that routes community store apps to `/community-app-store/<storeId>/<appId>` and everything else to the official route, using the `appStoreId` the registry already hydrates onto every app. It's the same branch the desktop context menu's "go to store page" already does in `app-icon.tsx`. Both dependency surfaces now use it. The dialog falls back to the official route when the app isn't present in any store anymore (e.g. a removed community app store), which preserves current behavior. Official-store dependencies produce identical paths, so nothing changes there.

<img width="1280" height="633" alt="dep-links-dialog-community" src="https://github.com/user-attachments/assets/7a98e2b4-0f17-4609-859b-45a4e4e9f5ee" />

## Testing

Manually in umbrel-dev with a local community app store containing two apps where one depends on the other:

- Community app page: Requires links now point to `/community-app-store/example-store/example-store-service` and open a working app page. Before the fix they pointed to `/app-store/example-store-service` and landed on "Something went wrong".
- Dependency dialog: the Install button for the community dependency routes the same way.
- No change for official store apps: Lightning Node's Requires links and dialog Install button still point to `/app-store/bitcoin` and work. Selecting an alternative in the dialog (Bitcoin Knots) links to `/app-store/bitcoin-knots` correctly.

## Caveat

Tested in the umbrel-dev VM (Docker/macOS), not on real umbrelOS hardware.