### PR TITLE
Keep kopia's cache on the data directory filesystem and limit its size

### DIFF
--- a/packages/umbreld/source/modules/backups/backups.integration.test.ts
+++ b/packages/umbreld/source/modules/backups/backups.integration.test.ts
@@ -1,3 +1,4 @@
+import nodePath from 'node:path'
 import {setTimeout} from 'node:timers/promises'
 
 import {expect, test, beforeEach, afterEach, vi} from 'vitest'
@@ -5,6 +6,7 @@ import fse from 'fs-extra'
 import yaml from 'js-yaml'
 import {execa} from 'execa'
 import pRetry from 'p-retry'
+import pWaitFor from 'p-wait-for'
 
 import createTestUmbreld from '../test-utilities/create-test-umbreld.js'
 import {BACKUP_RESTORE_FIRST_START_FLAG} from '../../constants.js'
@@ -192,6 +194,7 @@ test('backup() creates a backup successfully', async () => {
 	expect(files).not.toContain('external')
 	expect(files).not.toContain('network')
 	expect(files).not.toContain('thumbnails')
+	expect(files).not.toContain('kopia')
 })
 
 test('backup() throws error for non-existent repository', async () => {
@@ -543,6 +546,55 @@ test('backups respect app backupIgnore glob patterns', async () => {
 		path: '/app-data/sparkles-hello-world/important-data',
 	})
 	expect(importantDirFiles).toContain('config.json')
+})
+
+test('kopia keeps cache and logs in the data directory with hard cache size limits', async () => {
+	// Create a network share and mount it
+	const backupNetworkSharePath = await createBackupShare(umbreld)
+
+	// Create a new backup repository
+	const repositoryId = await umbreld.client.backups.createRepository.mutate({
+		path: backupNetworkSharePath,
+		password: 'test-password',
+	})
+
+	// Do the backup
+	await expect(umbreld.client.backups.backup.mutate({repositoryId})).resolves.toBe(true)
+
+	// Verify kopia wrote its cache and logs inside the data directory
+	const kopiaDataDirectory = `${umbreld.instance.dataDirectory}/kopia`
+	await expect(fse.readdir(`${kopiaDataDirectory}/cache`)).resolves.not.toHaveLength(0)
+	await expect(fse.readdir(`${kopiaDataDirectory}/logs`)).resolves.not.toHaveLength(0)
+
+	// Verify the kopia directory itself is excluded from the backup
+	const backups = await umbreld.client.backups.listBackups.query({repositoryId})
+	const files = await umbreld.client.backups.listBackupFiles.query({backupId: backups[0].id})
+	expect(files).not.toContain('kopia')
+
+	// Verify cache size limits are pinned in the repository config
+	// Sizes are stored in bytes, connect flags are in MiB (1 MB = 2^20 bytes)
+	// The cache directory is stored relative to the config file directory
+	const kopiaConfig = await fse.readJson(`/kopia/config/${repositoryId}.config`)
+	const cacheDirectory = nodePath.resolve('/kopia/config', kopiaConfig.caching.cacheDirectory)
+	expect(cacheDirectory.startsWith(`${kopiaDataDirectory}/cache/`)).toBe(true)
+	expect(kopiaConfig.caching.maxCacheSize).toBe(500 * 2 ** 20)
+	expect(kopiaConfig.caching.contentCacheSizeLimitBytes).toBe(1000 * 2 ** 20)
+	expect(kopiaConfig.caching.maxMetadataCacheSize).toBe(1000 * 2 ** 20)
+	expect(kopiaConfig.caching.metadataCacheSizeLimitBytes).toBe(2000 * 2 ** 20)
+})
+
+test('stale kopia cache in the legacy location is cleaned up on startup', async () => {
+	// Recreate stale cache leftovers in the legacy location
+	const legacyCacheDirectory = '/kopia/cache/kopia'
+	await fse.ensureDir(`${legacyCacheDirectory}/legacy-repo`)
+	await fse.writeFile(`${legacyCacheDirectory}/legacy-repo/blob`, 'stale-cache-data')
+
+	// Restart umbreld
+	await umbreld.instance.stop()
+	await umbreld.instance.start()
+
+	// Verify the legacy cache is cleaned up (cleanup runs in the background, so poll)
+	await pWaitFor(async () => !(await fse.pathExists(legacyCacheDirectory)), {timeout: 30_000, interval: 100})
 })
 
 test('backups handle disconnected network shares gracefully', async () => {

--- a/packages/umbreld/source/modules/backups/backups.ts
+++ b/packages/umbreld/source/modules/backups/backups.ts
@@ -77,6 +77,10 @@ export default class Backups {
 		// Cleanup any left over backup mounts
 		await this.unmountAll().catch((error) => this.logger.error('Error unmounting backups', error))
 
+		// Cleanup any kopia cache from the legacy /kopia/cache location. This can take
+		// a while if the old cache is large so we don't block startup on it.
+		this.cleanupLegacyCache().catch((error) => this.logger.error('Error cleaning up legacy kopia cache', error))
+
 		// Fire off background backup process
 		this.backupJobPromise = this.backupOnInterval().catch((error) =>
 			this.logger.error('Error running backups on interval', error),
@@ -184,8 +188,11 @@ export default class Backups {
 			// Spawn process
 			const env = {
 				KOPIA_CHECK_FOR_UPDATES: 'false',
-				XDG_CACHE_HOME: '/kopia/cache',
+				// Keep the cache and logs on the data directory's filesystem. /kopia lives on
+				// the data partition which on Raspberry Pi installs is too small to hold the cache.
+				XDG_CACHE_HOME: `${this.#umbreld.dataDirectory}/kopia/cache`,
 				XDG_CONFIG_HOME: '/kopia/config',
+				KOPIA_LOG_DIR: `${this.#umbreld.dataDirectory}/kopia/logs`,
 			}
 			const process = execa('kopia', flags, {env})
 
@@ -435,7 +442,36 @@ export default class Backups {
 			// continue to backup, kopia will see these as backups originating from
 			// different machines.
 			'--override-hostname=umbrel',
+			// Limit the size of kopia's local cache. The soft limits are only enforced
+			// by sweeps when the repository is opened, the hard limits are enforced
+			// continuously. Without a hard limit the cache can grow unbounded between
+			// repository opens and exhaust the disk space/inodes of its filesystem.
+			// We're connecting before every repository operation so these limits can
+			// never drift.
+			'--content-cache-size-mb=500',
+			'--content-cache-size-limit-mb=1000',
+			'--metadata-cache-size-mb=1000',
+			'--metadata-cache-size-limit-mb=2000',
 		])
+	}
+
+	// Remove any kopia cache left behind at the legacy /kopia/cache location. The cache
+	// now lives in the data directory so anything there is dead weight. On Raspberry Pi
+	// installs it could hold enough inodes to exhaust the partition it lives on.
+	private async cleanupLegacyCache() {
+		const legacyCacheDirectory = '/kopia/cache/kopia'
+		const deletingDirectory = `${legacyCacheDirectory}.deleting`
+
+		// Remove any leftovers from a previously interrupted cleanup
+		await fse.remove(deletingDirectory)
+
+		if (!(await fse.pathExists(legacyCacheDirectory))) return
+
+		// Rename first so the removal can't race anything writing into the tree it's deleting
+		this.logger.log('Removing kopia cache from legacy location')
+		await fse.move(legacyCacheDirectory, deletingDirectory)
+		await fse.remove(deletingDirectory)
+		this.logger.log('Removed kopia cache from legacy location')
 	}
 
 	// Wrapper for kopia commands that interact with a repository
@@ -590,6 +626,9 @@ export default class Backups {
 		// Ignore non critical directories that can be rebuilt and cause a lot of churn
 		ignoreFileContents.push('app-stores')
 		ignoreFileContents.push(this.#umbreld.files.thumbnails.thumbnailDirectory)
+
+		// Ignore kopia's own cache and logs otherwise backups include the backup cache
+		ignoreFileContents.push('kopia')
 
 		// Ignore temporary migration directory
 		ignoreFileContents.push('.temporary-migration')


### PR DESCRIPTION
Fixes #2207

## Problem

kopia keeps its cache at `/kopia/cache`, which is a bind mount of `/data/umbrel-os/kopia`
on the data partition. On Raspberry Pi installs that partition is small (~19 GB / 1.26M
inodes) and the cache grows without bound: kopia's default limits are soft limits, only
enforced by a sweep when the repository opens, and hard limits can't be pinned out-of-band
because umbreld re-runs `repository connect` before every operation, rewriting the config
with defaults.

On my Pi the cache reached **13 GB / 1.26M inodes for ~640 MB of backed-up data**,
exhausted the partition's inodes, and deadlocked: the repository could no longer open, so
the sweep could never run, and backups were silently dead — `df -h` showed free space,
only `df -i` showed the cause. See #2207 for the full incident details.

## Changes (all in `backups.ts`)

1. **Move cache and logs to the data directory** — `XDG_CACHE_HOME` and `KOPIA_LOG_DIR`
   now point at `${dataDirectory}/kopia/{cache,logs}`, which lives on the largest drive
   in the system instead of the data partition.
2. **Exclude the new location from snapshots** — `kopia` added to `createIgnoreFile()`,
   so backups don't back up their own cache (which would balloon snapshots and regrow the
   cache while snapshotting it).
3. **Pin hard cache size limits in `connect()`** — the root-cause fix. Because
   `connect()` runs before every repository operation and rewrites the local config, the
   limits are permanently enforced and can never drift. Hard limits are enforced
   continuously by kopia, not just at open. Values: content 500 MiB soft / 1000 MiB hard,
   metadata 1000 MiB soft / 2000 MiB hard (~3 GB worst case, ~1.5 GB typical). This also
   protects SD-only installs, where the data directory shares a partition with `/kopia`
   and relocation alone wouldn't help.
4. **Clean up the legacy cache on startup** — rename-then-delete of `/kopia/cache/kopia`,
   non-blocking so a large stale cache doesn't delay startup; no-op when absent.

### Why `XDG_CACHE_HOME` and not `KOPIA_CACHE_DIRECTORY`

When kopia derives the cache path from `XDG_CACHE_HOME` it gives every repository its own
hashed subdirectory (`<cache>/kopia/<hash>` — `repo/caching.go`,
`setupCachingOptionsWithDefaults`). An explicit `KOPIA_CACHE_DIRECTORY` is used verbatim
and shared by all repositories — umbrelOS supports multiple backup repositories, whose
caches would mix — and `kopia repository disconnect` runs `os.RemoveAll` on the configured
cache directory, which with a shared directory would delete every repository's cache.
`XDG_CACHE_HOME` avoids all of that. (Verified against kopia v0.19.0, the version
umbrelOS ships.)

Config files intentionally stay at `/kopia/config`: the three call sites pass an explicit
`--config-file=/kopia/config/...` which overrides `XDG_CONFIG_HOME`, and config files are
tiny — only the cache was the problem.

## Testing

**Integration tests (umbrel-dev Docker environment, same setup as CI):**

- Two new tests in `backups.integration.test.ts`, written first and watched fail against
  unmodified `master` before implementing:
  - after a backup, kopia's cache and logs live under `${dataDirectory}/kopia`, the
    `kopia` directory is excluded from the snapshot, and all four cache limit values are
    pinned byte-exact in the repository config (connect flags multiply MB by 2^20),
  - a stale legacy cache at `/kopia/cache/kopia` is removed on startup.
- Full backups integration suite run with the change and again on a stashed `master`
  baseline in a freshly restarted container: identical results apart from the two new
  tests — no regressions.
- `tsc --noEmit` and `prettier --check` clean.

**Field test (live Raspberry Pi on umbrelOS 1.7.4, NAS backup destination):**

- Patched `backups.ts` applied to `/opt/umbreld` on a device whose data partition was at
  52% inode use from the old cache (~650k inodes for ~640 MB of backed-up data).
- On restart the legacy cleanup dropped the partition to 1% (383 inodes) within minutes.
- A manually triggered backup and subsequent scheduled hourly backups completed
  successfully with the cache now on the data drive; the data partition has stayed at 1%.
- Repository config inspected directly: per-repository cache subdirectory under the data
  directory and all four limit values present exactly as set