### PR TITLE
Enable IPv6 support

### DIFF
--- a/packages/umbreld/source/modules/apps/legacy-compat/app-environment.ts
+++ b/packages/umbreld/source/modules/apps/legacy-compat/app-environment.ts
@@ -21,6 +21,7 @@ export default async function appEnvironment(umbreld: Umbreld, command: string) 
 			UMBREL_DATA_DIR: umbreld.dataDirectory,
 			// TODO: Load these from somewhere more appropriate
 			NETWORK_IP: '10.21.0.0',
+			NETWORK_IP_v6: 'fd40:95bc:786f::',
 			GATEWAY_IP: '10.21.0.1',
 			DASHBOARD_IP: '10.21.21.3',
 			MANAGER_IP: '10.21.21.4',

--- a/packages/umbreld/source/modules/apps/legacy-compat/docker-compose.yml
+++ b/packages/umbreld/source/modules/apps/legacy-compat/docker-compose.yml
@@ -45,7 +45,9 @@ services:
 networks:
   default:
     name: umbrel_main_network
+    enable_ipv6: true
     ipam:
       driver: default
       config:
         - subnet: '$NETWORK_IP/16'
+        - subnet: '$NETWORK_IP_v6/64'


### PR DESCRIPTION
This PR allows `umbrel_main_network` to assign IPv6 address.
I have chosen a random ULA IPv6 subnet but this can be changed of course.
Let me know if this needs any change.