### PR TITLE
ci: name change-detection and test-discovery steps for readability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - id: check
+      - name: Detect UI-only changes
+        id: check
         run: |
           DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
 
@@ -120,7 +121,8 @@ jobs:
       tests: ${{ steps.find.outputs.tests }}
     steps:
       - uses: actions/checkout@v3
-      - id: find
+      - name: Discover VM test files
+        id: find
         run: |
           tests=$(find packages/umbreld/source -name "*.vm.test.ts" | sed 's|packages/umbreld/||' | jq -R -s -c 'split("\n") | map(select(length > 0)) | map({path: ., name: (. | split("/") | last | sub("\\.vm\\.test\\.ts$"; ""))})')
           echo "tests=$tests" >> $GITHUB_OUTPUT
@@ -169,7 +171,8 @@ jobs:
       tests: ${{ steps.find.outputs.tests }}
     steps:
       - uses: actions/checkout@v3
-      - id: find
+      - name: Discover integration test files
+        id: find
         run: |
           tests=$(find packages/umbreld/source -name "*.integration.test.ts" | sed 's|packages/umbreld/||' | jq -R -s -c 'split("\n") | map(select(length > 0)) | map({path: ., name: (. | split("/") | last | sub("\\.integration\\.test\\.ts$"; ""))})')
           echo "tests=$tests" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

In `.github/workflows/ci.yml`, several helper `run` steps are unnamed and longer than **300 characters**. In the GitHub Actions UI those steps collapse into generic labels, which hurts readability when UI-only change detection or test matrix discovery fails.

## Changes

Semantics are unchanged: same step `id`s, same `GITHUB_OUTPUT` keys, and the same job output / matrix wiring.

- Add `name: Detect UI-only changes` to `id: check`
- Add `name: Discover VM test files` to `id: find` in `discover-vm-tests`
- Add `name: Discover integration test files` to `id: find` in `discover-integration-tests`

## Test plan
- [ ] Confirm later jobs still use `needs.detect-changes.outputs.ui-only`
- [ ] Confirm VM / integration matrices still use `needs.*.outputs.tests`
- [ ] Confirm the steps show the new names in the Actions UI
