### PR TITLE
fix: clean up old docker images after app updates

### DIFF
--- a/packages/umbreld/source/modules/apps/app.ts
+++ b/packages/umbreld/source/modules/apps/app.ts
@@ -1,5 +1,6 @@
 import crypto from 'node:crypto'
 import nodePath from 'node:path'
+import {fileURLToPath} from 'node:url'
 
 import fse from 'fs-extra'
 import yaml from 'js-yaml'
@@ -11,6 +12,7 @@ import pRetry from 'p-retry'
 
 import getDirectorySize from '../utilities/get-directory-size.js'
 import {pullAll} from '../utilities/docker-pull.js'
+import {imageHasNoTags, resolveImageIds} from '../utilities/docker-images.js'
 import FileStore from '../utilities/file-store.js'
 import {fillSelectedDependencies} from '../utilities/dependencies.js'
 import type Umbreld from '../../index.js'
@@ -28,6 +30,29 @@ async function writeYaml(path: string, data: any) {
 export async function readManifestInDirectory(dataDirectory: string) {
 	const parseYaml = readYaml(`${dataDirectory}/umbrel-app.yml`)
 	return parseYaml.then(validateManifest)
+}
+
+// Default system images used by all apps that aren't listed in app compose files
+export const defaultImages = [
+	'getumbrel/app-proxy:1.7.0@sha256:ec0de0b944a2e63d52fdd82b3760d90a35f8b442d17a8407afdee3af3e842d5a',
+	'ghcr.io/getumbrel/tor:0.4.9.11@sha256:e382b8629c0dfef6ceb396b062622d4e4e955b19d6f16b883fd2c0723ad5671a',
+]
+
+// Lists the image references of the app environment system containers (like
+// auth-server) alongside the default images. We read them from the legacy compat
+// compose files at runtime so they can't drift out of sync with what actually
+// runs. These images must always be protected from image cleanup.
+export async function readSystemImages() {
+	const currentDirname = nodePath.dirname(fileURLToPath(import.meta.url))
+	const composeFiles = ['docker-compose.yml', 'docker-compose.app_proxy.yml', 'docker-compose.tor.yml']
+	const images = new Set<string>(defaultImages)
+	for (const composeFile of composeFiles) {
+		const compose = (await readYaml(nodePath.join(currentDirname, 'legacy-compat', composeFile))) as Compose
+		for (const service of Object.values(compose.services ?? {})) {
+			if (service.image) images.add(service.image)
+		}
+	}
+	return [...images]
 }
 
 type AppState =
@@ -74,6 +99,13 @@ export default class App {
 
 	readCompose() {
 		return readYaml(`${this.dataDirectory}/docker-compose.yml`) as Promise<Compose>
+	}
+
+	async readComposeImages() {
+		const compose = await this.readCompose()
+		return Object.values(compose.services!)
+			.map((service) => service.image)
+			.filter(Boolean) as string[]
 	}
 
 	async readHiddenService() {
@@ -138,14 +170,7 @@ export default class App {
 	}
 
 	async pull() {
-		const defaultImages = [
-			'getumbrel/app-proxy:1.7.0@sha256:ec0de0b944a2e63d52fdd82b3760d90a35f8b442d17a8407afdee3af3e842d5a',
-			'ghcr.io/getumbrel/tor:0.4.9.11@sha256:e382b8629c0dfef6ceb396b062622d4e4e955b19d6f16b883fd2c0723ad5671a',
-		]
-		const compose = await this.readCompose()
-		const images = Object.values(compose.services!)
-			.map((service) => service.image)
-			.filter(Boolean) as string[]
+		const images = await this.readComposeImages()
 		await pullAll([...defaultImages, ...images], (progress) => {
 			this.stateProgress = Math.max(1, progress * 99)
 			this.logger.log(`Downloaded ${this.stateProgress}% of app ${this.id}`)
@@ -183,11 +208,11 @@ export default class App {
 
 		this.logger.log(`Updating app ${this.id}`)
 
-		// Get a reference to the old images
-		const compose = await this.readCompose()
-		const oldImages = Object.values(compose.services!)
-			.map((service) => service.image)
-			.filter(Boolean) as string[]
+		// Resolve the old images to image ids before we pull. Mutable references
+		// like `repo:tag` resolve to the new image after the pull which leaves the
+		// old image behind as an untagged orphan we can no longer identify.
+		const oldImages = await this.readComposeImages()
+		const oldImageIds = await resolveImageIds(oldImages)
 
 		// Update the app, patching the compose file half way through
 		await appScript(this.#umbreld, 'pre-patch-update', this.id)
@@ -195,11 +220,42 @@ export default class App {
 		await this.pull()
 		await appScript(this.#umbreld, 'post-patch-update', this.id)
 
-		// Delete the old images if we can. Silently fail on error cos docker
-		// will return an error even if only one image is still needed.
+		// Delete any old images that are no longer needed, skipping images that are
+		// still used by the updated app or any other installed app since apps can
+		// share images. Failures are logged but tolerated, cleanup should never fail
+		// an otherwise successful update.
 		try {
-			await $({stdio: 'inherit'})`docker rmi ${oldImages}`
-		} catch {}
+			const imagesInUse = [...(await this.#umbreld.apps.getInstalledAppImages()), ...(await readSystemImages())]
+			const imageIdsInUse = await resolveImageIds(imagesInUse)
+			const removableImageIds = new Set([...oldImageIds].filter((imageId) => !imageIdsInUse.has(imageId)))
+
+			// First remove the old compose references. This removes exactly the
+			// references the app owned and leaves any other references to the same
+			// image, like tags the user created themselves, alone.
+			for (const imageReference of oldImages) {
+				const [imageId] = await resolveImageIds([imageReference])
+				if (!imageId || !removableImageIds.has(imageId)) continue
+				this.logger.log(`Removing old image ${imageReference} of app ${this.id}`)
+				await $({stdio: 'inherit'})`docker rmi ${imageReference}`.catch((error) =>
+					this.logger.error(`Failed to remove old image ${imageReference} of app ${this.id}`, error),
+				)
+			}
+
+			// Mutable references like `repo:tag` resolve to the new image after the
+			// pull, leaving the old image behind untagged where the reference removal
+			// above can no longer identify it. Remove those by image id. We skip
+			// images that still have tags so we never remove an image the user has
+			// tagged themselves.
+			for (const imageId of removableImageIds) {
+				if (!(await imageHasNoTags(imageId))) continue
+				this.logger.log(`Removing old image ${imageId} of app ${this.id}`)
+				await $({stdio: 'inherit'})`docker rmi ${imageId}`.catch((error) =>
+					this.logger.error(`Failed to remove old image ${imageId} of app ${this.id}`, error),
+				)
+			}
+		} catch (error) {
+			this.logger.error(`Failed to clean up old images of app ${this.id}`, error)
+		}
 
 		this.state = 'ready'
 		this.stateProgress = 0

--- a/packages/umbreld/source/modules/apps/apps.integration.test.ts
+++ b/packages/umbreld/source/modules/apps/apps.integration.test.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import {expect, beforeAll, afterAll, test, vi} from 'vitest'
 import fse from 'fs-extra'
 import yaml from 'js-yaml'
+import {$} from 'execa'
 
 import createTestUmbreld from '../test-utilities/create-test-umbreld.js'
 import {BACKUP_RESTORE_FIRST_START_FLAG} from '../../constants.js'
@@ -255,6 +256,100 @@ test.sequential('restart() restarts an installed app', async () => {
 test.sequential('update() updates an installed app', async () => {
 	await expect(umbreld.client.apps.update.mutate({appId: 'sparkles-hello-world'})).resolves.toStrictEqual(true)
 	// TODO: Check this actually worked
+})
+
+test.sequential('update() removes the old image when a mutable reference is re-pointed', async () => {
+	// Simulate a stale local image for the app's mutable image reference by pointing
+	// the tag at a different image, like the state after the tag has been re-pushed
+	// upstream. Before the update the tag resolves to the stale image, after the
+	// update's pull it resolves to the new image which previously orphaned the stale
+	// image as an untagged leak.
+	const app = umbreld.instance.apps.getApp('sparkles-hello-world')
+	const [imageReference] = await app.readComposeImages()
+	await $`docker pull busybox:1.36.0`
+	await $`docker tag busybox:1.36.0 ${imageReference}`
+	const {stdout: staleImageId} = await $`docker image inspect --format {{.Id}} ${imageReference}`
+	await $`docker rmi busybox:1.36.0`
+
+	await expect(umbreld.client.apps.update.mutate({appId: 'sparkles-hello-world'})).resolves.toStrictEqual(true)
+
+	// The stale image should have been removed and the app's real image should remain
+	await expect($`docker image inspect ${staleImageId}`).rejects.toThrow()
+	const {stdout: currentImageId} = await $`docker image inspect --format {{.Id}} ${imageReference}`
+	expect(currentImageId).not.toBe(staleImageId)
+})
+
+test.sequential('update() applies a new app version from the app store', async () => {
+	// Add a busybox sidecar service to the app's compose file in the app store and
+	// bump the version, like a real app update. Note the app store repo umbreld
+	// installs from is the git server created by createTestUmbreld, not the
+	// separate community app store git server used by other tests.
+	const appDirectory = path.join(umbreld.gitServer.directory, 'sparkles-hello-world')
+	const manifestPath = path.join(appDirectory, 'umbrel-app.yml')
+	const manifest = yaml.load(await fse.readFile(manifestPath, 'utf8')) as AppManifest
+	manifest.version = '1.0.1'
+	await fse.writeFile(manifestPath, yaml.dump(manifest))
+	const composePath = path.join(appDirectory, 'docker-compose.yml')
+	const compose = yaml.load(await fse.readFile(composePath, 'utf8')) as any
+	compose.services.sidecar = {image: 'busybox:1.36.1', command: 'sleep infinity'}
+	await fse.writeFile(composePath, yaml.dump(compose))
+	const $$ = $({cwd: umbreld.gitServer.directory})
+	await $$`git add .`
+	await $$`git commit -m ${'Update sparkles-hello-world to 1.0.1'}`
+
+	// Refresh the local app store and update the app
+	await umbreld.instance.appStore.update()
+	await expect(umbreld.client.apps.update.mutate({appId: 'sparkles-hello-world'})).resolves.toStrictEqual(true)
+
+	// The app should now run the updated compose file including the new service
+	const app = umbreld.instance.apps.getApp('sparkles-hello-world')
+	await expect(app.readComposeImages()).resolves.toContain('busybox:1.36.1')
+})
+
+test.sequential('cleanOrphanedImages() removes orphaned app images and nothing else', async () => {
+	// Create an orphaned image of a managed repository: pull an old busybox by tag,
+	// then remove the tag and re-pull by digest so the image has a repo digest but
+	// no tags, like an image leaked by an interrupted app update. busybox is a
+	// managed repository because the app's compose file now includes it.
+	const repoDigestsFormat = '{{index .RepoDigests 0}}'
+	await $`docker pull busybox:1.35.0`
+	const {stdout: managedDigest} = await $`docker image inspect --format ${repoDigestsFormat} busybox:1.35.0`
+	const {stdout: orphanedImageId} = await $`docker image inspect --format {{.Id}} busybox:1.35.0`
+	await $`docker rmi busybox:1.35.0`
+	await $`docker pull ${managedDigest}`
+
+	// Create images that must all survive the sweep: an orphaned image of a
+	// repository umbrel doesn't manage, a tagged image and a locally built image
+	await $`docker pull alpine:3.19`
+	const {stdout: unmanagedDigest} = await $`docker image inspect --format ${repoDigestsFormat} alpine:3.19`
+	const {stdout: unmanagedImageId} = await $`docker image inspect --format {{.Id}} alpine:3.19`
+	await $`docker rmi alpine:3.19`
+	await $`docker pull ${unmanagedDigest}`
+	await $`docker pull busybox:1.37.0`
+	const {stdout: locallyBuiltImageId} = await $({
+		input: 'FROM busybox:1.37.0\nLABEL umbrel-test-locally-built=true',
+	})`docker build --quiet -`
+
+	try {
+		await umbreld.instance.apps.cleanOrphanedImages()
+
+		// The orphaned image of the managed repository should have been removed
+		await expect($`docker image inspect ${orphanedImageId}`).rejects.toThrow()
+		// The unmanaged orphan, the tagged image, the locally built image and the
+		// installed app's images all survive
+		await expect($`docker image inspect ${unmanagedImageId}`).resolves.toBeTruthy()
+		await expect($`docker image inspect busybox:1.37.0`).resolves.toBeTruthy()
+		await expect($`docker image inspect ${locallyBuiltImageId}`).resolves.toBeTruthy()
+		const app = umbreld.instance.apps.getApp('sparkles-hello-world')
+		for (const imageReference of await app.readComposeImages()) {
+			await expect($`docker image inspect ${imageReference}`).resolves.toBeTruthy()
+		}
+	} finally {
+		// Clean up the test images
+		await $`docker rmi ${unmanagedImageId}`.catch(() => {})
+		await $`docker rmi ${locallyBuiltImageId}`.catch(() => {})
+		await $`docker rmi busybox:1.37.0`.catch(() => {})
+	}
 })
 
 test.sequential("umbreld restart doesn't start stopped apps", async () => {

--- a/packages/umbreld/source/modules/apps/apps.ts
+++ b/packages/umbreld/source/modules/apps/apps.ts
@@ -7,10 +7,17 @@ import pRetry from 'p-retry'
 import semver from 'semver'
 
 import randomToken from '../../modules/utilities/random-token.js'
+import {
+	imageHasNoTags,
+	imageRepository,
+	listContainerImageIds,
+	listImages,
+	resolveImageIds,
+} from '../../modules/utilities/docker-images.js'
 import type Umbreld from '../../index.js'
 import appEnvironment from './legacy-compat/app-environment.js'
 import type {AppSettings} from './schema.js'
-import App, {readManifestInDirectory} from './app.js'
+import App, {readManifestInDirectory, readSystemImages} from './app.js'
 import type {AppManifest} from './schema.js'
 import {fillSelectedDependencies} from '../utilities/dependencies.js'
 
@@ -49,6 +56,48 @@ export default class Apps {
 			await $({stdio: 'inherit'})`docker network prune -f`
 		} catch (error) {
 			this.logger.error(`Failed to clean networks`, error)
+		}
+	}
+
+	// Lists the image references in the compose files of all installed apps
+	async getInstalledAppImages() {
+		const images = await Promise.all(this.instances.map((app) => app.readComposeImages()))
+		return images.flat()
+	}
+
+	// Cleans up orphaned images left behind by app updates. Once an image loses its
+	// tags it can no longer be identified by the old image cleanup in App.update()
+	// so we sweep orphans on boot. We only remove images that were pulled from a
+	// registry (they have a repo digest but no tags), come from a repository of an
+	// installed app or system container, aren't used by any container in any state
+	// and aren't currently referenced by any installed app. We remove specific
+	// image ids instead of running a global `docker image prune` so we can never
+	// touch images the user has built, tagged or pulled themselves. If we can't
+	// read the compose file of an installed app we abort the entire sweep since we
+	// can no longer know which images are safe to remove.
+	async cleanOrphanedImages() {
+		const images = await listImages()
+		const orphanCandidates = images.filter((image) => image.repoTags === 0 && image.repoDigests.length > 0)
+		if (orphanCandidates.length === 0) return
+
+		const protectedImages = [...(await this.getInstalledAppImages()), ...(await readSystemImages())]
+		const imageIdsInUse = await resolveImageIds(protectedImages)
+		const containerImageIds = await listContainerImageIds()
+		const managedRepositories = new Set(protectedImages.map(imageRepository))
+
+		const removableImageIds = orphanCandidates
+			.filter((image) => image.repoDigests.some((repoDigest) => managedRepositories.has(imageRepository(repoDigest))))
+			.map((image) => image.id)
+			.filter((imageId) => !containerImageIds.has(imageId) && !imageIdsInUse.has(imageId))
+
+		for (const imageId of removableImageIds) {
+			// Re-check the image is still untagged right before removal in case it
+			// was tagged while we were sweeping
+			if (!(await imageHasNoTags(imageId))) continue
+			this.logger.log(`Removing orphaned image ${imageId}`)
+			await $({stdio: 'inherit'})`docker rmi ${imageId}`.catch((error) =>
+				this.logger.error(`Failed to remove orphaned image ${imageId}`, error),
+			)
 		}
 	}
 
@@ -202,6 +251,14 @@ export default class Apps {
 
 		// Wait for current installed apps to finish starting
 		await startAppsPromise
+
+		// Clean up orphaned images in the background. This must run after the app
+		// instances have been created so installed apps' images are protected, and
+		// after the app environment is up so system containers exist again. Skip
+		// this in dev mode so we never sweep images on a development Docker host.
+		if (!this.#umbreld.developmentMode) {
+			this.cleanOrphanedImages().catch((error) => this.logger.error('Failed to clean orphaned images', error))
+		}
 	}
 
 	private async reinstallMissingAppsAfterRestore(appIds: string[]) {

--- a/packages/umbreld/source/modules/test-utilities/create-test-umbreld.ts
+++ b/packages/umbreld/source/modules/test-utilities/create-test-umbreld.ts
@@ -190,6 +190,7 @@ export default async function createTestUmbreld({autoLogin = false, autoStart = 
 
 	return {
 		instance: umbreld,
+		gitServer,
 		client,
 		unauthenticatedClient,
 		api,

--- a/packages/umbreld/source/modules/utilities/docker-images.ts
+++ b/packages/umbreld/source/modules/utilities/docker-images.ts
@@ -1,0 +1,61 @@
+import {$} from 'execa'
+
+// Resolves image references (like `repo:tag` or `repo:tag@sha256:digest`) to the
+// ids of the images they currently point to in the local Docker store. Docker
+// exits non zero when any reference is missing but still prints the ids it can
+// resolve, so we tolerate the error and use whatever output we get. This lets
+// callers safely diff before/after update states.
+export async function resolveImageIds(imageReferences: string[]) {
+	const references = [...new Set(imageReferences)]
+	if (references.length === 0) return new Set<string>()
+	const result = await $`docker image inspect --format {{.Id}} ${references}`.catch((error) => error)
+	return new Set<string>((result.stdout ?? '').split('\n').filter(Boolean))
+}
+
+// Lists all local images with their id, tag count and registry digests. Images
+// pulled by digest have no tags but retain a repo digest, images built locally
+// have neither. We tolerate inspect errors so an image removed between the list
+// and the inspect doesn't fail the entire listing.
+export async function listImages() {
+	const {stdout} = await $`docker image ls --all --no-trunc --quiet`
+	const imageIds = [...new Set(stdout.split('\n').filter(Boolean))]
+	if (imageIds.length === 0) return []
+	const format = '{{.Id}}\t{{len .RepoTags}}\t{{json .RepoDigests}}'
+	const inspection = await $`docker image inspect --format ${format} ${imageIds}`.catch((error) => error)
+	return ((inspection.stdout ?? '') as string)
+		.split('\n')
+		.filter(Boolean)
+		.map((line) => {
+			const [id, repoTags, repoDigestsJson] = line.split('\t')
+			const repoDigests = (JSON.parse(repoDigestsJson) ?? []) as string[]
+			return {id, repoTags: Number(repoTags), repoDigests}
+		})
+}
+
+// Lists the image ids referenced by all containers in any state. Docker won't
+// remove these images without force so we treat them as always in use.
+export async function listContainerImageIds() {
+	const {stdout: containerList} = await $`docker ps --all --quiet`
+	const containerIds = containerList.split('\n').filter(Boolean)
+	if (containerIds.length === 0) return new Set<string>()
+	const result = await $`docker container inspect --format {{.Image}} ${containerIds}`.catch((error) => error)
+	return new Set<string>((result.stdout ?? '').split('\n').filter(Boolean))
+}
+
+// Returns true if the image currently has no tags. Used as a final guard before
+// removing an image by id so we never remove an image the user has tagged, or
+// one that was re-tagged while we were working.
+export async function imageHasNoTags(imageId: string) {
+	const format = '{{len .RepoTags}}'
+	const result = await $`docker image inspect --format ${format} ${imageId}`.catch((error) => error)
+	return result.stdout?.trim() === '0'
+}
+
+// Extracts the repository from an image reference or repo digest, so
+// `registry:5000/repo:tag@sha256:digest` becomes `registry:5000/repo`
+export function imageRepository(imageReference: string) {
+	const withoutDigest = imageReference.split('@')[0]
+	const lastColon = withoutDigest.lastIndexOf(':')
+	const lastSlash = withoutDigest.lastIndexOf('/')
+	return lastColon > lastSlash ? withoutDigest.slice(0, lastColon) : withoutDigest
+}


### PR DESCRIPTION
## Problem

umbrelOS never reclaims old Docker images after app updates, so `/var/lib/docker` grows unbounded. #2140 reports 94 GB of overlay2 with 66 GB reclaimable, and the community threads linked there go back to 2021.

The cleanup actually exists (`app.ts` runs `docker rmi <old refs>` after every update) but it silently misses:

- For mutable `repo:tag` refs the pull re-points the tag first, so the rmi targets the new in-use image, fails, and the empty `catch {}` hides it. The old image is left behind as an untagged `<none>`. Repro'd in umbrel-dev with a local registry.
- Digest-pinned refs (the whole official store) clean up fine on the happy path, but leak permanently when an update throws before the rmi line.
- Once leaked, nothing ever removes an image. There's no periodic cleanup, and uninstall's `--rmi all` only covers images the current compose references (verified, a leaked image survives uninstall). Old app-proxy/tor images accumulate the same way after version bumps.

This looks like regression rather than policy. The 0.5.x era cleaned up old images several times over (`docker image prune` in 2020, scoped to Umbrel-only in #138, per-app rmi in 2022, cfc5a9b2 "Restore image cleanup logic from previous update" in 2023), and nothing in umbreld uses an old image after an update. Log rotation (solution 3 in the issue) was already fixed via #2169, so this is purely about images.

Fixes #2140

## Fix

Two parts. Both only ever touch images umbrelOS itself manages, never a global `docker image prune`, keeping the constraint from #138 that user images on the same daemon are untouchable.

**1. Make update cleanup correct** (`app.ts`): resolve the old compose refs to image ids before the pull, so a re-pointed tag can't dodge removal. After the update, remove the old refs first (leaves any user-created tags on the same image alone), then remove now-untagged old ids. Anything still used by the updated app or another installed app is skipped, since apps share images and the same `repo:tag` even exists with different digests across official apps. Failures are logged instead of swallowed, and cleanup can never fail an otherwise successful update.

**2. Reclaim already-leaked images** (`apps.ts` + `utilities/docker-images.ts`): a conservative sweep on boot (after apps are up, skipped in dev mode). An image is only removed if it was pulled from a registry and has no tags (the state leaked images are in, user-built images have neither), its repo belongs to an installed app or the system containers (read from the legacy-compat compose files at runtime so they can't drift), no container in any state uses it, it isn't what any installed app's compose currently resolves to, and it's still untagged at removal time. If any installed app's compose can't be read the sweep aborts entirely.

Two deliberate details worth flagging: `docker image ls --all` because Docker CLI 29 hides untagged images from plain listings (the sweep would silently no-op at the next Docker bump), and the sweep won't touch orphans of repos no installed app references (e.g. leftovers of an app uninstalled after a failed update). That's the "only images umbrel manages" rule, happy to change the dial there.

## Testing

Full `apps.integration.test.ts` suite passing via `test:umbrel-dev` (37 tests), including three new ones:

- `update() removes the old image when a mutable reference is re-pointed` — the #2140 leak mechanism, asserts the old image is removed and the new one survives
- `update() applies a new app version from the app store` — a real version-bump update through the git-server fixture, fills in the existing update test's `// TODO: Check this actually worked` (createTestUmbreld now exposes its git server to make this possible)
- `cleanOrphanedImages() removes orphaned app images and nothing else` — creates a leaked-style orphan of a managed repo plus three must-survive images (an orphan of an unmanaged repo, a tagged image, a locally built image), asserts only the managed orphan is removed

Also verified by hand in umbrel-dev before writing the fix: the mutable-tag leak (exact rmi conflict captured), the digest-pinned happy path not leaking, and a leaked image surviving uninstall.

## Caveat

Tested in umbrel-dev (Docker/macOS), not on real umbrelOS hardware. Failed updates still skip the in-update cleanup (the old ref stays tagged, so the next successful update or the boot sweep reclaims it), the leak just can't compound silently anymore.
