### PR TITLE
Install ZFS in the Raspberry Pi image

### DIFF
--- a/packages/os/umbrelos.Dockerfile
+++ b/packages/os/umbrelos.Dockerfile
@@ -177,6 +177,10 @@ RUN /build-steps/initialize.sh "${APT_SNAPSHOT_DATE}"
 
 RUN /build-steps/setup-raspberrypi.sh
 
+RUN apt-get install --yes \
+    zfs-dkms \
+    zfsutils-linux
+
 # Cleanup build steps.
 RUN rm -rf /build-steps
 


### PR DESCRIPTION
Closes #2217

## Summary

`umbrelos-base-pi` does not install ZFS, while `umbrelos-base` (amd64 and generic arm64) does. As a result `hardware:raid` cannot initialise on Pi hardware and Storage Manager is unavailable there, including on Pi boards that do have more than one internal NVMe slot.

The Raspberry Pi archive already configured by `setup-raspberrypi.sh` ships an OpenZFS build compatible with the rpi kernels installed in that stage, so this needs no new apt source.

## Current behaviour

On umbrelOS 2.0 Beta 1 (Pi 5), `umbreld` logs this on every boot:

```
[hardware:raid] Starting RAID
[hardware:raid] [error] Failed to set ZFS ARC min
[Error: ENOENT: no such file or directory, open '/sys/module/zfs/parameters/zfs_arc_min']
[hardware:raid] [error] Failed to set ZFS l2arc_exclude_special
[Error: ENOENT: no such file or directory, open '/sys/module/zfs/parameters/l2arc_exclude_special']
```

`zpool` and `zfs` are not present and `/sys/module/zfs` does not exist. The RAID module starts, expects ZFS, and fails.

## Verified on hardware

Installing the two packages manually on a Pi 5 running kernel `6.18.39+rpt-rpi-2712`:

```
zfs-dkms       2.4.1-1~bpo13+1~rpt1   (archive.raspberrypi.com trixie/main)
zfsutils-linux 2.4.1-1~bpo13+1~rpt1
```

DKMS builds cleanly for both kernel flavours:

```
Building initial module zfs/2.4.1 for 6.18.39+rpt-rpi-2712 ... done
Installing /lib/modules/6.18.39+rpt-rpi-2712/updates/dkms/zfs.ko.xz
Building initial module zfs/2.4.1 for 6.18.39+rpt-rpi-v8 ... done
Installing /lib/modules/6.18.39+rpt-rpi-v8/updates/dkms/zfs.ko.xz
```

```
$ zpool version
zfs-2.4.1-1~bpo13+1~rpt1
zfs-kmod-2.4.1-1~bpo13+1~rpt1
```

The `zfs_arc_min` and `l2arc_exclude_special` errors above stop once the module is present.

## Scope

This only closes the ZFS gap between the Pi and generic images. It does not change which transports are eligible for a pool, so external and USB drives remain excluded exactly as they are today.
