### PR TITLE
fix(app-store): align offered updates with install resolution

### DIFF
--- a/packages/ui/src/components/install-button-connected.test.tsx
+++ b/packages/ui/src/components/install-button-connected.test.tsx
@@ -49,7 +49,12 @@ vi.mock('@/providers/apps', () => ({
 	useApps: () => ({isLoading: false, userAppsKeyed: {[fixtures.userApp.id]: fixtures.userApp}}),
 }))
 vi.mock('@/providers/available-apps', () => ({
-	useAllAvailableApps: () => ({apps: [fixtures.app], ambiguousAppIds: new Set(), isLoading: false}),
+	useAllAvailableApps: () => ({
+		apps: [fixtures.app],
+		ambiguousAppIds: new Set(),
+		resolvedAppsKeyed: {[fixtures.app.id]: fixtures.app},
+		isLoading: false,
+	}),
 }))
 vi.mock('@/modules/app-store/install-review-dialog', () => ({
 	InstallReviewDialog: (props: unknown) => {

--- a/packages/ui/src/components/install-button-connected.tsx
+++ b/packages/ui/src/components/install-button-connected.tsx
@@ -67,7 +67,7 @@ export function InstallButtonConnectedController({
 	// Members browse the app store read-only, only the owner can install
 	const userQ = trpcReact.user.get.useQuery()
 	const isMember = userQ.data?.role === 'member'
-	const {apps, ambiguousAppIds} = useAllAvailableApps()
+	const {apps, ambiguousAppIds, resolvedAppsKeyed} = useAllAvailableApps()
 	const actions = useStoreActions()
 	const installReviewQ = trpcReact.apps.installReview.useQuery(
 		{appId: app.id},
@@ -80,7 +80,7 @@ export function InstallButtonConnectedController({
 	const updateApp = useUpdateApp(app.id)
 	const [highlightDependency, setHighlightDependency] = useState<string | undefined>(undefined)
 
-	const ready = !isLoading && Boolean(userQ.data && userAppsKeyed && apps && ambiguousAppIds)
+	const ready = !isLoading && Boolean(userQ.data && userAppsKeyed && apps && ambiguousAppIds && resolvedAppsKeyed)
 	const isAppIdAmbiguous = Boolean(ambiguousAppIds?.has(app.id))
 	const dependencies =
 		ready && apps && userAppsKeyed && ambiguousAppIds
@@ -123,15 +123,12 @@ export function InstallButtonConnectedController({
 	// Open remains the primary installed-app action. Updates are offered
 	// separately so an incompatible update never blocks launching the app.
 	const userApp = userAppsKeyed?.[app.id]
-	const updateAvailable = !isMember && !!userApp && isAppUpdateAvailable(userApp.version, app)
+	const resolvedApp = resolvedAppsKeyed?.[app.id] ?? app
+	const updateAvailable = !isMember && !!userApp && isAppUpdateAvailable(userApp.version, resolvedApp)
 	const canOfferUpdate = ready && updateAvailable && canPresentUpdateAction(appInstall.state)
 	const update = () => {
-		if (isAppIdAmbiguous) {
-			toast(t('app-store.app-id-conflict'), {area: 'app-store'})
-			return
-		}
 		if (!canPresentUpdateAction(appInstall.state)) return
-		if (!app.compatible) {
+		if (!resolvedApp.compatible) {
 			setShowOSUpdateRequiredDialog(true)
 			return
 		}
@@ -216,7 +213,7 @@ export function InstallButtonConnectedView() {
 					<Button
 						size='lg'
 						onClick={controller.update}
-						disabled={controller.isAppIdAmbiguous || controller.updatePending}
+						disabled={controller.updatePending}
 						className='max-sm:h-[30px] max-sm:w-full max-sm:text-13'
 					>
 						{t('app-updates.update')}

--- a/packages/ui/src/features/app-store/components/app-page.tsx
+++ b/packages/ui/src/features/app-store/components/app-page.tsx
@@ -23,7 +23,7 @@ import {StoreActionsProvider} from '@/features/app-store/providers/store-actions
 import {cn} from '@/lib/utils'
 import {isAppUpdateAvailable} from '@/modules/app-store/update-availability'
 import {useApps} from '@/providers/apps'
-import {useAvailableApp, useAvailableApps} from '@/providers/available-apps'
+import {useAllAvailableApps, useAvailableApp, useAvailableApps} from '@/providers/available-apps'
 import {useLinkToDialog} from '@/utils/dialog'
 
 import {AppPageHero} from './app-page/app-hero'
@@ -38,6 +38,7 @@ export default function AppPage() {
 	const navigate = useNavigate()
 
 	const {apps, isLoading: isLoadingApps} = useAvailableApps()
+	const {resolvedAppsKeyed, isLoading: isLoadingResolvedApps} = useAllAvailableApps()
 	const {userAppsKeyed, isLoading: isLoadingUserApps} = useApps()
 	const statuses = useAppStatusMap()
 
@@ -46,13 +47,14 @@ export default function AppPage() {
 
 	const installButtonRef = useRef<InstallButtonConnectedHandle>(null)
 
-	if (isLoading || isLoadingApps || isLoadingUserApps) return <Loading />
+	if (isLoading || isLoadingApps || isLoadingUserApps || isLoadingResolvedApps) return <Loading />
 	if (!app) throw new Error('App not found')
 
 	const userApp = userAppsKeyed?.[app.id]
 	const relatedApps = getRelatedApps(apps ?? [], app.id, 6)
-	const releaseTimeline = reconcileReleases(app, releasesQ.data)
-	const highlightLatestRelease = Boolean(userApp && isAppUpdateAvailable(userApp.version, app))
+	const resolvedApp = resolvedAppsKeyed?.[app.id] ?? app
+	const releaseTimeline = reconcileReleases(userApp ? resolvedApp : app, releasesQ.data)
+	const highlightLatestRelease = Boolean(userApp && isAppUpdateAvailable(userApp.version, resolvedApp))
 
 	const showDependencies = (dependencyId?: string) => {
 		if (userApp) {

--- a/packages/ui/src/hooks/use-apps-with-updates.ts
+++ b/packages/ui/src/hooks/use-apps-with-updates.ts
@@ -1,34 +1,32 @@
-import {canExecuteUpdate, isAppUpdateAvailable} from '@/modules/app-store/update-availability'
+import {canExecuteUpdate} from '@/modules/app-store/update-availability'
 import {useApps} from '@/providers/apps'
 import {useAllAvailableApps} from '@/providers/available-apps'
 import type {RegistryApp} from '@/trpc/trpc'
+import {trpcReact} from '@/trpc/trpc'
 
 const none: RegistryApp[] = []
 
 /**
- * Installed apps whose registry version differs from the installed one,
- * derived from the cached apps list and registry (no requests of its own).
- * An app stays in the list while its update runs — the version only changes
- * once the update completes — so `updatingApps` singles those out for the
- * surfaces that must not fire a second update or must read "updating".
+ * Installed apps whose registry version differs from the installed one.
+ * Uses the server-side apps.updates query so the offered version matches
+ * what umbreld will install when duplicate app IDs exist across stores.
  */
 export function useAppsWithUpdates() {
 	const apps = useApps()
 	const availableApps = useAllAvailableApps()
+	const updatesQ = trpcReact.apps.updates.useQuery(undefined, {
+		enabled: !availableApps.isLoading,
+		staleTime: 3 * 60 * 1000,
+	})
 
-	// NOTE: a parent should have the apps loaded before we get here, but don't wanna assume
-	if (apps.isLoading || availableApps.isLoading) {
+	if (apps.isLoading || availableApps.isLoading || updatesQ.isLoading) {
 		return {appsWithUpdates: none, updatingApps: none, updatableApps: none, isLoading: true} as const
 	}
 
-	const userApps = apps.userApps ?? []
-	const appsWithUpdates = userApps
-		.filter((app) => isAppUpdateAvailable(app.version, availableApps.appsKeyed[app.id]))
-		.map((app) => availableApps.appsKeyed[app.id])
+	const appsWithUpdates = (updatesQ.data ?? [])
+		.map(({id}) => availableApps.resolvedAppsKeyed[id])
+		.filter((app): app is RegistryApp => app !== undefined)
 
-	// The list's state is authoritative here: the shared update mutation seeds
-	// it optimistically, and server-side transitions (other tabs, agents)
-	// arrive through the apps:state:change subscription
 	const updatingApps = appsWithUpdates.filter((app) => apps.userAppsKeyed?.[app.id]?.state === 'updating')
 	const updatableApps = appsWithUpdates.filter((app) =>
 		canExecuteUpdate(apps.userAppsKeyed?.[app.id]?.state ?? 'not-installed', app.compatible),

--- a/packages/ui/src/lib/app-store-registry.test.ts
+++ b/packages/ui/src/lib/app-store-registry.test.ts
@@ -3,7 +3,7 @@ import {describe, expect, test} from 'vitest'
 import {appPathForIdentity, registryAppPath, UMBREL_APP_STORE_ID} from '@/constants/app-store'
 import type {RegistryApp} from '@/trpc/trpc'
 
-import {indexRegistryApps, resolveDependencyRegistryApp} from './app-store-registry'
+import {indexRegistryApps, resolveDependencyRegistryApp, resolveRegistryAppsFirstWins} from './app-store-registry'
 
 const registryApp = (registryId: string, id: string): RegistryApp =>
 	({appStoreId: registryId, id, name: `${registryId}:${id}`}) as RegistryApp
@@ -38,6 +38,18 @@ describe('indexRegistryApps', () => {
 				{meta: {id: 'community-store'}, apps: [duplicateCommunityApp]},
 			]),
 		).toEqual({appsKeyed: {}, ambiguousAppIds: new Set(['bitcoin'])})
+	})
+})
+
+describe('resolveRegistryAppsFirstWins', () => {
+	test('keeps the first repository that lists an app ID', () => {
+		const duplicateCommunityApp = registryApp('community-store', 'bitcoin')
+		expect(
+			resolveRegistryAppsFirstWins([
+				{meta: {id: UMBREL_APP_STORE_ID}, apps: [officialDependency]},
+				{meta: {id: 'community-store'}, apps: [duplicateCommunityApp]},
+			]),
+		).toEqual({bitcoin: officialDependency})
 	})
 })
 

--- a/packages/ui/src/lib/app-store-registry.ts
+++ b/packages/ui/src/lib/app-store-registry.ts
@@ -38,6 +38,20 @@ export function indexRegistryApps(registries: readonly (AppRegistry | null)[]): 
 	return {appsKeyed, ambiguousAppIds}
 }
 
+/** First-repository-wins lookup, matching umbreld's install/update resolution. */
+export function resolveRegistryAppsFirstWins(registries: readonly (AppRegistry | null)[]): Record<string, RegistryApp> {
+	const appsKeyed: Record<string, RegistryApp> = {}
+
+	for (const registry of registries) {
+		if (!registry) continue
+		for (const app of registry.apps) {
+			if (!appsKeyed[app.id]) appsKeyed[app.id] = app
+		}
+	}
+
+	return appsKeyed
+}
+
 /** Resolve a dependency only when exactly one loaded registry provides it. */
 export function resolveDependencyRegistryApp({
 	dependencyId,

--- a/packages/ui/src/modules/app-store/app-page/app-settings-dialog.tsx
+++ b/packages/ui/src/modules/app-store/app-page/app-settings-dialog.tsx
@@ -696,8 +696,8 @@ function AppSettingsDialogForApp({
 
 function AppSettingsSidebar({app, onNavigate}: {app: UserApp; onNavigate: (to: string) => void}) {
 	const {t} = useTranslation()
-	const {appsKeyed} = useAllAvailableApps()
-	const registryApp = appsKeyed?.[app.id]
+	const {resolvedAppsKeyed} = useAllAvailableApps()
+	const registryApp = resolvedAppsKeyed?.[app.id]
 	const hasUpdate = Boolean(app.version) && isAppUpdateAvailable(app.version, registryApp)
 	// No link when the app is gone from every registry — there is no store page
 	const storePath = registryApp ? registryAppPath(registryApp) : null

--- a/packages/ui/src/providers/available-apps.test.tsx
+++ b/packages/ui/src/providers/available-apps.test.tsx
@@ -81,6 +81,10 @@ describe('AvailableAppsProvider', () => {
 		const value = observe.mock.calls.at(-1)?.[0]
 		expect(value.allApps.apps).toEqual([fixtures.officialOnly])
 		expect(value.allApps.appsKeyed).toEqual({'official-only': fixtures.officialOnly})
+		expect(value.allApps.resolvedAppsKeyed).toEqual({
+			'official-only': fixtures.officialOnly,
+			conflict: fixtures.officialConflict,
+		})
 		expect(value.allApps.ambiguousAppIds).toEqual(new Set(['conflict']))
 		expect(value.officialApps.appsKeyed.conflict).toBe(fixtures.officialConflict)
 		expect(value.communityApps.appsKeyed.conflict).toBe(fixtures.communityConflict)

--- a/packages/ui/src/providers/available-apps.tsx
+++ b/packages/ui/src/providers/available-apps.tsx
@@ -2,7 +2,7 @@ import {createContext, useContext} from 'react'
 import {groupBy, indexBy, mapValues} from 'remeda'
 
 import {UMBREL_APP_STORE_ID} from '@/constants/app-store'
-import {indexRegistryApps} from '@/lib/app-store-registry'
+import {indexRegistryApps, resolveRegistryAppsFirstWins} from '@/lib/app-store-registry'
 import {RegistryApp, RouterOutput, trpcReact} from '@/trpc/trpc'
 
 type AppsContextT =
@@ -14,6 +14,7 @@ type AppsContextT =
 			repos: RouterOutput['appStore']['registry']
 			apps: RegistryApp[]
 			appsKeyed: Record<string, RegistryApp>
+			resolvedAppsKeyed: Record<string, RegistryApp>
 			ambiguousAppIds: ReadonlySet<string>
 			repoAppsKeyed: Record<string, Record<string, RegistryApp>>
 			// Keyed by plain strings: manifests may declare categories umbrelOS
@@ -38,13 +39,14 @@ export function AvailableAppsProvider({children}: {children: React.ReactNode}) {
 
 	const reposKeyed = indexBy(repos, (repo) => repo?.meta.id)
 	const {appsKeyed, ambiguousAppIds} = indexRegistryApps(repos)
+	const resolvedAppsKeyed = resolveRegistryAppsFirstWins(repos)
 	const apps = repos.flatMap((repo) => repo?.apps ?? []).filter((app) => !ambiguousAppIds.has(app.id))
 	const repoAppsKeyed = mapValues(reposKeyed, (repo) => indexBy(repo?.apps ?? [], (app) => app.id))
 	const repoAppsGroupedByCategory = mapValues(reposKeyed, (repo) => groupBy(repo?.apps ?? [], (app) => app.category))
 
 	const providerProps: AppsContextT = appsQ.isLoading
 		? {isLoading: true}
-		: {repos, apps, appsKeyed, ambiguousAppIds, repoAppsKeyed, repoAppsGroupedByCategory, isLoading: false}
+		: {repos, apps, appsKeyed, resolvedAppsKeyed, ambiguousAppIds, repoAppsKeyed, repoAppsGroupedByCategory, isLoading: false}
 
 	return <AppsContext value={providerProps}>{children}</AppsContext>
 }
@@ -77,6 +79,7 @@ export function useAllAvailableApps() {
 		isLoading: false,
 		apps: ctx.apps,
 		appsKeyed: ctx.appsKeyed,
+		resolvedAppsKeyed: ctx.resolvedAppsKeyed,
 		ambiguousAppIds: ctx.ambiguousAppIds,
 		repoAppsKeyed: ctx.repoAppsKeyed,
 	} as const


### PR DESCRIPTION
## Summary
- Add `resolveRegistryAppsFirstWins` on the dashboard to mirror umbreld's first-repository install/update resolution when duplicate app IDs exist across stores.
- Drive the Updates shelf and update buttons from `apps.updates` plus resolved registry apps so the offered version and release notes match what `apps.update` installs.
- Stop blocking updates solely because an app ID appears in multiple stores; compatibility and server-side resolution remain authoritative.

Fixes #2223

## Test plan
- [x] `npm test -- --run src/lib/app-store-registry.test.ts src/components/install-button-connected.test.tsx`
- [ ] On a device with two stores carrying the same app ID, confirm Updates only lists apps whose installed version differs from the first-wins registry version
- [ ] Click Update and verify the installed manifest/image matches the version shown in the Updates UI (no stuck badge loop)